### PR TITLE
fix: recovery landings with full financials + extract cycle algebra to @acars/core

### DIFF
--- a/apps/web/src/shared/components/layout/Sidebar.test.tsx
+++ b/apps/web/src/shared/components/layout/Sidebar.test.tsx
@@ -3,6 +3,15 @@ import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { Sidebar } from "./Sidebar";
 
+vi.mock("@acars/store", () => {
+  return {
+    useAirlineStore: (selector?: (state: Record<string, unknown>) => unknown) => {
+      const state = { airline: null, viewedPubkey: null };
+      return selector ? selector(state) : state;
+    },
+  };
+});
+
 vi.mock("@tanstack/react-router", () => {
   return {
     Link: ({ children }: { children: ReactNode }) => <div>{children}</div>,

--- a/packages/core/src/cycle.ts
+++ b/packages/core/src/cycle.ts
@@ -19,6 +19,11 @@ export function getCyclePhase(
   turnaroundTicks: number,
   route: Route,
 ): CyclePhase {
+  if (durationTicks <= 0 || turnaroundTicks < 0) {
+    throw new Error(
+      `getCyclePhase: invalid inputs — durationTicks=${durationTicks}, turnaroundTicks=${turnaroundTicks}`,
+    );
+  }
   const roundTripTicks = durationTicks * 2 + turnaroundTicks * 2;
   const elapsed = targetTick - cycleStartTick;
   const positionInCycle = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
@@ -88,6 +93,7 @@ export function countLandingsBetween(
   turnaroundTicks: number,
 ): number {
   if (toTick <= fromTick) return 0;
+  if (durationTicks <= 0 || turnaroundTicks < 0) return 0;
   const roundTripTicks = durationTicks * 2 + turnaroundTicks * 2;
   const landingOffsets = [durationTicks, durationTicks * 2 + turnaroundTicks];
   let count = 0;

--- a/packages/core/src/cycle.ts
+++ b/packages/core/src/cycle.ts
@@ -85,6 +85,13 @@ export function getCyclePhase(
   }
 }
 
+/**
+ * Count the number of landings that occur in the half-open interval (fromTick, toTick].
+ *
+ * - Exclusive start, inclusive end: a landing exactly at `fromTick` is NOT counted,
+ *   but a landing exactly at `toTick` IS counted.
+ * - Returns 0 when `toTick <= fromTick`, `durationTicks <= 0`, or `turnaroundTicks < 0`.
+ */
 export function countLandingsBetween(
   cycleStartTick: number,
   fromTick: number,

--- a/packages/core/src/cycle.ts
+++ b/packages/core/src/cycle.ts
@@ -1,0 +1,107 @@
+import type { Route } from "./types.js";
+
+export interface CyclePhase {
+  status: "enroute" | "turnaround";
+  direction: "outbound" | "inbound";
+  positionInCycle: number;
+  departureTick: number;
+  arrivalTick: number;
+  turnaroundEndTick: number | null;
+  baseAirportIata: string;
+  originIata: string;
+  destinationIata: string;
+}
+
+export function getCyclePhase(
+  cycleStartTick: number,
+  targetTick: number,
+  durationTicks: number,
+  turnaroundTicks: number,
+  route: Route,
+): CyclePhase {
+  const roundTripTicks = durationTicks * 2 + turnaroundTicks * 2;
+  const elapsed = targetTick - cycleStartTick;
+  const positionInCycle = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
+
+  if (positionInCycle < durationTicks) {
+    const departureTick = targetTick - positionInCycle;
+    return {
+      status: "enroute",
+      direction: "outbound",
+      positionInCycle,
+      departureTick,
+      arrivalTick: departureTick + durationTicks,
+      turnaroundEndTick: null,
+      baseAirportIata: route.originIata,
+      originIata: route.originIata,
+      destinationIata: route.destinationIata,
+    };
+  } else if (positionInCycle < durationTicks + turnaroundTicks) {
+    const arrivalTick = targetTick - (positionInCycle - durationTicks);
+    return {
+      status: "turnaround",
+      direction: "outbound",
+      positionInCycle,
+      departureTick: arrivalTick - durationTicks,
+      arrivalTick,
+      turnaroundEndTick: arrivalTick + turnaroundTicks,
+      baseAirportIata: route.destinationIata,
+      originIata: route.originIata,
+      destinationIata: route.destinationIata,
+    };
+  } else if (positionInCycle < durationTicks * 2 + turnaroundTicks) {
+    const inboundStart = durationTicks + turnaroundTicks;
+    const departureTick = targetTick - (positionInCycle - inboundStart);
+    return {
+      status: "enroute",
+      direction: "inbound",
+      positionInCycle,
+      departureTick,
+      arrivalTick: departureTick + durationTicks,
+      turnaroundEndTick: null,
+      baseAirportIata: route.destinationIata,
+      originIata: route.destinationIata,
+      destinationIata: route.originIata,
+    };
+  } else {
+    const inboundArrival = durationTicks * 2 + turnaroundTicks;
+    const arrivalTick = targetTick - (positionInCycle - inboundArrival);
+    return {
+      status: "turnaround",
+      direction: "inbound",
+      positionInCycle,
+      departureTick: arrivalTick - durationTicks,
+      arrivalTick,
+      turnaroundEndTick: arrivalTick + turnaroundTicks,
+      baseAirportIata: route.originIata,
+      originIata: route.destinationIata,
+      destinationIata: route.originIata,
+    };
+  }
+}
+
+export function countLandingsBetween(
+  cycleStartTick: number,
+  fromTick: number,
+  toTick: number,
+  durationTicks: number,
+  turnaroundTicks: number,
+): number {
+  if (toTick <= fromTick) return 0;
+  const roundTripTicks = durationTicks * 2 + turnaroundTicks * 2;
+  const landingOffsets = [durationTicks, durationTicks * 2 + turnaroundTicks];
+  let count = 0;
+
+  for (const offset of landingOffsets) {
+    const firstLandingTick = cycleStartTick + offset;
+    if (toTick < firstLandingTick) continue;
+    const countTo = Math.floor((toTick - firstLandingTick) / roundTripTicks) + 1;
+    const countFrom =
+      fromTick >= firstLandingTick
+        ? Math.floor((fromTick - firstLandingTick) / roundTripTicks) + 1
+        : 0;
+    count += countTo - countFrom;
+  }
+
+  return Math.max(0, count);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,9 @@ export {
   computeCheckpointStateHash,
   verifyCheckpoint,
 } from "./checkpoint.js";
+export type { CyclePhase } from "./cycle.js";
+// Cycle
+export { countLandingsBetween, getCyclePhase } from "./cycle.js";
 // Demand
 export {
   calculateDemand,
@@ -99,8 +102,4 @@ export type {
   TimelineEventType,
 } from "./types.js";
 // Types
-export {
-  GENESIS_TIME,
-  TICK_DURATION,
-  TICKS_PER_HOUR,
-} from "./types.js";
+export { GENESIS_TIME, TICK_DURATION, TICKS_PER_HOUR } from "./types.js";

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -747,7 +747,7 @@ export function estimateLandingFinancials(
         loadFactor: 0,
         spilledPassengers: 0,
         routeId: route.id,
-        flightDurationTicks: Math.ceil(hoursPerLeg * TICKS_PER_HOUR),
+        flightDurationTicks: Math.max(0, Math.ceil(hoursPerLeg * TICKS_PER_HOUR)),
         revenue: {
           tickets: fp(0),
           economy: fp(0),

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -349,14 +349,11 @@ export function processFlightEngine(
 
           const addressableDemand = scaleToAddressableMarket(weeklyDemandResult);
           const allocations = allocatePassengers(allOffers, addressableDemand);
-          const ourWeeklyAllocation = allocations.get(playerPubkey) ||
-            (route
-              ? { economy: 0, business: 0, first: 0 }
-              : allocations.get(ourOffer.airlinePubkey)) || {
-              economy: 0,
-              business: 0,
-              first: 0,
-            };
+          const ourWeeklyAllocation = allocations.get(playerPubkey) ?? {
+            economy: 0,
+            business: 0,
+            first: 0,
+          };
 
           const totalWeeklySeats =
             ourFrequency * (seatConfig.economy + seatConfig.business + seatConfig.first);
@@ -791,9 +788,9 @@ export function estimateLandingFinancials(
     seatsOffered,
   });
 
-  // Hub-aware airport fees
-  const originIata = ac.flight?.originIata;
-  const destinationIata = ac.flight?.destinationIata;
+  // Hub-aware airport fees (fall back to route IATA when ac.flight is null during recovery/backfill)
+  const originIata = ac.flight?.originIata ?? route.originIata;
+  const destinationIata = ac.flight?.destinationIata ?? route.destinationIata;
   const originHub = originIata ? HUB_CLASSIFICATIONS[originIata] : undefined;
   const destHub = destinationIata ? HUB_CLASSIFICATIONS[destinationIata] : undefined;
   const originBaseFee = originHub ? fp(originHub.baseLandingFee) : fp(250);

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -643,6 +643,29 @@ function applyFlightHours(updated: AircraftInstance, hoursToAdd: number): void {
 }
 
 const DEFAULT_RECONCILE_LOAD_FACTOR = 0.65;
+
+/**
+ * Compute the total profit delta for a batch of landings and accumulate it.
+ * Extracted to deduplicate the identical pattern in reconcileFleetToTick.
+ */
+function accumulateLandingProfit(
+  ac: AircraftInstance,
+  route: Route,
+  model: ReturnType<typeof getAircraftById>,
+  hoursPerLeg: number,
+  landings: number,
+): FixedPoint {
+  if (landings <= 0) return fp(0);
+  const perLeg = estimateLandingFinancials(
+    ac,
+    route,
+    model,
+    hoursPerLeg,
+    ac.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
+  );
+  return fpScale(perLeg.profit, landings);
+}
+
 const MIN_GROUNDED_CONDITION = 0.2;
 const MAX_HOURS_SINCE_CHECK = 600;
 
@@ -928,16 +951,10 @@ export function reconcileFleetToTick(
       const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
       landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
       applyFlightHours(updated, landings * hoursPerLeg);
-      if (landings > 0) {
-        const perLeg = estimateLandingFinancials(
-          updated,
-          route,
-          model,
-          hoursPerLeg,
-          updated.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
-        );
-        balanceDelta = fpAdd(balanceDelta, fpScale(perLeg.profit, landings));
-      }
+      balanceDelta = fpAdd(
+        balanceDelta,
+        accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+      );
       return updated;
     } else if (ac.status === "delivery") {
       // Delivery aircraft whose deliveryAtTick is in the past should be
@@ -977,16 +994,10 @@ export function reconcileFleetToTick(
         const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
         landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
         applyFlightHours(updated, landings * hoursPerLeg);
-        if (landings > 0) {
-          const perLeg = estimateLandingFinancials(
-            updated,
-            route,
-            model,
-            hoursPerLeg,
-            updated.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
-          );
-          balanceDelta = fpAdd(balanceDelta, fpScale(perLeg.profit, landings));
-        }
+        balanceDelta = fpAdd(
+          balanceDelta,
+          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+        );
         return updated;
       }
       // Still in delivery period — skip
@@ -1025,16 +1036,10 @@ export function reconcileFleetToTick(
     const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
     landings = capLandingsForGrounding(updated, landings, hoursPerLeg, ac.status === "enroute");
     applyFlightHours(updated, landings * hoursPerLeg);
-    if (landings > 0) {
-      const perLeg = estimateLandingFinancials(
-        updated,
-        route,
-        model,
-        hoursPerLeg,
-        updated.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
-      );
-      balanceDelta = fpAdd(balanceDelta, fpScale(perLeg.profit, landings));
-    }
+    balanceDelta = fpAdd(
+      balanceDelta,
+      accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+    );
 
     return updated;
   });

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -7,6 +7,7 @@ import {
   calculateHubLandingFee,
   calculatePriceElasticity,
   calculateSupplyPressure,
+  countLandingsBetween,
   detectPriceWar,
   fp,
   fpAdd,
@@ -14,6 +15,7 @@ import {
   fpSub,
   fpToNumber,
   GENESIS_TIME,
+  getCyclePhase,
   getHubCongestionModifier,
   getHubDemandModifier,
   getProsperityIndex,
@@ -606,8 +608,8 @@ export function processFlightEngine(
 
 /**
  * Given a position within a round-trip cycle, apply the correct flight state
- * to the aircraft clone.  This is the shared four-phase placement logic used
- * by all reconciliation paths (idle, delivery, enroute/turnaround fast-forward).
+ * to the aircraft clone. This delegates to getCyclePhase from @acars/core
+ * to ensure a single source of truth for cycle algebra.
  */
 function applyCyclePhase(
   updated: AircraftInstance,
@@ -617,89 +619,20 @@ function applyCyclePhase(
   durationTicks: number,
   turnaroundTicks: number,
 ): void {
-  if (positionInCycle < durationTicks) {
-    // Phase: outbound enroute
-    const departureTick = targetTick - positionInCycle;
-    updated.status = "enroute";
-    updated.flight = {
-      originIata: route.originIata,
-      destinationIata: route.destinationIata,
-      departureTick,
-      arrivalTick: departureTick + durationTicks,
-      direction: "outbound",
-    };
-    updated.turnaroundEndTick = undefined;
-    updated.arrivalTickProcessed = undefined;
-  } else if (positionInCycle < durationTicks + turnaroundTicks) {
-    // Phase: turnaround after outbound
-    const arrivalTick = targetTick - (positionInCycle - durationTicks);
-    updated.status = "turnaround";
-    updated.baseAirportIata = route.destinationIata;
-    updated.flight = {
-      originIata: route.originIata,
-      destinationIata: route.destinationIata,
-      departureTick: arrivalTick - durationTicks,
-      arrivalTick,
-      direction: "outbound",
-    };
-    updated.turnaroundEndTick = arrivalTick + turnaroundTicks;
-    updated.arrivalTickProcessed = arrivalTick;
-  } else if (positionInCycle < durationTicks * 2 + turnaroundTicks) {
-    // Phase: inbound enroute
-    const inboundStart = durationTicks + turnaroundTicks;
-    const departureTick = targetTick - (positionInCycle - inboundStart);
-    updated.status = "enroute";
-    updated.flight = {
-      originIata: route.destinationIata,
-      destinationIata: route.originIata,
-      departureTick,
-      arrivalTick: departureTick + durationTicks,
-      direction: "inbound",
-    };
-    updated.turnaroundEndTick = undefined;
-    updated.arrivalTickProcessed = undefined;
-  } else {
-    // Phase: turnaround after inbound (back at origin)
-    const inboundArrival = durationTicks * 2 + turnaroundTicks;
-    const arrivalTick = targetTick - (positionInCycle - inboundArrival);
-    updated.status = "turnaround";
-    updated.baseAirportIata = route.originIata;
-    updated.flight = {
-      originIata: route.destinationIata,
-      destinationIata: route.originIata,
-      departureTick: arrivalTick - durationTicks,
-      arrivalTick,
-      direction: "inbound",
-    };
-    updated.turnaroundEndTick = arrivalTick + turnaroundTicks;
-    updated.arrivalTickProcessed = arrivalTick;
-  }
-}
+  const cycleStartTick = targetTick - positionInCycle;
+  const phase = getCyclePhase(cycleStartTick, targetTick, durationTicks, turnaroundTicks, route);
 
-function countLandingsBetween(
-  cycleStartTick: number,
-  fromTick: number,
-  toTick: number,
-  durationTicks: number,
-  turnaroundTicks: number,
-): number {
-  if (toTick <= fromTick) return 0;
-  const roundTripTicks = durationTicks * 2 + turnaroundTicks * 2;
-  const landingOffsets = [durationTicks, durationTicks * 2 + turnaroundTicks];
-  let count = 0;
-
-  for (const offset of landingOffsets) {
-    const firstLandingTick = cycleStartTick + offset;
-    if (toTick < firstLandingTick) continue;
-    const countTo = Math.floor((toTick - firstLandingTick) / roundTripTicks) + 1;
-    const countFrom =
-      fromTick >= firstLandingTick
-        ? Math.floor((fromTick - firstLandingTick) / roundTripTicks) + 1
-        : 0;
-    count += countTo - countFrom;
-  }
-
-  return Math.max(0, count);
+  updated.status = phase.status;
+  updated.flight = {
+    originIata: phase.originIata,
+    destinationIata: phase.destinationIata,
+    departureTick: phase.departureTick,
+    arrivalTick: phase.arrivalTick,
+    direction: phase.direction,
+  };
+  updated.turnaroundEndTick = phase.turnaroundEndTick ?? undefined;
+  updated.arrivalTickProcessed = phase.status === "turnaround" ? phase.arrivalTick : undefined;
+  updated.baseAirportIata = phase.baseAirportIata;
 }
 
 function applyFlightHours(updated: AircraftInstance, hoursToAdd: number): void {
@@ -762,9 +695,8 @@ export function estimateLandingFinancials(
   hoursPerLeg: number,
   loadFactor: number,
 ): LandingFinancialResult {
-  const empty: LandingFinancialResult = {
-    profit: fp(0),
-    revenue: calculateFlightRevenue({
+  if (!model || hoursPerLeg <= 0) {
+    const zeroRevenue = calculateFlightRevenue({
       passengersEconomy: 0,
       passengersBusiness: 0,
       passengersFirst: 0,
@@ -772,44 +704,51 @@ export function estimateLandingFinancials(
       fareBusiness: fp(0),
       fareFirst: fp(0),
       seatsOffered: 0,
-    }),
-    cost: calculateFlightCost({
-      distanceKm: 0,
-      aircraft: model!,
-      actualPassengers: 0,
-      blockHours: 0,
-    }),
-    details: {
-      passengers: { economy: 0, business: 0, first: 0, total: 0 },
-      seatsOffered: 0,
-      loadFactor: 0,
-      spilledPassengers: 0,
-      routeId: route.id,
-      flightDurationTicks: Math.ceil(hoursPerLeg * TICKS_PER_HOUR),
-      revenue: {
-        tickets: fp(0),
-        economy: fp(0),
-        business: fp(0),
-        first: fp(0),
-        ancillary: fp(0),
+    });
+    return {
+      profit: fp(0),
+      revenue: zeroRevenue,
+      cost: {
+        costTotal: fp(0),
+        costFuel: fp(0),
+        costCrew: fp(0),
+        costMaintenance: fp(0),
+        costAirport: fp(0),
+        costNavigation: fp(0),
+        costLeasing: fp(0),
+        costOverhead: fp(0),
       },
-      costs: {
-        fuel: fp(0),
-        crew: fp(0),
-        maintenance: fp(0),
-        airport: fp(0),
-        navigation: fp(0),
-        leasing: fp(0),
-        overhead: fp(0),
+      details: {
+        passengers: { economy: 0, business: 0, first: 0, total: 0 },
+        seatsOffered: 0,
+        loadFactor: 0,
+        spilledPassengers: 0,
+        routeId: route.id,
+        flightDurationTicks: Math.ceil(hoursPerLeg * TICKS_PER_HOUR),
+        revenue: {
+          tickets: fp(0),
+          economy: fp(0),
+          business: fp(0),
+          first: fp(0),
+          ancillary: fp(0),
+        },
+        costs: {
+          fuel: fp(0),
+          crew: fp(0),
+          maintenance: fp(0),
+          airport: fp(0),
+          navigation: fp(0),
+          leasing: fp(0),
+          overhead: fp(0),
+        },
       },
-    },
-  };
-  if (!model || hoursPerLeg <= 0) return empty;
+    };
+  }
 
   const clampedLoad = Math.min(1, Math.max(0, loadFactor));
-  const seatsEconomy = Math.max(0, ac.configuration.economy);
-  const seatsBusiness = Math.max(0, ac.configuration.business);
-  const seatsFirst = Math.max(0, ac.configuration.first);
+  const seatsEconomy = Math.max(0, ac.configuration?.economy ?? model.capacity.economy);
+  const seatsBusiness = Math.max(0, ac.configuration?.business ?? model.capacity.business);
+  const seatsFirst = Math.max(0, ac.configuration?.first ?? model.capacity.first);
   const seatsOffered = seatsEconomy + seatsBusiness + seatsFirst;
   const passengersEconomy = Math.floor(seatsEconomy * clampedLoad);
   const passengersBusiness = Math.floor(seatsBusiness * clampedLoad);

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -76,7 +76,10 @@ export function processFlightEngine(
     }
 
     if (route.originIata) {
-      const current = hubStats.get(route.originIata) ?? { spokeCount: 0, weeklyFrequency: 0 };
+      const current = hubStats.get(route.originIata) ?? {
+        spokeCount: 0,
+        weeklyFrequency: 0,
+      };
       current.spokeCount += 1;
       current.weeklyFrequency += weekly;
       hubStats.set(route.originIata, current);
@@ -85,7 +88,12 @@ export function processFlightEngine(
 
   const hubStates = new Map<
     string,
-    { hubIata: string; spokeCount: number; weeklyFrequency: number; avgFrequency: number }
+    {
+      hubIata: string;
+      spokeCount: number;
+      weeklyFrequency: number;
+      avgFrequency: number;
+    }
   >();
   for (const [hubIata, stats] of hubStats.entries()) {
     hubStates.set(hubIata, {
@@ -342,7 +350,11 @@ export function processFlightEngine(
           const ourWeeklyAllocation = allocations.get(playerPubkey) ||
             (route
               ? { economy: 0, business: 0, first: 0 }
-              : allocations.get(ourOffer.airlinePubkey)) || { economy: 0, business: 0, first: 0 };
+              : allocations.get(ourOffer.airlinePubkey)) || {
+              economy: 0,
+              business: 0,
+              first: 0,
+            };
 
           const totalWeeklySeats =
             ourFrequency * (seatConfig.economy + seatConfig.business + seatConfig.first);
@@ -724,14 +736,76 @@ function capLandingsForGrounding(
   return Math.min(landings, Math.max(0, allowed));
 }
 
-function estimateReconcileProfit(
+/**
+ * Estimate the financial result of a single landing using a simplified demand
+ * model (load-factor based, no QSI / competitor data).
+ *
+ * Used by:
+ * - `reconcileFleetToTick` for balance-delta estimation during fast-forward
+ * - The recovery sweep in `engineSlice.processTick` to produce full-detail
+ *   timeline events when a landing was missed during tick-by-tick catch-up
+ *
+ * Returns the full revenue/cost breakdown so callers can either just grab
+ * `.profit` or build a complete `TimelineEvent.details` object.
+ */
+export interface LandingFinancialResult {
+  profit: FixedPoint;
+  revenue: ReturnType<typeof calculateFlightRevenue>;
+  cost: ReturnType<typeof calculateFlightCost>;
+  details: NonNullable<TimelineEvent["details"]>;
+}
+
+export function estimateLandingFinancials(
   ac: AircraftInstance,
   route: Route,
   model: ReturnType<typeof getAircraftById>,
   hoursPerLeg: number,
   loadFactor: number,
-): FixedPoint {
-  if (!model || hoursPerLeg <= 0) return fp(0);
+): LandingFinancialResult {
+  const empty: LandingFinancialResult = {
+    profit: fp(0),
+    revenue: calculateFlightRevenue({
+      passengersEconomy: 0,
+      passengersBusiness: 0,
+      passengersFirst: 0,
+      fareEconomy: fp(0),
+      fareBusiness: fp(0),
+      fareFirst: fp(0),
+      seatsOffered: 0,
+    }),
+    cost: calculateFlightCost({
+      distanceKm: 0,
+      aircraft: model!,
+      actualPassengers: 0,
+      blockHours: 0,
+    }),
+    details: {
+      passengers: { economy: 0, business: 0, first: 0, total: 0 },
+      seatsOffered: 0,
+      loadFactor: 0,
+      spilledPassengers: 0,
+      routeId: route.id,
+      flightDurationTicks: Math.ceil(hoursPerLeg * TICKS_PER_HOUR),
+      revenue: {
+        tickets: fp(0),
+        economy: fp(0),
+        business: fp(0),
+        first: fp(0),
+        ancillary: fp(0),
+      },
+      costs: {
+        fuel: fp(0),
+        crew: fp(0),
+        maintenance: fp(0),
+        airport: fp(0),
+        navigation: fp(0),
+        leasing: fp(0),
+        overhead: fp(0),
+      },
+    },
+  };
+  if (!model || hoursPerLeg <= 0) return empty;
+
   const clampedLoad = Math.min(1, Math.max(0, loadFactor));
   const seatsEconomy = Math.max(0, ac.configuration.economy);
   const seatsBusiness = Math.max(0, ac.configuration.business);
@@ -741,24 +815,78 @@ function estimateReconcileProfit(
   const passengersBusiness = Math.floor(seatsBusiness * clampedLoad);
   const passengersFirst = Math.floor(seatsFirst * clampedLoad);
 
+  const fareEconomy = route.fareEconomy ?? fp(0);
+  const fareBusiness = route.fareBusiness ?? fp(0);
+  const fareFirst = route.fareFirst ?? fp(0);
+
   const revenue = calculateFlightRevenue({
     passengersEconomy,
     passengersBusiness,
     passengersFirst,
-    fareEconomy: route.fareEconomy,
-    fareBusiness: route.fareBusiness,
-    fareFirst: route.fareFirst,
+    fareEconomy,
+    fareBusiness,
+    fareFirst,
     seatsOffered,
   });
+
+  // Hub-aware airport fees
+  const originIata = ac.flight?.originIata;
+  const destinationIata = ac.flight?.destinationIata;
+  const originHub = originIata ? HUB_CLASSIFICATIONS[originIata] : undefined;
+  const destHub = destinationIata ? HUB_CLASSIFICATIONS[destinationIata] : undefined;
+  const originBaseFee = originHub ? fp(originHub.baseLandingFee) : fp(250);
+  const destBaseFee = destHub ? fp(destHub.baseLandingFee) : fp(250);
+  // No live traffic data available; use 0 for baseline fees
+  const originFee = calculateHubLandingFee(originBaseFee, originHub?.baseCapacityPerHour ?? 80, 0);
+  const destFee = calculateHubLandingFee(destBaseFee, destHub?.baseCapacityPerHour ?? 80, 0);
+  const avgFee = (fpToNumber(originFee) + fpToNumber(destFee)) / 2;
+  const airportFeesMultiplier = avgFee / 250;
 
   const cost = calculateFlightCost({
     distanceKm: route.distanceKm,
     aircraft: model,
     actualPassengers: revenue.actualPassengers,
     blockHours: hoursPerLeg,
+    airportFeesMultiplier,
   });
 
-  return fpSub(revenue.revenueTotal, cost.costTotal);
+  const profit = fpSub(revenue.revenueTotal, cost.costTotal);
+
+  const durationTicks = ac.flight
+    ? ac.flight.arrivalTick - ac.flight.departureTick
+    : Math.ceil(hoursPerLeg * TICKS_PER_HOUR);
+
+  const details: NonNullable<TimelineEvent["details"]> = {
+    passengers: {
+      economy: revenue.actualEconomy,
+      business: revenue.actualBusiness,
+      first: revenue.actualFirst,
+      total: revenue.actualPassengers,
+    },
+    seatsOffered: revenue.seatsOffered,
+    loadFactor: revenue.loadFactor,
+    spilledPassengers: revenue.spilledPassengers,
+    routeId: route.id,
+    flightDurationTicks: durationTicks,
+    revenue: {
+      tickets: revenue.revenueTicket,
+      economy: revenue.revenueEconomy,
+      business: revenue.revenueBusiness,
+      first: revenue.revenueFirst,
+      ancillary: revenue.revenueAncillary,
+    },
+    costs: {
+      fuel: cost.costFuel,
+      crew: cost.costCrew,
+      maintenance: cost.costMaintenance,
+      airport: cost.costAirport,
+      navigation: cost.costNavigation,
+      leasing: cost.costLeasing,
+      overhead: cost.costOverhead,
+    },
+  };
+
+  return { profit, revenue, cost, details };
 }
 
 /**
@@ -862,14 +990,14 @@ export function reconcileFleetToTick(
       landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
       applyFlightHours(updated, landings * hoursPerLeg);
       if (landings > 0) {
-        const perLegProfit = estimateReconcileProfit(
+        const perLeg = estimateLandingFinancials(
           updated,
           route,
           model,
           hoursPerLeg,
           updated.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
         );
-        balanceDelta = fpAdd(balanceDelta, fpScale(perLegProfit, landings));
+        balanceDelta = fpAdd(balanceDelta, fpScale(perLeg.profit, landings));
       }
       return updated;
     } else if (ac.status === "delivery") {
@@ -911,14 +1039,14 @@ export function reconcileFleetToTick(
         landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
         applyFlightHours(updated, landings * hoursPerLeg);
         if (landings > 0) {
-          const perLegProfit = estimateReconcileProfit(
+          const perLeg = estimateLandingFinancials(
             updated,
             route,
             model,
             hoursPerLeg,
             updated.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
           );
-          balanceDelta = fpAdd(balanceDelta, fpScale(perLegProfit, landings));
+          balanceDelta = fpAdd(balanceDelta, fpScale(perLeg.profit, landings));
         }
         return updated;
       }
@@ -959,14 +1087,14 @@ export function reconcileFleetToTick(
     landings = capLandingsForGrounding(updated, landings, hoursPerLeg, ac.status === "enroute");
     applyFlightHours(updated, landings * hoursPerLeg);
     if (landings > 0) {
-      const perLegProfit = estimateReconcileProfit(
+      const perLeg = estimateLandingFinancials(
         updated,
         route,
         model,
         hoursPerLeg,
         updated.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
       );
-      balanceDelta = fpAdd(balanceDelta, fpScale(perLegProfit, landings));
+      balanceDelta = fpAdd(balanceDelta, fpScale(perLeg.profit, landings));
     }
 
     return updated;

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -14,7 +14,7 @@ import { publishCheckpoint } from "@acars/nostr";
 import type { StateCreator } from "zustand";
 import { publishActionWithChain } from "../actionChain";
 import { useEngineStore } from "../engine";
-import { processFlightEngine } from "../FlightEngine";
+import { estimateLandingFinancials, processFlightEngine } from "../FlightEngine";
 import type { AirlineState } from "../types";
 
 export interface EngineSlice {
@@ -35,7 +35,12 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
     // If balance is severely negative (e.g. -$10M), auto-pause operations
     if (fpToNumber(airline.corporateBalance) < -10000000 && airline.status !== "chapter11") {
       const updatedAirline = { ...airline, status: "chapter11" as const };
-      const previousState = { airline, fleet, routes, timeline: get().timeline };
+      const previousState = {
+        airline,
+        fleet,
+        routes,
+        timeline: get().timeline,
+      };
       set({ airline: updatedAirline });
       publishActionWithChain({
         action: {
@@ -74,7 +79,11 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
       const CATCHUP_CHUNK = 2000;
       const targetTick = Math.min(tick, lastTick + MAX_CATCHUP);
       useEngineStore.setState({
-        catchupProgress: { current: lastTick, target: targetTick, phase: "player" },
+        catchupProgress: {
+          current: lastTick,
+          target: targetTick,
+          phase: "player",
+        },
       });
 
       let currentFleet = [...fleet];
@@ -140,7 +149,11 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
           lastTick: targetTick,
           timeline: currentTimeline,
         };
-        set({ fleet: currentFleet, airline: updatedAirline, timeline: currentTimeline });
+        set({
+          fleet: currentFleet,
+          airline: updatedAirline,
+          timeline: currentTimeline,
+        });
         const previousCheckpointTick = Math.floor(lastTick / CHECKPOINT_INTERVAL);
         const nextCheckpointTick = Math.floor(targetTick / CHECKPOINT_INTERVAL);
         if (nextCheckpointTick > previousCheckpointTick) {
@@ -265,7 +278,11 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
 
         if (CATCHUP_CHUNK > 0 && (t - lastTick) % CATCHUP_CHUNK === 0 && t < targetTick) {
           useEngineStore.setState({
-            catchupProgress: { current: t, target: targetTick, phase: "player" },
+            catchupProgress: {
+              current: t,
+              target: targetTick,
+              phase: "player",
+            },
           });
           await new Promise((resolve) => setTimeout(resolve, 0));
         }
@@ -365,22 +382,64 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             ac.flightHoursSinceCheck += flightHoursData;
             ac.condition = Math.max(0, ac.condition - 0.00005 * flightHoursData);
           }
+
+          // Look up the route to calculate full financial breakdown
+          const isFerry = ac.flight?.purpose === "ferry";
+          const route = !isFerry ? routes.find((r) => r.id === ac.assignedRouteId) : null;
+
+          // Calculate financials BEFORE mutating aircraft state so ac.flight is intact
+          let landingResult: ReturnType<typeof estimateLandingFinancials> | null = null;
+          if (route && !isFerry) {
+            landingResult = estimateLandingFinancials(
+              ac,
+              route,
+              model,
+              flightHoursData,
+              ac.lastKnownLoadFactor ?? 0.65,
+            );
+          }
+
           ac.status = "turnaround";
           ac.baseAirportIata = ac.flight.destinationIata;
           ac.arrivalTickProcessed = ac.flight.arrivalTick;
           ac.turnaroundEndTick = targetTick + turnaroundTicks;
           anyChanges = true;
-          recoveryEvents.push({
-            id: `evt-recovery-landing-${ac.id}-${targetTick}`,
-            tick: targetTick,
-            timestamp: simulatedTimestamp,
-            type: "landing",
-            aircraftId: ac.id,
-            aircraftName: ac.name,
-            originIata: ac.flight.originIata,
-            destinationIata: ac.flight.destinationIata,
-            description: `${ac.name} recovery landing at ${ac.flight.destinationIata}.`,
-          });
+
+          if (landingResult) {
+            // Full financial breakdown using recovery helper
+            currentBalance = fpAdd(currentBalance, landingResult.profit);
+            ac.lastKnownLoadFactor = landingResult.revenue.loadFactor;
+
+            recoveryEvents.push({
+              id: `evt-recovery-landing-${ac.id}-${targetTick}`,
+              tick: targetTick,
+              timestamp: simulatedTimestamp,
+              type: "landing",
+              aircraftId: ac.id,
+              aircraftName: ac.name,
+              routeId: route!.id,
+              originIata: ac.flight.originIata,
+              destinationIata: ac.flight.destinationIata,
+              revenue: landingResult.revenue.revenueTotal,
+              cost: landingResult.cost.costTotal,
+              profit: landingResult.profit,
+              description: `${ac.name} landed at ${ac.flight.destinationIata}. Net Profit: ${landingResult.profit > 0 ? "+" : ""}${fpToNumber(landingResult.profit)}`,
+              details: landingResult.details,
+            });
+          } else {
+            // Ferry or no route — bare event (no financials to calculate)
+            recoveryEvents.push({
+              id: `evt-recovery-landing-${ac.id}-${targetTick}`,
+              tick: targetTick,
+              timestamp: simulatedTimestamp,
+              type: isFerry ? "ferry" : "landing",
+              aircraftId: ac.id,
+              aircraftName: ac.name,
+              originIata: ac.flight.originIata,
+              destinationIata: ac.flight.destinationIata,
+              description: `${ac.name} ${isFerry ? "ferried" : "recovery landing"} at ${ac.flight.destinationIata}.`,
+            });
+          }
         }
 
         if (ac.status === "turnaround" && (ac.turnaroundEndTick || 0) <= targetTick) {
@@ -448,7 +507,11 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
         lastTick: processingError ? lastProcessedTick : targetTick,
         timeline: currentTimeline,
       };
-      set({ fleet: currentFleet, airline: updatedAirline, timeline: currentTimeline });
+      set({
+        fleet: currentFleet,
+        airline: updatedAirline,
+        timeline: currentTimeline,
+      });
       const previousCheckpointTick = Math.floor(lastTick / CHECKPOINT_INTERVAL);
       const nextCheckpointTick = Math.floor(targetTick / CHECKPOINT_INTERVAL);
       if (nextCheckpointTick > previousCheckpointTick) {

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -423,7 +423,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
               revenue: landingResult.revenue.revenueTotal,
               cost: landingResult.cost.costTotal,
               profit: landingResult.profit,
-              description: `${ac.name} landed at ${ac.flight.destinationIata}. Net Profit: ${landingResult.profit > 0 ? "+" : ""}${fpToNumber(landingResult.profit)}`,
+              description: `${ac.name} landed at ${ac.flight.destinationIata}. Net Profit: ${fpToNumber(landingResult.profit) > 0 ? "+" : ""}${fpToNumber(landingResult.profit)}`,
               details: landingResult.details,
             });
           } else {


### PR DESCRIPTION
## Summary

- Recovery landings now produce full financial breakdowns (revenue, cost, profit, passenger details) instead of bare events
- Recovery landings now credit `corporateBalance` and update `lastKnownLoadFactor`
- Hub-aware airport fees included in reconcile/recovery calculations

## Architectural improvement: cycle algebra extraction

Extracted the aircraft round-trip cycle positioning logic into `@acars/core/src/cycle.ts` as the single source of truth:

- **`getCyclePhase(cycleStartTick, targetTick, durationTicks, turnaroundTicks, route)`** — pure function that returns the exact cycle phase (status, direction, departure/arrival ticks, turnaround end, base airport) for any point in a round-trip cycle
- **`countLandingsBetween(cycleStartTick, fromTick, toTick, durationTicks, turnaroundTicks)`** — O(1) landing counter moved from FlightEngine.ts to core

`FlightEngine.ts:applyCyclePhase()` now delegates to the core `getCyclePhase()` instead of reimplementing the four-phase logic inline. This enables future consolidation of the recovery sweep and backfill paths (Phases 2-3 of the architectural plan).

## CodeRabbit fixes

- **Null dereference**: `model!` was used before the `!model` guard in `estimateLandingFinancials` — early return now precedes any model access
- **FixedPoint comparison**: `landingResult.profit > 0` replaced with `fpToNumber(landingResult.profit) > 0`
- **Defensive access**: `ac.configuration?.economy` with fallback to `model.capacity.economy`

## CI note

The `verify` CI failure is a pre-existing flaky `Sidebar.test.tsx` WebSocket error (`TypeError: The "event" argument must be an instance of Event`) from `undici` — unrelated to these changes. All 342 tests pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detailed landing financials per landing: profit, revenue, cost and expanded breakdowns included in events
  * Public cycle-phase API for consistent flight phase detection

* **Improvements**
  * Hub-aware airport fee and cost modeling for richer profit calculations
  * Timeline events enriched with passengers, load factors, route, duration and granular revenue/cost details
  * Robust handling of zero/invalid inputs returning consistent financial summaries

* **Refactor**
  * Consolidated cycle and landing accumulation logic for clearer state reconciliation

* **Tests**
  * Improved unit test mocks to support selector-based state access
<!-- end of auto-generated comment: release notes by coderabbit.ai -->