### PR TITLE
fix(sync): rescue aircraft/route actions missing from stale checkpoints

### DIFF
--- a/packages/store/src/scopeActions.test.ts
+++ b/packages/store/src/scopeActions.test.ts
@@ -1,0 +1,352 @@
+import type { Checkpoint } from "@acars/core";
+import type { ActionLogEntry } from "@acars/nostr";
+import { describe, expect, it } from "vitest";
+import { scopeActionsToCheckpoint } from "./scopeActions";
+
+/**
+ * Helper to build a minimal ActionLogEntry for testing.
+ */
+function makeEntry(
+  action: string,
+  payload: Record<string, unknown>,
+  createdAt: number,
+  eventId = `evt-${Math.random().toString(36).slice(2, 8)}`,
+): ActionLogEntry {
+  return {
+    event: {
+      id: eventId,
+      created_at: createdAt,
+      author: { pubkey: "test-pubkey" },
+    } as unknown as ActionLogEntry["event"],
+    action: {
+      schemaVersion: 2,
+      action,
+      payload,
+    } as ActionLogEntry["action"],
+  };
+}
+
+/**
+ * Helper to build a minimal Checkpoint for testing.
+ */
+function makeCheckpoint(
+  tick: number,
+  createdAt: number,
+  fleetIds: string[],
+  routeIds: string[],
+): Checkpoint {
+  return {
+    schemaVersion: 1,
+    tick,
+    createdAt,
+    actionChainHash: "test-hash",
+    stateHash: "test-state-hash",
+    airline: {
+      ceoPubkey: "test-pubkey",
+      name: "Test Air",
+      iataCode: "TA",
+      hubs: ["JFK"],
+      corporateBalance: 1000000000000,
+      fleetIds,
+      routeIds,
+      brandScore: 0.5,
+      lastTick: tick,
+      status: "active",
+      genesisHash: "test-genesis",
+      shareCount: 10000000,
+      capTable: [],
+    } as unknown as Checkpoint["airline"],
+    fleet: fleetIds.map(
+      (id) =>
+        ({
+          id,
+          modelId: "b787-9",
+          status: "idle",
+        }) as unknown as Checkpoint["fleet"][0],
+    ),
+    routes: routeIds.map(
+      (id) =>
+        ({
+          id,
+          originIata: "JFK",
+          destinationIata: "LAX",
+          status: "active",
+        }) as unknown as Checkpoint["routes"][0],
+    ),
+    timeline: [],
+  };
+}
+
+describe("scopeActionsToCheckpoint", () => {
+  it("includes actions with tick > checkpoint tick", () => {
+    const checkpoint = makeCheckpoint(1000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("TICK_UPDATE", { tick: 1001 }, 100),
+      makeEntry("TICK_UPDATE", { tick: 999 }, 90),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0].action.payload).toMatchObject({ tick: 1001 });
+  });
+
+  it("filters out actions with tick <= checkpoint tick", () => {
+    const checkpoint = makeCheckpoint(1000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { tick: 1000 }, 90),
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { tick: 500 }, 80),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(0);
+  });
+
+  it("rescues AIRCRAFT_PURCHASE actions for aircraft missing from checkpoint fleet", () => {
+    // Checkpoint has ac-1, ac-2, ac-3 — but ac-4 and ac-5 were purchased
+    // before the checkpoint and are missing (corrupt checkpoint).
+    const checkpoint = makeCheckpoint(
+      10000,
+      Date.now(),
+      ["ac-1", "ac-2", "ac-3"],
+      ["rt-1", "rt-2"],
+    );
+    const actions = [
+      // These are BEFORE the checkpoint tick — normally filtered out
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-1", tick: 5000 }, 50),
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-4", tick: 8000 }, 80),
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-5", tick: 8100 }, 81),
+      // This is AFTER the checkpoint tick — always included
+      makeEntry("TICK_UPDATE", { tick: 10001 }, 100),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(3);
+    const instanceIds = scoped
+      .filter((e) => e.action.action === "AIRCRAFT_PURCHASE")
+      .map((e) => (e.action.payload as Record<string, unknown>).instanceId);
+    // ac-1 is already in the checkpoint — NOT rescued
+    expect(instanceIds).not.toContain("ac-1");
+    // ac-4 and ac-5 are missing from checkpoint — rescued
+    expect(instanceIds).toContain("ac-4");
+    expect(instanceIds).toContain("ac-5");
+  });
+
+  it("rescues ROUTE_OPEN actions for routes missing from checkpoint", () => {
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("ROUTE_OPEN", { routeId: "rt-1", tick: 5000 }, 50), // already in checkpoint
+      makeEntry("ROUTE_OPEN", { routeId: "rt-2", tick: 8000 }, 80), // missing
+      makeEntry("TICK_UPDATE", { tick: 10001 }, 100),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(2);
+    const routeIds = scoped
+      .filter((e) => e.action.action === "ROUTE_OPEN")
+      .map((e) => (e.action.payload as Record<string, unknown>).routeId);
+    expect(routeIds).not.toContain("rt-1");
+    expect(routeIds).toContain("rt-2");
+  });
+
+  it("does not rescue non-creative actions even if their tick is below checkpoint", () => {
+    // ROUTE_ASSIGN_AIRCRAFT for ac-1 is NOT rescued because ac-1 is already
+    // in the checkpoint fleet — only assignments referencing *rescued* (missing)
+    // aircraft are rescued.
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { routeId: "rt-1", aircraftId: "ac-1", tick: 8000 }, 80),
+      makeEntry("ROUTE_UPDATE_FARES", { routeId: "rt-1", tick: 9000 }, 90),
+      makeEntry("HUB_ADD", { iata: "LAX", tick: 7000 }, 70),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(0);
+  });
+
+  it("rescues ROUTE_ASSIGN_AIRCRAFT actions referencing rescued aircraft", () => {
+    // ac-2 was purchased before the checkpoint but is missing from it.
+    // The assignment of ac-2 to rt-1 should be rescued along with the purchase.
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-2", tick: 8000 }, 80),
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { routeId: "rt-1", aircraftId: "ac-2", tick: 8500 }, 85),
+      // ac-1 assignment should NOT be rescued — ac-1 is in checkpoint
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { routeId: "rt-1", aircraftId: "ac-1", tick: 8600 }, 86),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(2);
+    expect(scoped[0].action.action).toBe("AIRCRAFT_PURCHASE");
+    expect(scoped[1].action.action).toBe("ROUTE_ASSIGN_AIRCRAFT");
+    expect((scoped[1].action.payload as Record<string, unknown>).aircraftId).toBe("ac-2");
+  });
+
+  it("rescues ROUTE_UNASSIGN_AIRCRAFT actions referencing rescued aircraft", () => {
+    // ac-2 was purchased, assigned, then unassigned before the stale checkpoint.
+    // All three actions should be rescued to replay the correct state.
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-2", tick: 7000 }, 70),
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { routeId: "rt-1", aircraftId: "ac-2", tick: 7500 }, 75),
+      makeEntry("ROUTE_UNASSIGN_AIRCRAFT", { routeId: "rt-1", aircraftId: "ac-2", tick: 8000 }, 80),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(3);
+    const actionTypes = scoped.map((e) => e.action.action);
+    expect(actionTypes).toEqual([
+      "AIRCRAFT_PURCHASE",
+      "ROUTE_ASSIGN_AIRCRAFT",
+      "ROUTE_UNASSIGN_AIRCRAFT",
+    ]);
+  });
+
+  it("rescues ROUTE_ASSIGN_AIRCRAFT actions referencing a rescued route", () => {
+    // rt-2 was opened before the checkpoint but is missing from it.
+    // ac-1 IS in the checkpoint, but its assignment to rt-2 should still
+    // be rescued so the aircraft flies the rescued route.
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("ROUTE_OPEN", { routeId: "rt-2", tick: 7000 }, 70),
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { routeId: "rt-2", aircraftId: "ac-1", tick: 7500 }, 75),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(2);
+    expect(scoped[0].action.action).toBe("ROUTE_OPEN");
+    expect(scoped[1].action.action).toBe("ROUTE_ASSIGN_AIRCRAFT");
+    expect((scoped[1].action.payload as Record<string, unknown>).routeId).toBe("rt-2");
+    expect((scoped[1].action.payload as Record<string, unknown>).aircraftId).toBe("ac-1");
+  });
+
+  it("does not rescue AIRCRAFT_PURCHASE for aircraft that were sold before the checkpoint", () => {
+    // ac-2 was purchased then sold before the stale checkpoint.  It is
+    // correctly absent from the checkpoint fleet — we must NOT resurrect it.
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-2", tick: 7000 }, 70),
+      makeEntry("AIRCRAFT_SELL", { instanceId: "ac-2", tick: 8000 }, 80),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(0);
+  });
+
+  it("does not rescue ROUTE_OPEN for routes that were closed before the checkpoint", () => {
+    // rt-2 was opened then closed before the stale checkpoint.
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("ROUTE_OPEN", { routeId: "rt-2", tick: 7000 }, 70),
+      makeEntry("ROUTE_CLOSE", { routeId: "rt-2", tick: 8000 }, 80),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(0);
+  });
+
+  it("does not rescue assignments for sold aircraft", () => {
+    // ac-2 was purchased, assigned, then sold.  None of these actions
+    // should be rescued since the aircraft no longer exists.
+    const checkpoint = makeCheckpoint(10000, Date.now(), ["ac-1"], ["rt-1"]);
+    const actions = [
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-2", tick: 6000 }, 60),
+      makeEntry("ROUTE_ASSIGN_AIRCRAFT", { routeId: "rt-1", aircraftId: "ac-2", tick: 7000 }, 70),
+      makeEntry("AIRCRAFT_SELL", { instanceId: "ac-2", tick: 8000 }, 80),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(0);
+  });
+
+  it("uses created_at fallback when action has no tick", () => {
+    const checkpoint = makeCheckpoint(10000, 1772400000000, [], []);
+    const checkpointSec = Math.floor(1772400000000 / 1000); // 1772400000
+    const actions = [
+      makeEntry("AIRLINE_CREATE", {}, checkpointSec + 1), // after checkpoint
+      makeEntry("AIRLINE_CREATE", {}, checkpointSec - 1), // before checkpoint
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    expect(scoped).toHaveLength(1);
+    expect(scoped[0].event.created_at).toBe(checkpointSec + 1);
+  });
+
+  it("reproduces the ANZ scenario: stale checkpoint missing 2 of 5 aircraft", () => {
+    // Real-world scenario from the bug:
+    // Checkpoint at tick 10689848, fleet has only [ac-1, ac-2, ac-3]
+    // But there are 5 AIRCRAFT_PURCHASE events, 2 of which (ac-4, ac-5)
+    // have ticks below the checkpoint tick.
+    const checkpoint = makeCheckpoint(
+      10689848,
+      1772403146000,
+      ["ac-mm56reyx", "ac-mm5b4gwc", "ac-mm5qntmu"],
+      ["rt-mm56q5zw", "rt-mm5b7tqd", "rt-mm5qp2cm", "rt-mm5qtopt"],
+    );
+
+    const actions = [
+      makeEntry("AIRLINE_CREATE", { tick: 10601263 }, 1772137390),
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-mm56reyx", tick: 10626969 }, 1772214509),
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-mm5b4gwc", tick: 10629411 }, 1772221836),
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-mm5qntmu", tick: 10638111 }, 1772247933),
+      makeEntry("ROUTE_OPEN", { routeId: "rt-mm56q5zw", tick: 10626950 }, 1772214450),
+      makeEntry("ROUTE_OPEN", { routeId: "rt-mm5b7tqd", tick: 10629464 }, 1772221993),
+      makeEntry("ROUTE_OPEN", { routeId: "rt-mm5qp2cm", tick: 10638130 }, 1772247991),
+      makeEntry("ROUTE_OPEN", { routeId: "rt-mm5qtopt", tick: 10638202 }, 1772248207),
+      // THE TWO MISSING PURCHASES — ticks below checkpoint tick
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-mm853kwh", tick: 10686505 }, 1772393116),
+      makeEntry("AIRCRAFT_PURCHASE", { instanceId: "ac-mm857w9b", tick: 10686572 }, 1772393317),
+      makeEntry(
+        "ROUTE_ASSIGN_AIRCRAFT",
+        { routeId: "rt-mm5qtopt", aircraftId: "ac-mm857w9b", tick: 10686819 },
+        1772394059,
+      ),
+      // Post-checkpoint actions
+      makeEntry("TICK_UPDATE", { tick: 10690081 }, 1772403844),
+      makeEntry(
+        "ROUTE_ASSIGN_AIRCRAFT",
+        { routeId: "rt-mm56q5zw", aircraftId: "ac-mm853kwh", tick: 10690094 },
+        1772403883,
+      ),
+    ];
+
+    const scoped = scopeActionsToCheckpoint(actions, checkpoint);
+
+    // Should include: 2 rescued purchases + 1 rescued ROUTE_ASSIGN_AIRCRAFT
+    // (ac-mm857w9b → rt-mm5qtopt) + 2 post-checkpoint actions = 5
+    const purchaseIds = scoped
+      .filter((e) => e.action.action === "AIRCRAFT_PURCHASE")
+      .map((e) => (e.action.payload as Record<string, unknown>).instanceId);
+    expect(purchaseIds).toContain("ac-mm853kwh");
+    expect(purchaseIds).toContain("ac-mm857w9b");
+    // Should NOT include purchases already in checkpoint
+    expect(purchaseIds).not.toContain("ac-mm56reyx");
+    expect(purchaseIds).not.toContain("ac-mm5b4gwc");
+    expect(purchaseIds).not.toContain("ac-mm5qntmu");
+    // The ROUTE_ASSIGN_AIRCRAFT for rescued ac-mm857w9b should be rescued
+    const rescuedAssigns = scoped.filter(
+      (e) =>
+        e.action.action === "ROUTE_ASSIGN_AIRCRAFT" &&
+        (e.action.payload as Record<string, unknown>).aircraftId === "ac-mm857w9b",
+    );
+    expect(rescuedAssigns).toHaveLength(1);
+    expect((rescuedAssigns[0].action.payload as Record<string, unknown>).routeId).toBe(
+      "rt-mm5qtopt",
+    );
+    // Post-checkpoint actions should still be included
+    expect(scoped.some((e) => e.action.action === "TICK_UPDATE")).toBe(true);
+    // Total: 2 purchases + 1 rescued assign + 1 TICK_UPDATE + 1 post-checkpoint assign = 5
+    expect(scoped).toHaveLength(5);
+  });
+});

--- a/packages/store/src/scopeActions.ts
+++ b/packages/store/src/scopeActions.ts
@@ -1,0 +1,159 @@
+import type { Checkpoint } from "@acars/core";
+import type { ActionLogEntry } from "@acars/nostr";
+
+/**
+ * Scope an action log to only entries newer than a checkpoint, while
+ * defensively including any AIRCRAFT_PURCHASE or ROUTE_OPEN actions whose
+ * entities are missing from the checkpoint state — and any
+ * ROUTE_ASSIGN_AIRCRAFT / ROUTE_UNASSIGN_AIRCRAFT actions that reference
+ * those rescued entities.
+ *
+ * This prevents a self-reinforcing corrupt-checkpoint loop: if a checkpoint
+ * was saved with a stale fleet (e.g. after an app reload that itself loaded
+ * from an older stale checkpoint), purchase and route-creation actions whose
+ * ticks fall before the checkpoint tick would normally be filtered out,
+ * perpetuating the data loss.  By cross-referencing the action log against
+ * the checkpoint fleet/route IDs, we rescue those orphaned actions.
+ *
+ * The rescue is a two-pass process:
+ *   Pass 1 — Identify rescued aircraft IDs (purchases missing from
+ *            checkpoint fleet) and rescued route IDs (opens missing from
+ *            checkpoint routes).  Also detect AIRCRAFT_SELL / ROUTE_CLOSE
+ *            actions below the checkpoint tick and exclude those IDs —
+ *            they are correctly absent, not stale.
+ *   Pass 2 — Filter actions using the standard time-based rule, plus
+ *            rescue rules for purchases, route opens, and assignment/
+ *            unassignment actions that reference rescued aircraft.
+ */
+export function scopeActionsToCheckpoint(
+  actions: ActionLogEntry[],
+  checkpoint: Checkpoint,
+): ActionLogEntry[] {
+  const checkpointTick = checkpoint.tick;
+  const checkpointCreatedAtSeconds = Math.floor(checkpoint.createdAt / 1000);
+
+  // Build lookup sets of entity IDs present in the checkpoint.
+  const checkpointFleetIds = new Set(checkpoint.fleet.map((ac) => ac.id));
+  const checkpointRouteIds = new Set(checkpoint.routes.map((rt) => rt.id));
+
+  // --- Pass 1: identify rescued entity IDs ---
+  //
+  // We must also detect AIRCRAFT_SELL / ROUTE_CLOSE actions below the
+  // checkpoint tick.  If an aircraft was purchased then sold (or a route
+  // opened then closed) before the stale checkpoint, neither entity would
+  // appear in the checkpoint — but rescuing the purchase/open without the
+  // sell/close would resurrect a zombie entity.  We exclude sold/closed
+  // IDs from the rescue sets to prevent this.
+  const candidateAircraftIds = new Set<string>();
+  const candidateRouteIds = new Set<string>();
+  const soldBeforeCheckpointIds = new Set<string>();
+  const closedBeforeCheckpointIds = new Set<string>();
+
+  for (const entry of actions) {
+    const payload = entry.action.payload as Record<string, unknown>;
+    const actionTick = payload?.tick;
+
+    // Only consider actions at or below the checkpoint tick — actions
+    // newer than the checkpoint are always included and don't need rescue.
+    const isNewer =
+      typeof actionTick === "number" && Number.isFinite(actionTick)
+        ? actionTick > checkpointTick
+        : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
+
+    if (isNewer) continue;
+
+    if (entry.action.action === "AIRCRAFT_PURCHASE") {
+      const instanceId = payload?.instanceId;
+      if (typeof instanceId === "string" && !checkpointFleetIds.has(instanceId)) {
+        candidateAircraftIds.add(instanceId);
+      }
+    }
+
+    if (entry.action.action === "AIRCRAFT_SELL") {
+      const instanceId = payload?.instanceId;
+      if (typeof instanceId === "string") {
+        soldBeforeCheckpointIds.add(instanceId);
+      }
+    }
+
+    if (entry.action.action === "ROUTE_OPEN") {
+      const routeId = payload?.routeId;
+      if (typeof routeId === "string" && !checkpointRouteIds.has(routeId)) {
+        candidateRouteIds.add(routeId);
+      }
+    }
+
+    if (entry.action.action === "ROUTE_CLOSE") {
+      const routeId = payload?.routeId;
+      if (typeof routeId === "string") {
+        closedBeforeCheckpointIds.add(routeId);
+      }
+    }
+  }
+
+  // Final rescue sets: exclude aircraft that were sold and routes that
+  // were closed before the checkpoint — those are correctly absent.
+  const rescuedAircraftIds = new Set<string>();
+  for (const id of candidateAircraftIds) {
+    if (!soldBeforeCheckpointIds.has(id)) {
+      rescuedAircraftIds.add(id);
+    }
+  }
+  const rescuedRouteIds = new Set<string>();
+  for (const id of candidateRouteIds) {
+    if (!closedBeforeCheckpointIds.has(id)) {
+      rescuedRouteIds.add(id);
+    }
+  }
+
+  // --- Pass 2: filter with rescue rules ---
+  return actions.filter((entry) => {
+    const payload = entry.action.payload as Record<string, unknown>;
+    const actionTick = payload?.tick;
+
+    // Standard time-based filter: include actions newer than checkpoint.
+    const isNewer =
+      typeof actionTick === "number" && Number.isFinite(actionTick)
+        ? actionTick > checkpointTick
+        : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
+
+    if (isNewer) return true;
+
+    // Defensive rescue: include AIRCRAFT_PURCHASE actions for aircraft
+    // not present in the checkpoint fleet.
+    if (entry.action.action === "AIRCRAFT_PURCHASE") {
+      const instanceId = payload?.instanceId;
+      if (typeof instanceId === "string" && rescuedAircraftIds.has(instanceId)) {
+        return true;
+      }
+    }
+
+    // Rescue ROUTE_OPEN actions for routes missing from the checkpoint.
+    if (entry.action.action === "ROUTE_OPEN") {
+      const routeId = payload?.routeId;
+      if (typeof routeId === "string" && rescuedRouteIds.has(routeId)) {
+        return true;
+      }
+    }
+
+    // Rescue ROUTE_ASSIGN_AIRCRAFT / ROUTE_UNASSIGN_AIRCRAFT actions that
+    // reference a rescued aircraft OR a rescued route.  Without this,
+    // rescued entities appear as idle/unassigned instead of flying because
+    // the assignment action's tick is below the checkpoint tick.
+    if (
+      entry.action.action === "ROUTE_ASSIGN_AIRCRAFT" ||
+      entry.action.action === "ROUTE_UNASSIGN_AIRCRAFT"
+    ) {
+      const aircraftId = payload?.aircraftId;
+      const routeId = payload?.routeId;
+      if (
+        (typeof aircraftId === "string" && rescuedAircraftIds.has(aircraftId)) ||
+        (typeof routeId === "string" && rescuedRouteIds.has(routeId))
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+}

--- a/packages/store/src/slices/identitySlice.ts
+++ b/packages/store/src/slices/identitySlice.ts
@@ -22,6 +22,7 @@ import { replayActionLog } from "../actionReducer";
 import { useEngineStore } from "../engine";
 import { reconcileFleetToTick } from "../FlightEngine";
 import { computeRejectedBuyEventIds } from "../marketplaceReplay";
+import { scopeActionsToCheckpoint } from "../scopeActions";
 import type { AirlineState } from "../types";
 
 export interface IdentitySlice {
@@ -134,14 +135,7 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
 
       let scopedActions = actions;
       if (checkpoint) {
-        const checkpointTick = checkpoint.tick;
-        const checkpointCreatedAtSeconds = Math.floor(checkpoint.createdAt / 1000);
-        scopedActions = actions.filter((entry) => {
-          const actionTick = (entry.action.payload as Record<string, unknown>)?.tick;
-          return typeof actionTick === "number" && Number.isFinite(actionTick)
-            ? actionTick > checkpointTick
-            : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
-        });
+        scopedActions = scopeActionsToCheckpoint(actions, checkpoint);
         // If no actions are newer than the checkpoint, the checkpoint
         // state is authoritative — do NOT fall back to replaying all
         // actions, as that overwrites live flight state (status, flight,

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -341,6 +341,179 @@ describe("syncWorld", () => {
     expect(ids).toHaveLength(2);
   });
 
+  it("rescues aircraft purchases missing from a stale checkpoint", async () => {
+    const { loadActionLog, loadCheckpoints } = await import("@acars/nostr");
+    const pubkey = "comp-stale-checkpoint";
+
+    // Stale checkpoint: has only 3 aircraft, but 5 were actually purchased.
+    // Aircraft ac-4 and ac-5 were purchased BEFORE the checkpoint tick but
+    // are missing from the checkpoint fleet (corrupt checkpoint).
+    const staleCheckpoint = {
+      schemaVersion: 1,
+      tick: 10000,
+      createdAt: Date.now(),
+      actionChainHash: "hash",
+      stateHash: "state-hash",
+      airline: {
+        ceoPubkey: pubkey,
+        name: "Stale Air",
+        iataCode: "SA",
+        hubs: ["JFK"],
+        corporateBalance: 1000000000000,
+        fleetIds: ["ac-1", "ac-2", "ac-3"],
+        routeIds: [],
+        brandScore: 0.5,
+        lastTick: 10000,
+        status: "active",
+        genesisHash: "genesis",
+        shareCount: 10000000,
+        capTable: [],
+      },
+      fleet: [
+        {
+          id: "ac-1",
+          modelId: "atr72-600",
+          status: "idle",
+          ownerPubkey: pubkey,
+        },
+        {
+          id: "ac-2",
+          modelId: "atr72-600",
+          status: "idle",
+          ownerPubkey: pubkey,
+        },
+        {
+          id: "ac-3",
+          modelId: "atr72-600",
+          status: "idle",
+          ownerPubkey: pubkey,
+        },
+      ],
+      routes: [],
+      timeline: [],
+    };
+
+    (loadCheckpoints as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Map([[pubkey, staleCheckpoint]]),
+    );
+
+    // Action log includes all 5 purchases (ac-1..ac-5) plus a post-checkpoint TICK_UPDATE.
+    // ac-4 and ac-5 have ticks below the checkpoint tick (8000, 9000) — they should
+    // be rescued by the defensive scoping logic.
+    (loadActionLog as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        event: { id: "evt-create", author: { pubkey }, created_at: 1 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRLINE_CREATE",
+          payload: {
+            name: "Stale Air",
+            hubs: ["JFK"],
+            corporateBalance: 1000000000000,
+            tick: 100,
+          },
+        },
+      },
+      {
+        event: { id: "evt-p1", author: { pubkey }, created_at: 2 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-1",
+            modelId: "atr72-600",
+            price: 1000000,
+            deliveryHubIata: "JFK",
+            tick: 200,
+          },
+        },
+      },
+      {
+        event: { id: "evt-p2", author: { pubkey }, created_at: 3 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-2",
+            modelId: "atr72-600",
+            price: 1000000,
+            deliveryHubIata: "JFK",
+            tick: 300,
+          },
+        },
+      },
+      {
+        event: { id: "evt-p3", author: { pubkey }, created_at: 4 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-3",
+            modelId: "atr72-600",
+            price: 1000000,
+            deliveryHubIata: "JFK",
+            tick: 400,
+          },
+        },
+      },
+      // These two are missing from the checkpoint but have ticks below checkpoint tick
+      {
+        event: { id: "evt-p4", author: { pubkey }, created_at: 5 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-4",
+            modelId: "atr72-600",
+            price: 1000000,
+            deliveryHubIata: "JFK",
+            tick: 8000,
+          },
+        },
+      },
+      {
+        event: { id: "evt-p5", author: { pubkey }, created_at: 6 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-5",
+            modelId: "atr72-600",
+            price: 1000000,
+            deliveryHubIata: "JFK",
+            tick: 9000,
+          },
+        },
+      },
+      // Post-checkpoint action
+      {
+        event: { id: "evt-tick", author: { pubkey }, created_at: 7 },
+        action: {
+          schemaVersion: 2,
+          action: "TICK_UPDATE",
+          payload: { tick: 10001 },
+        },
+      },
+    ]);
+
+    const { state } = createSliceState({
+      competitors: new Map(),
+      fleetByOwner: buildFleetIndex([]),
+      routesByOwner: buildRoutesIndex([]),
+    });
+
+    await state.syncWorld();
+
+    // All 5 aircraft should be present: 3 from checkpoint + 2 rescued purchases
+    const ids = [...state.fleetByOwner.values()].flat().map((ac) => ac.id);
+    expect(ids).toContain("ac-1");
+    expect(ids).toContain("ac-2");
+    expect(ids).toContain("ac-3");
+    expect(ids).toContain("ac-4");
+    expect(ids).toContain("ac-5");
+    expect(ids).toHaveLength(5);
+  });
+
   it("projects competitor fleet to current tick during sync", async () => {
     const { loadActionLog } = await import("@acars/nostr");
     const pubkey = "comp-catchup";

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -23,6 +23,7 @@ import { replayActionLog } from "../actionReducer";
 import { useEngineStore } from "../engine";
 import { reconcileFleetToTick } from "../FlightEngine";
 import { computeRejectedBuyEventIds } from "../marketplaceReplay";
+import { scopeActionsToCheckpoint } from "../scopeActions";
 import type { AirlineState } from "../types";
 
 export interface WorldSlice {
@@ -216,14 +217,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           const checkpoint = checkpoints.get(authorPubkey) ?? null;
           let scopedEntries = entries;
           if (checkpoint) {
-            const checkpointTick = checkpoint.tick;
-            const checkpointCreatedAtSeconds = Math.floor(checkpoint.createdAt / 1000);
-            scopedEntries = entries.filter((entry) => {
-              const actionTick = (entry.action.payload as Record<string, unknown>)?.tick;
-              return typeof actionTick === "number" && Number.isFinite(actionTick)
-                ? actionTick > checkpointTick
-                : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
-            });
+            scopedEntries = scopeActionsToCheckpoint(entries, checkpoint);
             // No fallback: if no actions are newer than checkpoint, checkpoint
             // state is authoritative.  Replaying ALL actions would push lastTick
             // ahead of the checkpoint fleet state, causing the synchronized-
@@ -570,14 +564,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       const checkpoint = checkpoints.get(competitorPubkey) ?? null;
       let scopedEntries = actions;
       if (checkpoint) {
-        const checkpointTick = checkpoint.tick;
-        const checkpointCreatedAtSeconds = Math.floor(checkpoint.createdAt / 1000);
-        scopedEntries = actions.filter((entry) => {
-          const actionTick = (entry.action.payload as Record<string, unknown>)?.tick;
-          return typeof actionTick === "number" && Number.isFinite(actionTick)
-            ? actionTick > checkpointTick
-            : (entry.event.created_at ?? 0) > checkpointCreatedAtSeconds;
-        });
+        scopedEntries = scopeActionsToCheckpoint(actions, checkpoint);
       }
 
       const rejectedBuyEventIds = computeRejectedBuyEventIds(globalActions);


### PR DESCRIPTION
## Summary

- Extracts a shared `scopeActionsToCheckpoint()` helper that cross-references the action log against checkpoint fleet/route IDs
- Defensively rescues `AIRCRAFT_PURCHASE` and `ROUTE_OPEN` actions whose entity IDs are absent from the checkpoint, regardless of tick comparison
- Applied to all three scoping sites: identitySlice (player load), syncWorld (periodic competitor sync), and syncCompetitor (live competitor sync)
- Adds 8 tests covering the defensive rescue logic and the ANZ stale checkpoint scenario

## Root Cause

ANZ's checkpoint at tick 10689848 contained only 3 of 5 aircraft. The 2 missing `AIRCRAFT_PURCHASE` events (ticks 10686505 and 10686572) fell below the checkpoint tick and were filtered out by the scoping logic, causing PIX/AVA to see only 3 aircraft for ANZ.

This creates a self-reinforcing corrupt-checkpoint loop: once a checkpoint is stale, every subsequent checkpoint perpetuates the data loss because the purchase actions keep getting scoped out.

The defensive rescue logic fixes this by detecting when a checkpoint is missing aircraft/routes that exist in the action log and including those "orphan" actions in the replay regardless of tick comparison.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved state recovery during sync so missing purchases, route opens, and related assignments can be restored from the action log when a snapshot is stale.

* **Tests**
  * Added comprehensive tests covering rescue scenarios, timing fallbacks, sold/closed exclusions, and complex multi-action sequences.

* **Refactor**
  * Centralized action-scoping logic to simplify syncing and ensure consistent checkpoint handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->