### PR TITLE
feat(map): add aircraft nav lights and visible strobe

### DIFF
--- a/apps/web/src/features/network/hooks/useRouteDemand.test.ts
+++ b/apps/web/src/features/network/hooks/useRouteDemand.test.ts
@@ -3,6 +3,13 @@ import { fp } from "@acars/core";
 import { describe, expect, it, vi } from "vitest";
 import { getRouteDemandSnapshot } from "./useRouteDemand";
 
+vi.mock("@acars/store", () => {
+  return {
+    useAirlineStore: vi.fn(),
+    useEngineStore: vi.fn(),
+  };
+});
+
 vi.mock("@acars/data", () => {
   return {
     airports: [

--- a/packages/map/src/Globe.tsx
+++ b/packages/map/src/Globe.tsx
@@ -11,7 +11,7 @@ import {
   pointInViewport,
   routeIntersectsViewport,
 } from "./geo.js";
-import { FAMILY_ICONS } from "./icons.js";
+import { FAMILY_ICONS, LIGHT_DOT_SVG, WING_TIP_OFFSETS } from "./icons.js";
 
 const NIGHT_CANVAS_W = 1024;
 const NIGHT_CANVAS_H = 512;
@@ -469,6 +469,9 @@ export function Globe({
       // Backward-compatible fallback alias
       addIcon("airplane-icon", FAMILY_ICONS["a320"].body);
       addIcon("airplane-icon-accent", FAMILY_ICONS["a320"].accent);
+
+      // Register navigation light icon (single SDF circle, positioned via icon-offset)
+      addIcon("light-dot", LIGHT_DOT_SVG);
 
       // --- Night canvas source (smooth solar gradient) ---
       const nightCanvas = document.createElement("canvas");
@@ -958,6 +961,131 @@ export function Globe({
         "flights-layer",
       );
 
+      // Navigation light layers (port/starboard/strobe for each flight source)
+      // Build per-family icon-offset match expressions from WING_TIP_OFFSETS
+      const portOffsetExpr = [
+        "match",
+        ["get", "familyId"],
+        ...Object.entries(WING_TIP_OFFSETS).flatMap(([fam, [px, py]]) => [
+          fam,
+          ["literal", [px, py]],
+        ]),
+        ["literal", [-20, 3]],
+      ] as unknown as maplibregl.ExpressionSpecification;
+      const stbdOffsetExpr = [
+        "match",
+        ["get", "familyId"],
+        ...Object.entries(WING_TIP_OFFSETS).flatMap(([fam, [px, py]]) => [
+          fam,
+          ["literal", [-px, py]],
+        ]),
+        ["literal", [20, 3]],
+      ] as unknown as maplibregl.ExpressionSpecification;
+      // Keep icon-size scaling identical to aircraft icons so wing-tip offsets
+      // remain aligned per family and wingspan across zoom levels.
+      const lightIconSizeExpr: maplibregl.ExpressionSpecification = [
+        "interpolate",
+        ["linear"],
+        ["zoom"],
+        2,
+        ["*", ["get", "sizeScale"], 0.15],
+        5,
+        ["*", ["get", "sizeScale"], 0.4],
+        8,
+        ["*", ["get", "sizeScale"], 0.7],
+        12,
+        ["*", ["get", "sizeScale"], 1.0],
+      ];
+      const addLightLayers = (sourceId: string, prefix: string, baseOpacity: number) => {
+        const sharedLayout: maplibregl.SymbolLayerSpecification["layout"] = {
+          "icon-image": "light-dot",
+          "icon-rotate": ["get", "bearing"],
+          "icon-rotation-alignment": "map",
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
+          "icon-anchor": "center",
+          "icon-size": lightIconSizeExpr,
+        };
+        // Port light (red, steady)
+        map.addLayer({
+          id: `${prefix}-light-port`,
+          type: "symbol",
+          source: sourceId,
+          minzoom: 4,
+          layout: {
+            ...sharedLayout,
+            "icon-offset": portOffsetExpr,
+          },
+          paint: {
+            "icon-color": "#ff0000",
+            "icon-opacity": ["interpolate", ["linear"], ["zoom"], 4, 0, 5, baseOpacity],
+            "icon-halo-color": "#ff0000",
+            "icon-halo-width": 0.4,
+            "icon-halo-blur": 0.2,
+          },
+        });
+        // Starboard light (blue, steady)
+        map.addLayer({
+          id: `${prefix}-light-stbd`,
+          type: "symbol",
+          source: sourceId,
+          minzoom: 4,
+          layout: {
+            ...sharedLayout,
+            "icon-offset": stbdOffsetExpr,
+          },
+          paint: {
+            "icon-color": "#4488ff",
+            "icon-opacity": ["interpolate", ["linear"], ["zoom"], 4, 0, 5, baseOpacity],
+            "icon-halo-color": "#4488ff",
+            "icon-halo-width": 0.4,
+            "icon-halo-blur": 0.2,
+          },
+        });
+        // Strobe light — offset symbol pulse so white flash is not hidden by fuselage.
+        const strobeIconSizeExpr: maplibregl.ExpressionSpecification = [
+          "interpolate",
+          ["linear"],
+          ["zoom"],
+          2,
+          ["*", ["get", "sizeScale"], 0.22],
+          5,
+          ["*", ["get", "sizeScale"], 0.55],
+          8,
+          ["*", ["get", "sizeScale"], 0.9],
+          12,
+          ["*", ["get", "sizeScale"], 1.25],
+        ];
+        map.addLayer({
+          id: `${prefix}-light-strobe`,
+          type: "symbol",
+          source: sourceId,
+          minzoom: 4,
+          layout: {
+            ...sharedLayout,
+            "icon-size": strobeIconSizeExpr,
+            "icon-offset": [0, 8],
+          },
+          paint: {
+            "icon-color": "#ffffff",
+            "icon-opacity": [
+              "*",
+              ["get", "strobeOn"],
+              ["interpolate", ["linear"], ["zoom"], 4, 0, 5, baseOpacity],
+            ],
+            "icon-halo-color": "#ffffff",
+            "icon-halo-width": [
+              "*",
+              ["get", "strobeOn"],
+              ["interpolate", ["linear"], ["zoom"], 4, 0.8, 5, 1.8],
+            ],
+            "icon-halo-blur": ["*", ["get", "strobeOn"], 0.8],
+          },
+        });
+      };
+      addLightLayers("global-flights", "global-flight", 0.6);
+      addLightLayers("flights", "flight", 0.9);
+
       // Airport click handler (uses ref to avoid stale closure)
       map.on("click", "airports-layer", (e) => {
         if (!e.features || e.features.length === 0) return;
@@ -1290,6 +1418,7 @@ export function Globe({
       bounds: maplibregl.LngLatBounds,
       resolveColor: (ac: AircraftInstance) => { primary?: string; secondary?: string } | undefined,
       baseSize: number,
+      now: number,
     ): GeoJSON.Feature[] => {
       const features: GeoJSON.Feature[] = [];
       for (const ac of targetFleet) {
@@ -1325,6 +1454,15 @@ export function Globe({
         const wingspanM = model?.wingspanM || 35.8;
         const colors = resolveColor(ac);
 
+        // Per-aircraft strobe phase uses ID + departure tick to avoid synchronization.
+        // 1.8s cycle with 500ms pulse keeps the flash clearly visible.
+        const idPhase =
+          ((ac.id.charCodeAt(0) || 0) * 31 +
+            (ac.id.charCodeAt(ac.id.length - 1) || 0) * 17 +
+            f.departureTick) %
+          1800;
+        const strobeOn = (now + idPhase) % 1800 < 500 ? 1 : 0;
+
         features.push({
           type: "Feature",
           geometry: { type: "Point", coordinates: coords },
@@ -1333,6 +1471,7 @@ export function Globe({
             bearing,
             familyId,
             sizeScale: (wingspanM / 35.8) * baseSize,
+            strobeOn,
             ...(colors?.primary ? { primaryColor: colors.primary } : {}),
             ...(colors?.secondary ? { secondaryColor: colors.secondary } : {}),
           },
@@ -1367,6 +1506,7 @@ export function Globe({
         bounds,
         () => latestPlayerLivery.current || undefined,
         1.1,
+        now,
       );
       const globalFlightFeatures = processFleet(
         latestGlobalFleet.current,
@@ -1375,6 +1515,7 @@ export function Globe({
         bounds,
         (ac) => latestCompetitorLiveries.current.get(ac.ownerPubkey),
         0.8,
+        now,
       );
 
       (map.getSource("flights") as maplibregl.GeoJSONSource)?.setData({

--- a/packages/map/src/Globe.tsx
+++ b/packages/map/src/Globe.tsx
@@ -1024,7 +1024,7 @@ export function Globe({
             "icon-halo-blur": 0.2,
           },
         });
-        // Starboard light (blue, steady)
+        // Starboard light (green, steady)
         map.addLayer({
           id: `${prefix}-light-stbd`,
           type: "symbol",
@@ -1035,9 +1035,9 @@ export function Globe({
             "icon-offset": stbdOffsetExpr,
           },
           paint: {
-            "icon-color": "#4488ff",
+            "icon-color": "#00ff00",
             "icon-opacity": ["interpolate", ["linear"], ["zoom"], 4, 0, 5, baseOpacity],
-            "icon-halo-color": "#4488ff",
+            "icon-halo-color": "#00ff00",
             "icon-halo-width": 0.4,
             "icon-halo-blur": 0.2,
           },

--- a/packages/map/src/Globe.tsx
+++ b/packages/map/src/Globe.tsx
@@ -1093,12 +1093,18 @@ export function Globe({
         latestOnAirportSelect.current(e.features[0].properties as unknown as Airport);
       });
 
-      // Aircraft click handlers (all 4 flight layers, uses ref to avoid stale closure)
+      // Aircraft click handlers (flight + light layers, uses ref to avoid stale closure)
       const flightLayers = [
         "flights-layer",
         "flights-accent-layer",
         "global-flights-layer",
         "global-flights-accent-layer",
+        "flight-light-port",
+        "flight-light-stbd",
+        "flight-light-strobe",
+        "global-flight-light-port",
+        "global-flight-light-stbd",
+        "global-flight-light-strobe",
       ];
       for (const layerId of flightLayers) {
         map.on("click", layerId, (e) => {

--- a/packages/map/src/icons.ts
+++ b/packages/map/src/icons.ts
@@ -79,6 +79,36 @@ export const FAMILY_ICONS: Record<string, { body: string; accent: string }> = {
 };
 
 // =============================================================================
+// Navigation light icon + per-family wing-tip offsets
+//
+// A single high-res SDF circle is used for all lights. Per-family icon-offset
+// match expressions position it at the correct wing tip. This avoids SDF
+// rasterization artifacts from tiny circles in huge viewBoxes.
+//
+// Offsets are in 48×48 icon-coordinate space (multiplied by icon-size at
+// runtime). Computed from SVG viewBox geometry: each family's wing-tip
+// position is projected into the rendered 48×48 space, then offset from center.
+// =============================================================================
+
+export const LIGHT_DOT_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="white"><circle cx="6" cy="6" r="1.5"/></svg>`;
+
+// Port wing-tip offsets [x, y] in 48px icon space (starboard = negate x)
+export const WING_TIP_OFFSETS: Record<string, [number, number]> = {
+  atr: [-18.8, -4.2],
+  dash8: [-17.7, -1.9],
+  a220: [-22.6, 2.8],
+  ejet: [-22.6, 2.8],
+  a320: [-20.8, 3.4],
+  b737: [-18.4, 3.5],
+  a330: [-22.3, 2.6],
+  b787: [-18.5, 7.6],
+  b777: [-18.5, 7.6],
+  a350: [-21.7, 6.3],
+  a380: [-18.2, 5.2],
+  b747: [-20.3, 7.5],
+};
+
+// =============================================================================
 // Backward-compatible aliases (old type-based exports)
 // These map to a representative family for each aircraft type category.
 // =============================================================================


### PR DESCRIPTION
## Summary\n- add navigation light rendering for enroute aircraft (port/starboard + strobe)\n- position nav lights by aircraft family wing-tip offsets and wingspan-scaled icon size\n- add per-aircraft desynced strobe pulse and render it as an offset symbol for visibility\n- tune nav light dot size to subtle pixel-scale lights\n\n## Validation\n- pnpm --filter @acars/map build\n- pnpm --filter @acars/map test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Aircraft in the map view now display navigation lights, including port, starboard, and animated strobe lights with proper positioning based on aircraft type and synchronized timing across the display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->