### PR TITLE
fix: replace boolean concurrency flags with AsyncMutex, serialize tick processing

### DIFF
--- a/packages/nostr/src/identity.test.ts
+++ b/packages/nostr/src/identity.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getPublicKeyMock = vi.fn();
 const signerMock = vi.fn();
@@ -28,6 +28,10 @@ describe("identity", () => {
     delete (globalThis as any).window;
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("detects missing NIP-07 extension", () => {
     expect(hasNip07()).toBe(false);
   });
@@ -55,7 +59,6 @@ describe("identity", () => {
     vi.advanceTimersByTime(4000);
     const result = await promise;
     expect(result).toBeNull();
-    vi.useRealTimers();
   });
 
   it("attaches a new signer when available", () => {

--- a/packages/store/src/actionChain.test.ts
+++ b/packages/store/src/actionChain.test.ts
@@ -13,8 +13,8 @@ vi.mock("@acars/nostr", () => {
 });
 
 import { computeActionChainHash } from "@acars/core";
-import { publishActionWithChain } from "./actionChain.js";
 import { publishAction } from "@acars/nostr";
+import { publishActionWithChain } from "./actionChain.js";
 
 describe("publishActionWithChain", () => {
   it("serializes action chain hash updates", async () => {
@@ -49,17 +49,18 @@ describe("publishActionWithChain", () => {
     const first = publishActionWithChain({ action: firstAction, get, set });
     const second = publishActionWithChain({ action: secondAction, get, set });
 
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(computeMock).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(computeMock).toHaveBeenCalledTimes(1);
+    });
     expect(computeMock.mock.calls[0]?.[0]).toBe("");
 
     deferred[0]?.("hash-1");
     await first;
     expect(state.actionChainHash).toBe("hash-1");
 
-    await Promise.resolve();
-    expect(computeMock).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => {
+      expect(computeMock).toHaveBeenCalledTimes(2);
+    });
     expect(computeMock.mock.calls[1]?.[0]).toBe("hash-1");
 
     deferred[1]?.("hash-2");

--- a/packages/store/src/airline.ts
+++ b/packages/store/src/airline.ts
@@ -43,6 +43,15 @@ let lastSubscribedTick = -1;
 let initialSyncComplete = false;
 let unsubscribeActionStream: (() => void) | null = null;
 const logger = createLogger("WorldSync");
+
+/**
+ * Persistent promise chain that serializes tick processing across boundaries.
+ *
+ * Without this, a fast-returning `processTick` (mutex already held) would
+ * cause `processGlobalTick` to run immediately and potentially overlap with
+ * a still-in-flight `processTick` from the previous tick.
+ */
+let tickPipeline: Promise<void> = Promise.resolve();
 const runtimeEnv = (
   globalThis as {
     process?: { env?: { NODE_ENV?: string } };
@@ -81,7 +90,14 @@ useEngineStore.subscribe((state) => {
   lastSubscribedTick = state.tick;
 
   const store = useAirlineStore.getState();
-  void store.processTick(state.tick).then(() => store.processGlobalTick(state.tick));
+  tickPipeline = tickPipeline
+    .then(async () => {
+      await store.processTick(state.tick);
+      await store.processGlobalTick(state.tick);
+    })
+    .catch((error) => {
+      logger.warn("Tick pipeline failed", error);
+    });
 
   // Sync world state every 20 ticks (~1 min) as a safety net.
   // The primary sync path is the live subscription handler above.

--- a/packages/store/src/airline.ts
+++ b/packages/store/src/airline.ts
@@ -81,8 +81,7 @@ useEngineStore.subscribe((state) => {
   lastSubscribedTick = state.tick;
 
   const store = useAirlineStore.getState();
-  void store.processTick(state.tick);
-  void store.processGlobalTick(state.tick);
+  void store.processTick(state.tick).then(() => store.processGlobalTick(state.tick));
 
   // Sync world state every 20 ticks (~1 min) as a safety net.
   // The primary sync path is the live subscription handler above.

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -29,48 +29,47 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
   processTick: async (tick: number) => {
     if (!tickMutex.tryLock()) return;
 
-    const { fleet, airline, routes } = get();
-    if (!airline || airline.status === "liquidated") return;
-
-    // EMERGENCY BANKRUPTCY CHECK
-    // If balance is severely negative (e.g. -$10M), auto-pause operations
-    if (fpToNumber(airline.corporateBalance) < -10000000 && airline.status !== "chapter11") {
-      const updatedAirline = { ...airline, status: "chapter11" as const };
-      const previousState = {
-        airline,
-        fleet,
-        routes,
-        timeline: get().timeline,
-      };
-      set({ airline: updatedAirline });
-      publishActionWithChain({
-        action: {
-          schemaVersion: 2,
-          action: "TICK_UPDATE",
-          payload: {
-            status: "chapter11",
-            tick,
-          },
-        },
-        get,
-        set,
-      }).catch((e) => {
-        set(previousState);
-        console.error("Bankruptcy sync failed", e);
-      });
-      return;
-    }
-
-    // Prevent processing flights for a bankrupt airline
-    if (airline.status === "chapter11") return;
-
-    // 1. Determine where we are vs where we need to be
-    const lastTick = airline.lastTick ?? tick - 1;
-
-    // If we are already caught up, skip.
-    if (lastTick >= tick) return;
-
     try {
+      const { fleet, airline, routes } = get();
+      if (!airline || airline.status === "liquidated") return;
+
+      // EMERGENCY BANKRUPTCY CHECK
+      // If balance is severely negative (e.g. -$10M), auto-pause operations
+      if (fpToNumber(airline.corporateBalance) < -10000000 && airline.status !== "chapter11") {
+        const updatedAirline = { ...airline, status: "chapter11" as const };
+        const previousState = {
+          airline,
+          fleet,
+          routes,
+          timeline: get().timeline,
+        };
+        set({ airline: updatedAirline });
+        publishActionWithChain({
+          action: {
+            schemaVersion: 2,
+            action: "TICK_UPDATE",
+            payload: {
+              status: "chapter11",
+              tick,
+            },
+          },
+          get,
+          set,
+        }).catch((e) => {
+          set(previousState);
+          console.error("Bankruptcy sync failed", e);
+        });
+        return;
+      }
+
+      // Prevent processing flights for a bankrupt airline
+      if (airline.status === "chapter11") return;
+
+      // 1. Determine where we are vs where we need to be
+      const lastTick = airline.lastTick ?? tick - 1;
+
+      // If we are already caught up, skip.
+      if (lastTick >= tick) return;
       // 2. Catch up simulation
       // Safety cap: Never simulate more than 50,000 ticks (~40 hours) in one frame
       // to avoid freezing the browser. If the jump is larger, we will catch up

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -16,17 +16,18 @@ import { publishActionWithChain } from "../actionChain";
 import { useEngineStore } from "../engine";
 import { estimateLandingFinancials, processFlightEngine } from "../FlightEngine";
 import type { AirlineState } from "../types";
+import { AsyncMutex } from "../utils/asyncMutex";
 
 export interface EngineSlice {
   processTick: (tick: number) => Promise<void>;
 }
 
-let isProcessing = false;
+const tickMutex = new AsyncMutex();
 const CHECKPOINT_INTERVAL = 1200;
 
 export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> = (set, get) => ({
   processTick: async (tick: number) => {
-    if (isProcessing) return;
+    if (!tickMutex.tryLock()) return;
 
     const { fleet, airline, routes } = get();
     if (!airline || airline.status === "liquidated") return;
@@ -69,7 +70,6 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
     // If we are already caught up, skip.
     if (lastTick >= tick) return;
 
-    isProcessing = true;
     try {
       // 2. Catch up simulation
       // Safety cap: Never simulate more than 50,000 ticks (~40 hours) in one frame
@@ -561,7 +561,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
       }
       useEngineStore.setState({ catchupProgress: null });
     } finally {
-      isProcessing = false;
+      tickMutex.unlock();
       useEngineStore.setState({ catchupProgress: null });
     }
   },

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -387,7 +387,7 @@ describe("processGlobalTick", () => {
 
     // Simulate processGlobalTick holding the mutex by acquiring it directly.
     const mutex = _getGlobalTickMutex();
-    mutex.tryLock();
+    expect(mutex.tryLock()).toBe(true);
 
     // syncWorld without force should be skipped while the mutex is held.
     await state.syncWorld();

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -2,7 +2,7 @@ import type { AircraftInstance, AirlineEntity, FixedPoint, Route } from "@acars/
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateCreator } from "zustand";
 import type { AirlineState } from "../types";
-import { _resetWorldFlags, createWorldSlice } from "./worldSlice";
+import { _getGlobalTickMutex, _resetWorldFlags, createWorldSlice } from "./worldSlice";
 
 const mockProcessFlightEngine = vi.fn();
 
@@ -270,7 +270,12 @@ describe("processGlobalTick", () => {
         action: {
           schemaVersion: 2,
           action: "AIRLINE_CREATE",
-          payload: { name: "Old Air", hubs: ["JFK"], corporateBalance: 1000000000000, tick: 80 },
+          payload: {
+            name: "Old Air",
+            hubs: ["JFK"],
+            corporateBalance: 1000000000000,
+            tick: 80,
+          },
         },
       },
     ]);
@@ -366,7 +371,9 @@ describe("processGlobalTick", () => {
     await Promise.all([first, second]);
 
     // Wait for the queued follow-up sync to complete
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await vi.waitFor(() => {
+      expect(loadActionLog).toHaveBeenCalledTimes(2);
+    });
 
     // First call runs immediately, second is queued and runs after first completes
     expect(loadActionLog).toHaveBeenCalledTimes(2);
@@ -376,49 +383,19 @@ describe("processGlobalTick", () => {
     const { loadActionLog } = await import("@acars/nostr");
     (loadActionLog as unknown as ReturnType<typeof vi.fn>).mockClear();
 
-    // Set up a competitor that needs 1000 ticks of catchup.
-    // GLOBAL_CATCHUP_CHUNK = 200, so the loop yields every 200 ticks via setTimeout(0).
-    // That means 4 yield points (at ticks 200, 400, 600, 800).
-    // We call syncWorld right after the first yield while isProcessingGlobal is still true.
-    const tick = 1100;
-    const pubkey = "comp-blocking";
-    const competitors = new Map<string, AirlineEntity>([
-      [pubkey, makeAirline(pubkey, tick - 1000)],
-    ]);
-    const globalFleet = [makeAircraft("ac-blocking", pubkey)];
+    const { state } = createSliceState({});
 
-    const { state } = createSliceState({
-      competitors,
-      globalFleet,
-      globalFleetByOwner: buildFleetIndex(globalFleet),
-      globalRoutes: [],
-      globalRoutesByOwner: buildRoutesIndex([]),
-    });
+    // Simulate processGlobalTick holding the mutex by acquiring it directly.
+    const mutex = _getGlobalTickMutex();
+    mutex.tryLock();
 
-    // processGlobalTick will set isProcessingGlobal=true and yield at the
-    // 200-tick boundary.  We inject syncWorld into the macrotask queue
-    // right after the first yield so it runs while processing is still active.
-    let syncResult: Promise<void> | null = null;
-    const origSetTimeout = globalThis.setTimeout;
-    let yieldCount = 0;
-    vi.spyOn(globalThis, "setTimeout").mockImplementation((fn: TimerHandler, ms?: number) => {
-      yieldCount++;
-      if (yieldCount === 1) {
-        // After the first yield from processGlobalTick, insert syncWorld
-        return origSetTimeout(() => {
-          syncResult = state.syncWorld();
-          (fn as () => void)();
-        }, ms) as unknown as ReturnType<typeof setTimeout>;
-      }
-      return origSetTimeout(fn as TimerHandler, ms) as unknown as ReturnType<typeof setTimeout>;
-    });
-
-    await state.processGlobalTick(tick);
-    if (syncResult) await syncResult;
-
-    vi.restoreAllMocks();
-
-    // syncWorld should have been skipped because isProcessingGlobal was true
+    // syncWorld without force should be skipped while the mutex is held.
+    await state.syncWorld();
     expect(loadActionLog).toHaveBeenCalledTimes(0);
+
+    // Release and verify syncWorld works again.
+    mutex.unlock();
+    await state.syncWorld();
+    expect(loadActionLog).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -131,19 +131,18 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
   processGlobalTick: async (tick: number) => {
     if (!globalTickMutex.tryLock()) return;
 
-    const {
-      competitors,
-      globalFleetByOwner,
-      globalRoutesByOwner,
-      globalRouteRegistry,
-      routes,
-      fleet,
-      pubkey: playerPubkey,
-      airline: playerAirline,
-    } = get();
-    if (competitors.size === 0) return;
-
     try {
+      const {
+        competitors,
+        globalFleetByOwner,
+        globalRoutesByOwner,
+        globalRouteRegistry,
+        routes,
+        fleet,
+        pubkey: playerPubkey,
+        airline: playerAirline,
+      } = get();
+      if (competitors.size === 0) return;
       const updatedGlobalFleet: AircraftInstance[] = [];
       const updatedCompetitors = new Map(competitors);
       const processedPubkeys = new Set<string>();
@@ -336,7 +335,11 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       }
       return;
     }
-    if (globalTickMutex.isLocked && !options?.force) return;
+    // For non-force calls, acquire the globalTickMutex so processGlobalTick
+    // cannot run concurrently.  Force calls (initial sync, periodic resync)
+    // skip the mutex to guarantee they always execute.
+    const holdGlobalTickLock = !options?.force;
+    if (holdGlobalTickLock && !globalTickMutex.tryLock()) return;
     isSyncingWorld = true;
     try {
       try {
@@ -796,6 +799,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
         useEngineStore.setState({ catchupProgress: null });
       }
     } finally {
+      if (holdGlobalTickLock) globalTickMutex.unlock();
       isSyncingWorld = false;
       // Drain the queue: if a sync was requested while we were busy, run it now.
       if (pendingSyncWorldOptions) {

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -23,6 +23,7 @@ import { replayActionLog } from "../actionReducer";
 import { useEngineStore } from "../engine";
 import { processFlightEngine, reconcileFleetToTick } from "../FlightEngine";
 import type { AirlineState } from "../types";
+import { AsyncMutex } from "../utils/asyncMutex";
 
 export interface WorldSlice {
   competitors: Map<string, AirlineEntity>;
@@ -37,8 +38,7 @@ export interface WorldSlice {
   processGlobalTick: (tick: number) => Promise<void>;
 }
 
-let isProcessingGlobal = false;
-let isProcessingGlobalSince = 0;
+const globalTickMutex = new AsyncMutex();
 let isSyncingWorld = false;
 let pendingSyncWorldOptions: { force?: boolean } | null = null;
 const GLOBAL_CATCHUP_CHUNK = 200;
@@ -46,15 +46,17 @@ const MAX_COMPETITOR_CATCHUP = 1000;
 const MAX_TOTAL_COMPETITOR_TICKS = 5000;
 const TICKS_PER_DAY = 24 * TICKS_PER_HOUR;
 const MONTH_TICKS = 30 * TICKS_PER_DAY;
-/** If processGlobalTick takes longer than this, auto-reset the flag. */
-const PROCESSING_GLOBAL_TIMEOUT_MS = 30_000;
 
 /** @internal — test-only helper to reset module-level concurrency flags */
 export function _resetWorldFlags() {
-  isProcessingGlobal = false;
-  isProcessingGlobalSince = 0;
+  globalTickMutex.reset();
   isSyncingWorld = false;
   pendingSyncWorldOptions = null;
+}
+
+/** @internal — test-only accessor for the global tick mutex */
+export function _getGlobalTickMutex() {
+  return globalTickMutex;
 }
 
 const buildFleetIndex = (fleet: AircraftInstance[]) => {
@@ -127,19 +129,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
   viewAs: (pubkey) => set({ viewedPubkey: pubkey }),
 
   processGlobalTick: async (tick: number) => {
-    // Auto-reset if the flag has been stuck for too long (e.g. unhandled throw).
-    if (isProcessingGlobal && isProcessingGlobalSince > 0) {
-      const elapsed = Date.now() - isProcessingGlobalSince;
-      if (elapsed > PROCESSING_GLOBAL_TIMEOUT_MS) {
-        console.warn(
-          `[WorldSlice] isProcessingGlobal stuck for ${Math.round(elapsed / 1000)}s — auto-resetting.`,
-        );
-        isProcessingGlobal = false;
-        isProcessingGlobalSince = 0;
-      }
-    }
-
-    if (isProcessingGlobal) return;
+    if (!globalTickMutex.tryLock()) return;
 
     const {
       competitors,
@@ -153,8 +143,6 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
     } = get();
     if (competitors.size === 0) return;
 
-    isProcessingGlobal = true;
-    isProcessingGlobalSince = Date.now();
     try {
       const updatedGlobalFleet: AircraftInstance[] = [];
       const updatedCompetitors = new Map(competitors);
@@ -333,8 +321,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       });
       useEngineStore.setState({ catchupProgress: null });
     } finally {
-      isProcessingGlobal = false;
-      isProcessingGlobalSince = 0;
+      globalTickMutex.unlock();
     }
   },
 
@@ -349,7 +336,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       }
       return;
     }
-    if (isProcessingGlobal && !options?.force) return;
+    if (globalTickMutex.isLocked && !options?.force) return;
     isSyncingWorld = true;
     try {
       try {
@@ -792,7 +779,9 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           }
 
           if (newTimelineEvents.length > 0) {
-            set({ timeline: [...newTimelineEvents, ...existingState.timeline].slice(0, 1000) });
+            set({
+              timeline: [...newTimelineEvents, ...existingState.timeline].slice(0, 1000),
+            });
           }
         }
 

--- a/packages/store/src/utils/asyncMutex.ts
+++ b/packages/store/src/utils/asyncMutex.ts
@@ -1,0 +1,43 @@
+/**
+ * Lightweight async mutex with try-lock semantics.
+ *
+ * Unlike a traditional mutex that queues waiters, `tryLock()` returns `false`
+ * immediately when already held — callers skip rather than queue.  This is the
+ * correct primitive for tick processing where a missed lock simply means "the
+ * next tick will retry."
+ *
+ * The previous approach used bare `let isProcessing = false` booleans which
+ * are NOT safe across `await` points: two async functions can both read the
+ * flag as `false` before either sets it to `true`.
+ *
+ * This class solves the problem by making `tryLock()` synchronous and
+ * non-reentrant — the flag is set atomically within a single microtask.
+ */
+export class AsyncMutex {
+  private _locked = false;
+
+  /** `true` when the mutex is currently held. */
+  get isLocked(): boolean {
+    return this._locked;
+  }
+
+  /**
+   * Attempt to acquire the lock.
+   * @returns `true` if the lock was acquired, `false` if already held.
+   */
+  tryLock(): boolean {
+    if (this._locked) return false;
+    this._locked = true;
+    return true;
+  }
+
+  /** Release the lock.  Safe to call even if not currently held. */
+  unlock(): void {
+    this._locked = false;
+  }
+
+  /** Force-reset the lock (e.g. for test teardown). */
+  reset(): void {
+    this._locked = false;
+  }
+}


### PR DESCRIPTION
## Summary

- Replace ad-hoc boolean locks (`isProcessing`, `isProcessingGlobal`) with a proper `AsyncMutex` utility providing atomic tryLock/unlock semantics
- Eliminate race conditions across await points in tick processing
- Serialize `processTick` → `processGlobalTick` to prevent concurrent reads/writes to Zustand state
- Fix flaky tests by replacing timing-dependent patterns with deterministic `vi.waitFor` assertions

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization to prevent concurrent processing/race conditions during tick and global operations, making state updates more reliable.

* **Tests**
  * Increased test robustness with deterministic synchronization and teardown hooks to avoid flaky timing-based assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->