### PR TITLE
Fix antimeridian viewport culling

### DIFF
--- a/packages/map/src/Globe.tsx
+++ b/packages/map/src/Globe.tsx
@@ -4,7 +4,13 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import type { AircraftInstance, Airport, HubTier, Route } from "@acars/core";
 import { getSubsolarPoint } from "@acars/core";
 import { aircraftModels, HUB_CLASSIFICATIONS } from "@acars/data";
-import { getBearing, getGreatCircleInterpolation, makeArcFeature } from "./geo.js";
+import {
+  getBearing,
+  getGreatCircleInterpolation,
+  makeArcFeature,
+  pointInViewport,
+  routeIntersectsViewport,
+} from "./geo.js";
 import { FAMILY_ICONS } from "./icons.js";
 
 const NIGHT_CANVAS_W = 1024;
@@ -168,75 +174,6 @@ function getSegmentCount(zoom: number): number {
   if (zoom < 6) return 24;
   if (zoom < 8) return 36;
   return 50;
-}
-
-// =============================================================================
-// --- Viewport Culling Helpers ---
-// =============================================================================
-
-/**
- * Fast bounding-box test: does a great circle route between two points
- * potentially intersect the given viewport bounds?
- *
- * We expand the route's bounding box by a generous margin to account for
- * the curvature of great circles (which can bulge significantly away from
- * the straight-line bounding box, especially on long routes).
- */
-function routeIntersectsViewport(
-  originLng: number,
-  originLat: number,
-  destLng: number,
-  destLat: number,
-  bounds: maplibregl.LngLatBounds,
-): boolean {
-  const sw = bounds.getSouthWest();
-  const ne = bounds.getNorthEast();
-
-  // If the route crosses the antimeridian (longitude difference > 180°),
-  // the simple AABB test produces an inverted bounding box that covers
-  // everything *except* the actual route. These are rare long-haul routes;
-  // always render them rather than attempting wrapped AABB math.
-  const lngDiff = Math.abs(originLng - destLng);
-  if (lngDiff > 180) return true;
-
-  // Calculate route bounding box
-  let minLng = Math.min(originLng, destLng);
-  let maxLng = Math.max(originLng, destLng);
-  let minLat = Math.min(originLat, destLat);
-  let maxLat = Math.max(originLat, destLat);
-
-  // Great circle curvature margin: longer routes bulge more.
-  // Use a rough heuristic based on lat/lng span.
-  const latSpan = maxLat - minLat;
-  const lngSpan = maxLng - minLng;
-  const margin = Math.max(latSpan, lngSpan) * 0.3 + 5; // min 5 degrees margin
-
-  minLng -= margin;
-  maxLng += margin;
-  minLat -= margin;
-  maxLat += margin;
-
-  // AABB overlap test
-  return !(maxLng < sw.lng || minLng > ne.lng || maxLat < sw.lat || minLat > ne.lat);
-}
-
-/**
- * Check if a single point is within viewport bounds (with margin).
- */
-function pointInViewport(
-  lng: number,
-  lat: number,
-  bounds: maplibregl.LngLatBounds,
-  margin: number = 5,
-): boolean {
-  const sw = bounds.getSouthWest();
-  const ne = bounds.getNorthEast();
-  return (
-    lng >= sw.lng - margin &&
-    lng <= ne.lng + margin &&
-    lat >= sw.lat - margin &&
-    lat <= ne.lat + margin
-  );
 }
 
 type AirportClass =

--- a/packages/map/src/geo.test.ts
+++ b/packages/map/src/geo.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { ViewportBounds } from "./geo.js";
 import {
   getBearing,
   getGreatCircleInterpolation,
   makeArcFeature,
+  pointInViewport,
+  routeIntersectsViewport,
   splitAntimeridian,
 } from "./geo.js";
 
@@ -204,5 +207,97 @@ describe("makeArcFeature", () => {
     expect(feature.geometry.type).toBe("MultiLineString");
     const coords = (feature.geometry as GeoJSON.MultiLineString).coordinates;
     expect(coords).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helper: create a mock ViewportBounds from sw/ne corners
+// ---------------------------------------------------------------------------
+function makeBounds(swLng: number, swLat: number, neLng: number, neLat: number): ViewportBounds {
+  return {
+    getSouthWest: () => ({ lng: swLng, lat: swLat }),
+    getNorthEast: () => ({ lng: neLng, lat: neLat }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pointInViewport — antimeridian tests
+// ---------------------------------------------------------------------------
+describe("pointInViewport", () => {
+  it("returns true for point clearly inside normal bounds", () => {
+    const bounds = makeBounds(10, -10, 30, 10);
+    expect(pointInViewport(20, 0, bounds)).toBe(true);
+  });
+
+  it("returns false for point clearly outside normal bounds", () => {
+    const bounds = makeBounds(10, -10, 30, 10);
+    expect(pointInViewport(100, 0, bounds)).toBe(false);
+  });
+
+  it("handles viewport crossing antimeridian eastward (ne.lng > 180)", () => {
+    // Viewport from 170°E to 190° (= 170°W unwrapped)
+    const bounds = makeBounds(170, -45, 190, -30);
+    // Aircraft at -178° (= 182° unwrapped) should be visible
+    expect(pointInViewport(-178, -37, bounds)).toBe(true);
+    // Aircraft at 175° should also be visible
+    expect(pointInViewport(175, -37, bounds)).toBe(true);
+    // Aircraft at 150° should NOT be visible
+    expect(pointInViewport(150, -37, bounds)).toBe(false);
+  });
+
+  it("handles viewport crossing antimeridian westward (sw.lng < -180)", () => {
+    // Viewport from -190° (= 170°E unwrapped) to -170°
+    const bounds = makeBounds(-190, -45, -170, -30);
+    // Aircraft at 178° (= -182° unwrapped) should be visible
+    expect(pointInViewport(178, -37, bounds)).toBe(true);
+    // Aircraft at -175° should also be visible
+    expect(pointInViewport(-175, -37, bounds)).toBe(true);
+    // Aircraft at -150° should NOT be visible
+    expect(pointInViewport(-150, -37, bounds)).toBe(false);
+  });
+
+  it("NZ scenario: both AKL→SYD and LAX→AKL aircraft visible when viewport covers them", () => {
+    // Wide viewport centered near NZ covering 155°E to 185° (= 175°W)
+    const bounds = makeBounds(155, -50, 185, -25);
+    // AKL→SYD aircraft at ~165°E
+    expect(pointInViewport(165, -38, bounds)).toBe(true);
+    // LAX→AKL aircraft at ~178°E
+    expect(pointInViewport(178, -36, bounds)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// routeIntersectsViewport — antimeridian tests
+// ---------------------------------------------------------------------------
+describe("routeIntersectsViewport", () => {
+  it("returns true for route inside normal bounds", () => {
+    const bounds = makeBounds(10, -10, 50, 10);
+    expect(routeIntersectsViewport(20, 0, 40, 5, bounds)).toBe(true);
+  });
+
+  it("returns false for route outside normal bounds", () => {
+    const bounds = makeBounds(10, -10, 30, 10);
+    expect(routeIntersectsViewport(80, 20, 100, 30, bounds)).toBe(false);
+  });
+
+  it("always returns true for antimeridian-crossing routes", () => {
+    const bounds = makeBounds(10, -10, 30, 10);
+    // LAX to AKL crosses antimeridian (lng diff > 180)
+    expect(routeIntersectsViewport(-118, 34, 175, -37, bounds)).toBe(true);
+  });
+
+  it("handles non-crossing route when VIEWPORT crosses antimeridian eastward", () => {
+    // Viewport from 165°E to 195° (= 165°W unwrapped)
+    const bounds = makeBounds(165, -50, 195, -25);
+    // AKL→SYD route (174.8° to 151.2°): does NOT cross antimeridian itself
+    // but its western end should overlap the viewport's western edge
+    expect(routeIntersectsViewport(174.8, -37, 151.2, -33.9, bounds)).toBe(true);
+  });
+
+  it("handles non-crossing route when VIEWPORT crosses antimeridian westward", () => {
+    // Viewport from -195° (= 165°E) to -165°
+    const bounds = makeBounds(-195, -50, -165, -25);
+    // AKL→SYD route: both endpoints positive, should still be visible
+    expect(routeIntersectsViewport(174.8, -37, 151.2, -33.9, bounds)).toBe(true);
   });
 });

--- a/packages/map/src/geo.ts
+++ b/packages/map/src/geo.ts
@@ -117,6 +117,103 @@ export function splitAntimeridian(points: [number, number][]): [number, number][
   return segments;
 }
 
+// =============================================================================
+// --- Viewport Culling Helpers ---
+// =============================================================================
+
+/** Minimal bounds interface satisfied by maplibregl.LngLatBounds. */
+export interface ViewportBounds {
+  getSouthWest(): { lng: number; lat: number };
+  getNorthEast(): { lng: number; lat: number };
+}
+
+/**
+ * Shift `lng` into the same winding as the viewport centre so that the
+ * simple min/max range check works even when MapLibre's `getBounds()`
+ * returns unwrapped longitudes past ±180° (antimeridian crossing).
+ */
+function normalizeLngToViewport(lng: number, swLng: number, neLng: number): number {
+  const center = (swLng + neLng) / 2;
+  const d = lng - center;
+  if (d > 180) return lng - 360;
+  if (d < -180) return lng + 360;
+  return lng;
+}
+
+/**
+ * Fast bounding-box test: does a great circle route between two points
+ * potentially intersect the given viewport bounds?
+ *
+ * We expand the route's bounding box by a generous margin to account for
+ * the curvature of great circles (which can bulge significantly away from
+ * the straight-line bounding box, especially on long routes).
+ */
+export function routeIntersectsViewport(
+  originLng: number,
+  originLat: number,
+  destLng: number,
+  destLat: number,
+  bounds: ViewportBounds,
+): boolean {
+  const sw = bounds.getSouthWest();
+  const ne = bounds.getNorthEast();
+
+  // If the route crosses the antimeridian (longitude difference > 180°),
+  // the simple AABB test produces an inverted bounding box that covers
+  // everything *except* the actual route. These are rare long-haul routes;
+  // always render them rather than attempting wrapped AABB math.
+  const lngDiff = Math.abs(originLng - destLng);
+  if (lngDiff > 180) return true;
+
+  // Normalize route endpoints to the viewport's coordinate space
+  originLng = normalizeLngToViewport(originLng, sw.lng, ne.lng);
+  destLng = normalizeLngToViewport(destLng, sw.lng, ne.lng);
+
+  // Calculate route bounding box
+  let minLng = Math.min(originLng, destLng);
+  let maxLng = Math.max(originLng, destLng);
+  const minLat = Math.min(originLat, destLat);
+  const maxLat = Math.max(originLat, destLat);
+
+  // Great circle curvature margin: longer routes bulge more.
+  const latSpan = maxLat - minLat;
+  const lngSpan = maxLng - minLng;
+  const margin = Math.max(latSpan, lngSpan) * 0.3 + 5;
+
+  minLng -= margin;
+  maxLng += margin;
+  const adjMinLat = minLat - margin;
+  const adjMaxLat = maxLat + margin;
+
+  // AABB overlap test
+  return !(maxLng < sw.lng || minLng > ne.lng || adjMaxLat < sw.lat || adjMinLat > ne.lat);
+}
+
+/**
+ * Check if a single point is within viewport bounds (with margin).
+ *
+ * Handles the antimeridian by normalising `lng` to the viewport's
+ * (possibly unwrapped) coordinate space before the range check.
+ */
+export function pointInViewport(
+  lng: number,
+  lat: number,
+  bounds: ViewportBounds,
+  margin: number = 5,
+): boolean {
+  const sw = bounds.getSouthWest();
+  const ne = bounds.getNorthEast();
+
+  lng = normalizeLngToViewport(lng, sw.lng, ne.lng);
+
+  return (
+    lng >= sw.lng - margin &&
+    lng <= ne.lng + margin &&
+    lat >= sw.lat - margin &&
+    lat <= ne.lat + margin
+  );
+}
+
 /**
  * Converts arc points into a GeoJSON Feature, automatically splitting at
  * the antimeridian if the route crosses it.

--- a/packages/map/src/geo.ts
+++ b/packages/map/src/geo.ts
@@ -134,10 +134,9 @@ export interface ViewportBounds {
  */
 function normalizeLngToViewport(lng: number, swLng: number, neLng: number): number {
   const center = (swLng + neLng) / 2;
-  const d = lng - center;
-  if (d > 180) return lng - 360;
-  if (d < -180) return lng + 360;
-  return lng;
+  const wraps = Math.round((lng - center) / 360);
+  return lng - wraps * 360;
+}
 }
 
 /**

--- a/packages/map/src/geo.ts
+++ b/packages/map/src/geo.ts
@@ -137,7 +137,6 @@ function normalizeLngToViewport(lng: number, swLng: number, neLng: number): numb
   const wraps = Math.round((lng - center) / 360);
   return lng - wraps * 360;
 }
-}
 
 /**
  * Fast bounding-box test: does a great circle route between two points


### PR DESCRIPTION
## Summary
- prevent aircraft and arc culling from misbehaving when the map viewport crosses the antimeridian by normalizing longitudes to the viewport coordinate space
- move the viewport culling helpers into geo.ts so they are reusable and add detailed tests for antimeridian viewports

## Testing
- pnpm vitest run packages/map/src/geo.test.ts
- pnpm --filter @acars/map run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Viewport culling and point-in-viewport logic consolidated into shared helpers for more consistent map rendering and improved handling of dateline/antimeridian crossings.

* **Tests**
  * Added comprehensive tests covering point-in-viewport and route-vs-viewport intersection scenarios, including antimeridian and global edge cases to ensure robust behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->