### PR TITLE
feat(ui): badge & notification system for nav sidebar and mobile bar

### DIFF
--- a/apps/web/src/shared/components/layout/NavBadge.tsx
+++ b/apps/web/src/shared/components/layout/NavBadge.tsx
@@ -1,0 +1,38 @@
+const MAX_BADGE = 99;
+
+function formatCount(count: number): string {
+  return count > MAX_BADGE ? `${MAX_BADGE}+` : String(count);
+}
+
+interface NavBadgeProps {
+  count: number;
+  variant: "gray" | "red";
+  /** Extra Tailwind classes for size/position overrides */
+  className?: string;
+}
+
+/**
+ * A small pill badge to overlay on nav icons.
+ * Renders nothing when count <= 0.
+ * Position: absolute, placed by the parent's `relative` wrapper.
+ */
+export function NavBadge({ count, variant, className = "" }: NavBadgeProps) {
+  if (count <= 0) return null;
+
+  const base =
+    "absolute -top-1 -right-1 z-10 flex min-w-[16px] h-4 items-center justify-center rounded-full px-1 text-[9px] font-bold leading-none tabular-nums pointer-events-none";
+
+  const colors =
+    variant === "red"
+      ? "bg-destructive text-white"
+      : "bg-muted text-muted-foreground border border-border/60";
+
+  return (
+    <span
+      className={`${base} ${colors} ${className}`}
+      aria-label={`${count} notification${count !== 1 ? "s" : ""}`}
+    >
+      {formatCount(count)}
+    </span>
+  );
+}

--- a/apps/web/src/shared/components/layout/Sidebar.test.tsx
+++ b/apps/web/src/shared/components/layout/Sidebar.test.tsx
@@ -1,13 +1,22 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { Sidebar } from "./Sidebar";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MobileNav, Sidebar } from "./Sidebar";
+
+afterEach(cleanup);
+
+const defaultState = {
+  airline: null,
+  viewedPubkey: null,
+  fleet: [],
+  routes: [],
+  competitors: new Map(),
+};
 
 vi.mock("@acars/store", () => {
   return {
     useAirlineStore: (selector?: (state: Record<string, unknown>) => unknown) => {
-      const state = { airline: null, viewedPubkey: null };
-      return selector ? selector(state) : state;
+      return selector ? selector(defaultState) : defaultState;
     },
   };
 });
@@ -26,5 +35,18 @@ describe("Sidebar", () => {
     expect(screen.getByText("Network")).toBeInTheDocument();
     expect(screen.getByText("Leaderboard")).toBeInTheDocument();
     expect(screen.getByText("Corporate")).toBeInTheDocument();
+  });
+
+  it("renders no badges when no airline is loaded", () => {
+    render(<Sidebar />);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});
+
+describe("MobileNav", () => {
+  it("renders navigation items", () => {
+    render(<MobileNav />);
+    expect(screen.getByText("Map")).toBeInTheDocument();
+    expect(screen.getByText("Fleet")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/shared/components/layout/Sidebar.tsx
+++ b/apps/web/src/shared/components/layout/Sidebar.tsx
@@ -1,6 +1,8 @@
 import { useAirlineStore } from "@acars/store";
 import { Link } from "@tanstack/react-router";
 import { Building2, Globe, Map as MapIcon, Plane, Trophy } from "lucide-react";
+import { NavBadge } from "./NavBadge";
+import { useNavBadges } from "@/shared/hooks/useNavBadges";
 
 const navItems = [
   { icon: MapIcon, label: "Map", to: "/", requiresAirline: false },
@@ -10,15 +12,39 @@ const navItems = [
   { icon: Building2, label: "Corporate", to: "/corporate", requiresAirline: true },
 ];
 
+/** Resolve the badge to show for a given nav route path, given current badge counts. */
+function resolveNavBadge(
+  to: string,
+  badges: ReturnType<typeof useNavBadges>,
+): { count: number; variant: "gray" | "red" } | null {
+  if (to === "/fleet") {
+    if (badges.fleetUnassigned > 0) return { count: badges.fleetUnassigned, variant: "red" };
+    if (badges.fleetTotal > 0) return { count: badges.fleetTotal, variant: "gray" };
+    return null;
+  }
+  if (to === "/network") {
+    if (badges.networkUnassigned > 0) return { count: badges.networkUnassigned, variant: "red" };
+    if (badges.networkTotal > 0) return { count: badges.networkTotal, variant: "gray" };
+    return null;
+  }
+  if (to === "/leaderboard") {
+    if (badges.leaderboardRank > 0) return { count: badges.leaderboardRank, variant: "gray" };
+    return null;
+  }
+  return null;
+}
+
 export function Sidebar() {
   const { airline, viewedPubkey } = useAirlineStore((state) => state);
   const hasAirlineContext = Boolean(airline || viewedPubkey);
+  const badges = useNavBadges();
 
   return (
     <div className="pointer-events-auto hidden sm:flex h-full w-16 md:w-20 flex-col items-center border-r border-border bg-background/80 py-6 backdrop-blur-xl transition-all">
       <div className="flex flex-1 flex-col space-y-4">
         {navItems.map((item) => {
           const isDisabled = item.requiresAirline && !hasAirlineContext;
+          const badge = resolveNavBadge(item.to, badges);
           return (
             <Link
               key={item.to}
@@ -35,6 +61,7 @@ export function Sidebar() {
               }}
             >
               <item.icon className="h-6 w-6" />
+              {badge && <NavBadge count={badge.count} variant={badge.variant} />}
               {/* Tooltip on hover */}
               <span className="absolute left-14 z-50 rounded-md bg-popover px-2 py-1 text-xs font-semibold text-popover-foreground opacity-0 shadow-md transition-opacity group-hover:opacity-100 pointer-events-none whitespace-nowrap">
                 {item.label}
@@ -52,11 +79,13 @@ export function Sidebar() {
 export function MobileNav() {
   const { airline, viewedPubkey } = useAirlineStore((state) => state);
   const hasAirlineContext = Boolean(airline || viewedPubkey);
+  const badges = useNavBadges();
 
   return (
     <nav className="pointer-events-auto flex sm:hidden items-center justify-around border-t border-border bg-background/90 backdrop-blur-xl px-2 py-1.5 shrink-0">
       {navItems.map((item) => {
         const isDisabled = item.requiresAirline && !hasAirlineContext;
+        const badge = resolveNavBadge(item.to, badges);
         return (
           <Link
             key={item.to}
@@ -71,7 +100,16 @@ export function MobileNav() {
                 : "text-muted-foreground active:text-foreground",
             }}
           >
-            <item.icon className="h-5 w-5" />
+            <span className="relative">
+              <item.icon className="h-5 w-5" />
+              {badge && (
+                <NavBadge
+                  count={badge.count}
+                  variant={badge.variant}
+                  className="min-w-[14px] h-3.5 text-[8px]"
+                />
+              )}
+            </span>
             <span className="text-[9px] font-semibold uppercase tracking-wider leading-none">
               {item.label}
             </span>

--- a/apps/web/src/shared/hooks/useNavBadges.test.ts
+++ b/apps/web/src/shared/hooks/useNavBadges.test.ts
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AircraftInstance, AirlineEntity, Route } from "@acars/core";
+import { fp } from "@acars/core";
 import { useNavBadges } from "./useNavBadges";
 
 // Minimal factory helpers
@@ -14,7 +15,7 @@ const makeAircraft = (overrides: Partial<AircraftInstance> = {}): AircraftInstan
     assignedRouteId: null,
     baseAirportIata: "JFK",
     purchasedAtTick: 0,
-    purchasePrice: 1000000,
+    purchasePrice: fp(1000000),
     birthTick: 0,
     listingPrice: null,
     flight: null,
@@ -37,9 +38,9 @@ const makeRoute = (overrides: Partial<Route> = {}): Route =>
     distanceKm: 5500,
     frequencyPerWeek: 7,
     assignedAircraftIds: [],
-    fareEconomy: 300,
-    fareBusiness: 900,
-    fareFirst: 1800,
+    fareEconomy: fp(300),
+    fareBusiness: fp(900),
+    fareFirst: fp(1800),
     status: "active",
     ...overrides,
   }) as Route;
@@ -55,10 +56,10 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity =>
     hubs: ["JFK"],
     fleetIds: [],
     routeIds: [],
-    corporateBalance: 1000000,
+    corporateBalance: fp(1000000),
     brandScore: 5,
     tier: 1,
-    stockPrice: 10,
+    stockPrice: fp(10),
     livery: { primary: "#000", secondary: "#fff", accent: "#0f0" },
     status: "public",
     ...overrides,
@@ -124,9 +125,9 @@ describe("useNavBadges", () => {
   });
 
   it("computes leaderboard rank correctly", () => {
-    const airline = makeAirline({ id: "al-own", corporateBalance: 500000 });
-    const comp1 = makeAirline({ id: "al-comp1", ceoPubkey: "pk2", corporateBalance: 2000000 });
-    const comp2 = makeAirline({ id: "al-comp2", ceoPubkey: "pk3", corporateBalance: 100000 });
+    const airline = makeAirline({ id: "al-own", corporateBalance: fp(500000) });
+    const comp1 = makeAirline({ id: "al-comp1", ceoPubkey: "pk2", corporateBalance: fp(2000000) });
+    const comp2 = makeAirline({ id: "al-comp2", ceoPubkey: "pk3", corporateBalance: fp(100000) });
     mockState = {
       airline,
       fleet: [],
@@ -142,8 +143,8 @@ describe("useNavBadges", () => {
   });
 
   it("returns rank 1 when airline is top by balance", () => {
-    const airline = makeAirline({ id: "al-own", corporateBalance: 9999999 });
-    const comp = makeAirline({ id: "al-comp", ceoPubkey: "pk2", corporateBalance: 100 });
+    const airline = makeAirline({ id: "al-own", corporateBalance: fp(9999999) });
+    const comp = makeAirline({ id: "al-comp", ceoPubkey: "pk2", corporateBalance: fp(100) });
     mockState = {
       airline,
       fleet: [],

--- a/apps/web/src/shared/hooks/useNavBadges.test.ts
+++ b/apps/web/src/shared/hooks/useNavBadges.test.ts
@@ -1,0 +1,156 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AircraftInstance, AirlineEntity, Route } from "@acars/core";
+import { useNavBadges } from "./useNavBadges";
+
+// Minimal factory helpers
+const makeAircraft = (overrides: Partial<AircraftInstance> = {}): AircraftInstance =>
+  ({
+    id: "ac-1",
+    ownerPubkey: "pk1",
+    modelId: "b737",
+    name: "Test",
+    status: "idle",
+    assignedRouteId: null,
+    baseAirportIata: "JFK",
+    purchasedAtTick: 0,
+    purchasePrice: 1000000,
+    birthTick: 0,
+    listingPrice: null,
+    flight: null,
+    purchaseType: "buy",
+    flightHoursTotal: 0,
+    condition: 1,
+    seatsEconomy: 150,
+    seatsBusiness: 20,
+    seatsFirst: 0,
+    cargoKg: 0,
+    ...overrides,
+  }) as AircraftInstance;
+
+const makeRoute = (overrides: Partial<Route> = {}): Route =>
+  ({
+    id: "rt-1",
+    originIata: "JFK",
+    destinationIata: "LHR",
+    airlinePubkey: "pk1",
+    distanceKm: 5500,
+    frequencyPerWeek: 7,
+    assignedAircraftIds: [],
+    fareEconomy: 300,
+    fareBusiness: 900,
+    fareFirst: 1800,
+    status: "active",
+    ...overrides,
+  }) as Route;
+
+const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity =>
+  ({
+    id: "al-1",
+    ceoPubkey: "pk1",
+    name: "Test Air",
+    icaoCode: "TST",
+    callsign: "TESTA",
+    hubIata: "JFK",
+    hubs: ["JFK"],
+    fleetIds: [],
+    routeIds: [],
+    corporateBalance: 1000000,
+    brandScore: 5,
+    tier: 1,
+    stockPrice: 10,
+    livery: { primary: "#000", secondary: "#fff", accent: "#0f0" },
+    status: "public",
+    ...overrides,
+  }) as unknown as AirlineEntity;
+
+// State we'll mutate per test
+let mockState = {
+  airline: null as AirlineEntity | null,
+  fleet: [] as AircraftInstance[],
+  routes: [] as Route[],
+  competitors: new Map<string, AirlineEntity>(),
+};
+
+vi.mock("@acars/store", () => ({
+  useAirlineStore: (selector: (s: typeof mockState) => unknown) => selector(mockState),
+}));
+
+describe("useNavBadges", () => {
+  it("returns all zeros when no airline is loaded", () => {
+    mockState = { airline: null, fleet: [], routes: [], competitors: new Map() };
+    const { result } = renderHook(() => useNavBadges());
+    expect(result.current).toEqual({
+      fleetTotal: 0,
+      fleetUnassigned: 0,
+      networkTotal: 0,
+      networkUnassigned: 0,
+      leaderboardRank: 0,
+    });
+  });
+
+  it("counts total fleet and idle-unassigned aircraft", () => {
+    const airline = makeAirline();
+    mockState = {
+      airline,
+      fleet: [
+        makeAircraft({ id: "ac-1", status: "idle", assignedRouteId: null }),
+        makeAircraft({ id: "ac-2", status: "idle", assignedRouteId: "rt-1" }),
+        makeAircraft({ id: "ac-3", status: "enroute", assignedRouteId: "rt-1" }),
+      ],
+      routes: [],
+      competitors: new Map(),
+    };
+    const { result } = renderHook(() => useNavBadges());
+    expect(result.current.fleetTotal).toBe(3);
+    expect(result.current.fleetUnassigned).toBe(1); // only ac-1 is idle+unassigned
+  });
+
+  it("counts total routes and active-unassigned routes", () => {
+    const airline = makeAirline();
+    mockState = {
+      airline,
+      fleet: [],
+      routes: [
+        makeRoute({ id: "rt-1", status: "active", assignedAircraftIds: [] }),
+        makeRoute({ id: "rt-2", status: "active", assignedAircraftIds: ["ac-1"] }),
+        makeRoute({ id: "rt-3", status: "suspended", assignedAircraftIds: [] }),
+      ],
+      competitors: new Map(),
+    };
+    const { result } = renderHook(() => useNavBadges());
+    expect(result.current.networkTotal).toBe(3);
+    expect(result.current.networkUnassigned).toBe(1); // only rt-1 active+empty
+  });
+
+  it("computes leaderboard rank correctly", () => {
+    const airline = makeAirline({ id: "al-own", corporateBalance: 500000 });
+    const comp1 = makeAirline({ id: "al-comp1", ceoPubkey: "pk2", corporateBalance: 2000000 });
+    const comp2 = makeAirline({ id: "al-comp2", ceoPubkey: "pk3", corporateBalance: 100000 });
+    mockState = {
+      airline,
+      fleet: [],
+      routes: [],
+      competitors: new Map([
+        ["pk2", comp1],
+        ["pk3", comp2],
+      ]),
+    };
+    const { result } = renderHook(() => useNavBadges());
+    // Sorted: comp1 (2M), own (500k), comp2 (100k) → rank 2
+    expect(result.current.leaderboardRank).toBe(2);
+  });
+
+  it("returns rank 1 when airline is top by balance", () => {
+    const airline = makeAirline({ id: "al-own", corporateBalance: 9999999 });
+    const comp = makeAirline({ id: "al-comp", ceoPubkey: "pk2", corporateBalance: 100 });
+    mockState = {
+      airline,
+      fleet: [],
+      routes: [],
+      competitors: new Map([["pk2", comp]]),
+    };
+    const { result } = renderHook(() => useNavBadges());
+    expect(result.current.leaderboardRank).toBe(1);
+  });
+});

--- a/apps/web/src/shared/hooks/useNavBadges.ts
+++ b/apps/web/src/shared/hooks/useNavBadges.ts
@@ -1,0 +1,47 @@
+import { useAirlineStore } from "@acars/store";
+import { useMemo } from "react";
+
+export interface NavBadges {
+  fleetTotal: number;
+  fleetUnassigned: number;
+  networkTotal: number;
+  networkUnassigned: number;
+  /** 1-based rank position by corporate balance; 0 if unknown */
+  leaderboardRank: number;
+}
+
+/**
+ * Derives badge counts for nav items from the airline store.
+ * All computations are O(N) on already-loaded arrays — safe for large fleets.
+ * Returns all zeros when no airline is loaded.
+ */
+export function useNavBadges(): NavBadges {
+  const airline = useAirlineStore((s) => s.airline);
+  const fleet = useAirlineStore((s) => s.fleet);
+  const routes = useAirlineStore((s) => s.routes);
+  const competitors = useAirlineStore((s) => s.competitors);
+
+  const fleetTotal = airline ? fleet.length : 0;
+
+  const fleetUnassigned = useMemo(() => {
+    if (!airline) return 0;
+    return fleet.filter((ac) => ac.status === "idle" && ac.assignedRouteId === null).length;
+  }, [fleet, airline]);
+
+  const networkTotal = airline ? routes.length : 0;
+
+  const networkUnassigned = useMemo(() => {
+    if (!airline) return 0;
+    return routes.filter((r) => r.status === "active" && r.assignedAircraftIds.length === 0).length;
+  }, [routes, airline]);
+
+  const leaderboardRank = useMemo(() => {
+    if (!airline) return 0;
+    const allAirlines = [...Array.from(competitors.values()), airline];
+    const sorted = allAirlines.slice().sort((a, b) => b.corporateBalance - a.corporateBalance);
+    const idx = sorted.findIndex((a) => a.id === airline.id);
+    return idx === -1 ? 0 : idx + 1;
+  }, [airline, competitors]);
+
+  return { fleetTotal, fleetUnassigned, networkTotal, networkUnassigned, leaderboardRank };
+}


### PR DESCRIPTION
## Summary

Adds at-a-glance status badges to the nav icons in both the desktop sidebar (left bar) and mobile bottom bar.

## Badge Behavior

| Nav Item | Gray mode | Red mode |
|---|---|---|
| **Fleet** ✈️ | Total aircraft count | Idle aircraft with no route assigned |
| **Network** 🌐 | Total routes count | Active routes with no aircraft assigned |
| **Leaderboard** 🏆 | Rank position (by balance) | *(no red mode)* |
| Map / Corporate | *(no badge)* | *(no badge)* |

**Priority rule:** Red takes precedence over gray. Nothing shown when count is 0 or no airline is loaded.

## Files Changed

### New
- `apps/web/src/shared/hooks/useNavBadges.ts` — pure selector hook, derives all badge counts from existing store state (no new state added)
- `apps/web/src/shared/components/layout/NavBadge.tsx` — small pill badge component, gray/red variants, caps at `99+`
- `apps/web/src/shared/hooks/useNavBadges.test.ts` — 5 unit tests covering fleet counts, route counts, and leaderboard rank

### Modified
- `apps/web/src/shared/components/layout/Sidebar.tsx` — wired badges into both `Sidebar` (desktop) and `MobileNav` (mobile)
- `apps/web/src/shared/components/layout/Sidebar.test.tsx` — updated state mock + added MobileNav tests

## Implementation Notes
- Zero new store state — all data derived from already-loaded `fleet`, `routes`, `competitors`, `airline`
- Fleet unassigned = `status === 'idle' && assignedRouteId === null`
- Route unassigned = `status === 'active' && assignedAircraftIds.length === 0`
- Leaderboard rank = 1-based position sorted descending by `corporateBalance`
- All 89 tests pass ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation badges now display counts and metrics on relevant icons
  * Visual indicators show fleet status, network information, and competitive ranking
  * Badges automatically update as data changes

* **Tests**
  * Added test coverage for badge functionality and calculation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->