### PR TITLE
fix(sync): resolve multiplayer fleet/balance desync across 4 root causes

### DIFF
--- a/apps/web/src/routes/-fleet.lazy.test.tsx
+++ b/apps/web/src/routes/-fleet.lazy.test.tsx
@@ -10,6 +10,17 @@ vi.mock("@acars/store", () => {
       const state = mockUseAirlineStore();
       return selector ? selector(state) : state;
     },
+    useActiveAirline: () => {
+      const state = mockUseAirlineStore();
+      return {
+        airline: state.airline,
+        fleet: state.fleet ?? [],
+        routes: state.routes ?? [],
+        timeline: state.timeline ?? [],
+        isViewingOther: false,
+        isGuest: !state.airline,
+      };
+    },
   };
 });
 

--- a/apps/web/src/routes/-fleet.lazy.tsx
+++ b/apps/web/src/routes/-fleet.lazy.tsx
@@ -1,11 +1,12 @@
-import { useAirlineStore } from "@acars/store";
+import { useActiveAirline, useAirlineStore } from "@acars/store";
 import { FleetManager } from "@/features/fleet/components/FleetManager";
 import { PanelLayout } from "@/shared/components/layout/PanelLayout";
 
 export default function FleetDashboard() {
   const { airline, initializeIdentity, isLoading } = useAirlineStore();
   const isViewingOther = useAirlineStore((state) => Boolean(state.viewedPubkey));
-  const fleetSize = useAirlineStore((state) => state.fleet.length);
+  const { fleet } = useActiveAirline();
+  const fleetSize = fleet.length;
 
   if (!airline && !isViewingOther) {
     return (

--- a/packages/nostr/src/schema.ts
+++ b/packages/nostr/src/schema.ts
@@ -384,6 +384,7 @@ export async function loadCheckpoint(pubkey: string): Promise<Checkpoint | null>
   const filter: NDKFilter = {
     kinds: [ACTION_KIND],
     authors: [pubkey],
+    "#d": [CHECKPOINT_D_TAG],
     limit: 5,
   };
 
@@ -432,6 +433,7 @@ export async function loadCheckpoints(pubkeys: string[]): Promise<Map<string, Ch
   const filter: NDKFilter = {
     kinds: [ACTION_KIND],
     authors: pubkeys,
+    "#d": [CHECKPOINT_D_TAG],
     limit: Math.max(pubkeys.length, 100),
   };
 

--- a/packages/store/src/slices/identitySlice.test.ts
+++ b/packages/store/src/slices/identitySlice.test.ts
@@ -116,7 +116,7 @@ describe("identitySlice initializeIdentity", () => {
     expect(state.airline?.lastTick).toBe(50000);
   });
 
-  it("filters action log entries after checkpoint timestamp", async () => {
+  it("filters action log entries using tick-based scoping (not wall-clock)", async () => {
     loadCheckpoint.mockResolvedValueOnce({
       schemaVersion: 1,
       tick: 10,
@@ -131,19 +131,73 @@ describe("identitySlice initializeIdentity", () => {
     loadActionLog.mockResolvedValueOnce([
       {
         event: {
-          id: "event-old",
-          created_at: 1,
+          id: "event-at-checkpoint-tick",
+          created_at: 3, // wall-clock AFTER checkpoint, but tick == checkpoint
           author: { pubkey: "pubkey-1" },
         },
         action: { action: "TICK_UPDATE", payload: { tick: 10 } },
       },
       {
         event: {
-          id: "event-new",
-          created_at: 3,
+          id: "event-after-checkpoint-tick",
+          created_at: 2, // wall-clock AT checkpoint, but tick > checkpoint
           author: { pubkey: "pubkey-1" },
         },
-        action: { action: "TICK_UPDATE", payload: { tick: 11 } },
+        action: { action: "PURCHASE_AIRCRAFT", payload: { tick: 11 } },
+      },
+    ]);
+    replayActionLog.mockResolvedValueOnce({
+      airline: makeAirline(10),
+      fleet: [],
+      routes: [],
+      actionChainHash: "hash",
+    });
+
+    const { state } = createSliceState();
+
+    await state.initializeIdentity();
+
+    // tick:10 should be excluded (== checkpoint tick, not >)
+    // tick:11 should be included even though wall-clock (2) == checkpoint wall-clock (2)
+    expect(replayActionLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [
+          expect.objectContaining({
+            eventId: "event-after-checkpoint-tick",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("falls back to wall-clock filtering for actions without tick field", async () => {
+    loadCheckpoint.mockResolvedValueOnce({
+      schemaVersion: 1,
+      tick: 10,
+      createdAt: 2000,
+      actionChainHash: "hash",
+      stateHash: "state",
+      airline: makeAirline(10),
+      fleet: [],
+      routes: [],
+      timeline: [],
+    });
+    loadActionLog.mockResolvedValueOnce([
+      {
+        event: {
+          id: "event-no-tick-old",
+          created_at: 1, // before checkpoint (createdAt 2000 => 2 seconds)
+          author: { pubkey: "pubkey-1" },
+        },
+        action: { action: "LEGACY_ACTION", payload: {} },
+      },
+      {
+        event: {
+          id: "event-no-tick-new",
+          created_at: 3, // after checkpoint
+          author: { pubkey: "pubkey-1" },
+        },
+        action: { action: "LEGACY_ACTION", payload: {} },
       },
     ]);
     replayActionLog.mockResolvedValueOnce({
@@ -161,7 +215,7 @@ describe("identitySlice initializeIdentity", () => {
       expect.objectContaining({
         actions: [
           expect.objectContaining({
-            eventId: "event-new",
+            eventId: "event-no-tick-new",
           }),
         ],
       }),

--- a/packages/store/src/slices/identitySlice.ts
+++ b/packages/store/src/slices/identitySlice.ts
@@ -134,10 +134,14 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
 
       let scopedActions = actions;
       if (checkpoint) {
+        const checkpointTick = checkpoint.tick;
         const checkpointCreatedAtSeconds = Math.floor(checkpoint.createdAt / 1000);
-        scopedActions = actions.filter(
-          (entry) => (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds,
-        );
+        scopedActions = actions.filter((entry) => {
+          const actionTick = (entry.action.payload as Record<string, unknown>)?.tick;
+          return typeof actionTick === "number" && Number.isFinite(actionTick)
+            ? actionTick > checkpointTick
+            : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
+        });
         // If no actions are newer than the checkpoint, the checkpoint
         // state is authoritative — do NOT fall back to replaying all
         // actions, as that overwrites live flight state (status, flight,

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -230,10 +230,14 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           const checkpoint = checkpoints.get(authorPubkey) ?? null;
           let scopedEntries = entries;
           if (checkpoint) {
+            const checkpointTick = checkpoint.tick;
             const checkpointCreatedAtSeconds = Math.floor(checkpoint.createdAt / 1000);
-            scopedEntries = entries.filter(
-              (entry) => (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds,
-            );
+            scopedEntries = entries.filter((entry) => {
+              const actionTick = (entry.action.payload as Record<string, unknown>)?.tick;
+              return typeof actionTick === "number" && Number.isFinite(actionTick)
+                ? actionTick > checkpointTick
+                : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
+            });
             // No fallback: if no actions are newer than checkpoint, checkpoint
             // state is authoritative.  Replaying ALL actions would push lastTick
             // ahead of the checkpoint fleet state, causing the synchronized-
@@ -549,7 +553,11 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
     try {
       // Targeted fetch for this competitor plus global marketplace buys for replay filtering.
       const [actions, checkpoints, globalActions] = await Promise.all([
-        loadActionLog({ authors: [competitorPubkey], limit: 500, maxPages: 5 }),
+        loadActionLog({
+          authors: [competitorPubkey],
+          limit: 500,
+          maxPages: 20,
+        }),
         loadCheckpoints([competitorPubkey]),
         loadActionLog({ limit: 500, maxPages: 20 }),
       ]);
@@ -559,10 +567,14 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       const checkpoint = checkpoints.get(competitorPubkey) ?? null;
       let scopedEntries = actions;
       if (checkpoint) {
+        const checkpointTick = checkpoint.tick;
         const checkpointCreatedAtSeconds = Math.floor(checkpoint.createdAt / 1000);
-        scopedEntries = actions.filter(
-          (entry) => (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds,
-        );
+        scopedEntries = actions.filter((entry) => {
+          const actionTick = (entry.action.payload as Record<string, unknown>)?.tick;
+          return typeof actionTick === "number" && Number.isFinite(actionTick)
+            ? actionTick > checkpointTick
+            : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
+        });
       }
 
       const rejectedBuyEventIds = computeRejectedBuyEventIds(globalActions);


### PR DESCRIPTION
## Summary

Fixes 4 independent bugs that caused competitor fleet and balance to display incorrectly when viewing another player (e.g. seeing fleet=3 when actual=5).

## Changes

- **Fleet badge showed own fleet count when viewing competitor** — `fleet.lazy.tsx` read from `state.fleet.length` (always the player's own fleet) instead of `useActiveAirline().fleet.length` which switches data source based on `viewedPubkey`
- **Checkpoint fetch returned action events instead of checkpoints** — `loadCheckpoint`/`loadCheckpoints` in `schema.ts` queried `kind: 30078` without a `#d` tag filter; since action events share this kind, the relay's `limit` was consumed by actions before the checkpoint could arrive
- **Wall-clock action scoping dropped same-second events** — Post-checkpoint filtering in `identitySlice.ts` and `worldSlice.ts` (2 locations) used `created_at > checkpoint.createdAt`, dropping purchase events published in the same wall-clock second as the checkpoint. Switched to game-tick comparison (`actionTick > checkpointTick`) with wall-clock fallback for legacy actions without a tick field
- **Competitor pagination too low** — `syncCompetitor` used `maxPages: 5` vs `syncWorld`'s `maxPages: 20`, causing older purchase events to be missed for prolific players

## Tests

- Replaced coincidental wall-clock test with two explicit tick-based scoping tests (same wall-clock / different ticks, and wall-clock fallback for tick-less actions)
- Fixed fleet route test mock to include `useActiveAirline` export
- All 310 tests pass, build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for fleet and identity features with tick-based filtering logic.

* **Refactor**
  * Improved checkpoint filtering with enhanced event selection criteria.
  * Optimized data retrieval for replay operations with expanded data loading capacity.
  * Refactored fleet data access patterns for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->