### PR TITLE
fix(store): harden realtime resubscribe and tick lock diagnostics

### DIFF
--- a/packages/store/src/airline.test.ts
+++ b/packages/store/src/airline.test.ts
@@ -28,7 +28,10 @@ describe("airline store", () => {
 describe("airline store – event buffering during initial sync", () => {
   // Captured handles set during beforeEach, available in each test.
   let capturedOnEvent:
-    | ((entry: { event: { author: { pubkey: string } }; action: { action: string } }) => void)
+    | ((entry: {
+        event: { author: { pubkey: string }; created_at?: number };
+        action: { action: string };
+      }) => void)
     | null;
   let resolveSyncWorld: (() => void) | null;
   let syncCompetitorSpy: ReturnType<typeof vi.fn>;
@@ -64,7 +67,7 @@ describe("airline store – event buffering during initial sync", () => {
           onEvent,
         }: {
           onEvent: (e: {
-            event: { author: { pubkey: string } };
+            event: { author: { pubkey: string }; created_at?: number };
             action: { action: string };
           }) => void;
           onClose: () => void;
@@ -205,5 +208,118 @@ describe("airline store – event buffering during initial sync", () => {
 
     // competitor-ddd is genuinely new → must be synced exactly once.
     expect(syncedPubkeys.filter((pk) => pk === "competitor-ddd")).toHaveLength(1);
+  });
+});
+
+describe("airline store – reconnect resubscribe watermark", () => {
+  let capturedOnEvent:
+    | ((entry: {
+        event: { author: { pubkey: string }; created_at?: number };
+        action: { action: string };
+      }) => void)
+    | null;
+  let capturedOnClose: (() => void) | null;
+  let subscribeSinceCalls: number[];
+  let resolveSyncWorld: (() => void) | null;
+  let connectedRelayCountMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date("2024-01-01T00:00:00.000Z"));
+
+    capturedOnEvent = null;
+    capturedOnClose = null;
+    subscribeSinceCalls = [];
+    resolveSyncWorld = null;
+    connectedRelayCountMock = vi.fn().mockReturnValue(1);
+
+    const syncWorldDeferred = new Promise<void>((resolve) => {
+      resolveSyncWorld = resolve;
+    });
+
+    vi.doMock("./engine.js", () => ({
+      useEngineStore: {
+        subscribe: vi.fn(),
+        getState: vi.fn(() => ({ tick: 0 })),
+        setState: vi.fn(),
+      },
+    }));
+
+    vi.doMock("@acars/nostr", () => ({
+      ensureConnected: vi.fn().mockResolvedValue(undefined),
+      connectedRelayCount: connectedRelayCountMock,
+      reconnectIfNeeded: vi.fn().mockResolvedValue(false),
+      subscribeActions: vi.fn(
+        async ({
+          since,
+          onEvent,
+          onClose,
+        }: {
+          since: number;
+          onEvent: (e: {
+            event: { author: { pubkey: string }; created_at?: number };
+            action: { action: string };
+          }) => void;
+          onClose: () => void;
+        }) => {
+          subscribeSinceCalls.push(since);
+          capturedOnEvent = onEvent;
+          capturedOnClose = onClose;
+          return () => {};
+        },
+      ),
+    }));
+
+    vi.doMock("./slices/worldSlice.js", () => ({
+      _resetWorldFlags: vi.fn(),
+      createWorldSlice: (set: (partial: Record<string, unknown>) => void) => ({
+        competitors: new Map<string, unknown>(),
+        globalRouteRegistry: new Map<string, unknown[]>(),
+        fleetByOwner: new Map<string, unknown[]>(),
+        routesByOwner: new Map<string, unknown[]>(),
+        viewAs: vi.fn(),
+        syncWorld: vi.fn(async () => {
+          await syncWorldDeferred;
+          set({ competitors: new Map([["initial-competitor", {}]]) });
+        }),
+        syncCompetitor: vi.fn(),
+        projectCompetitorFleet: vi.fn(),
+      }),
+    }));
+
+    await import("./airline.js");
+    await vi.waitFor(() => expect(capturedOnEvent).not.toBeNull(), { timeout: 2000 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("re-subscribes from last-seen watermark after unexpected close", async () => {
+    // Initial sync completes so reconnect path behaves like runtime steady-state.
+    resolveSyncWorld!();
+    await vi.waitFor(() => expect(subscribeSinceCalls.length).toBeGreaterThan(0), {
+      timeout: 2000,
+    });
+
+    // Advance wall clock and feed a live event with created_at at this second.
+    vi.setSystemTime(new Date("2024-01-01T00:00:10.000Z"));
+    capturedOnEvent!({
+      event: { author: { pubkey: "competitor-z" }, created_at: 1704067210 },
+      action: { action: "ROUTE_OPEN" },
+    });
+
+    // Simulate relay close and run delayed re-subscribe timer.
+    capturedOnClose!();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    await vi.waitFor(() => expect(subscribeSinceCalls.length).toBeGreaterThan(1), {
+      timeout: 2000,
+    });
+
+    // Last seen event at :10 with a 5-second overlap window => since should be :05.
+    expect(subscribeSinceCalls.at(-1)).toBe(1704067205);
   });
 });

--- a/packages/store/src/airline.ts
+++ b/packages/store/src/airline.ts
@@ -244,7 +244,6 @@ async function startActionSubscription(since: number): Promise<void> {
     unsubscribeActionStream = null;
   }
 
-  lastSeenActionCreatedAtSec = Math.max(lastSeenActionCreatedAtSec, since);
   logger.info(`Starting live action subscription (since=${since})`);
 
   unsubscribeActionStream = await subscribeActions({

--- a/packages/store/src/airline.ts
+++ b/packages/store/src/airline.ts
@@ -121,6 +121,8 @@ const enableRealtimeSyncLogs = runtimeEnv !== "production";
 const LIVE_SYNC_BATCH_MS = 1000;
 let pendingCompetitorSyncs = new Set<string>();
 let batchFlushTimer: ReturnType<typeof setTimeout> | null = null;
+const RESUBSCRIBE_REPLAY_WINDOW_SEC = 5;
+let lastSeenActionCreatedAtSec = 0;
 
 // Buffer for live events that arrive before the initial sync completes.
 // Flushed (with deduplication) once initialSyncComplete is set to true.
@@ -129,6 +131,20 @@ const eventBuffer: string[] = [];
 /** @internal — test-only accessor for the pre-sync event buffer */
 export function _getEventBuffer(): string[] {
   return [...eventBuffer];
+}
+
+function updateLastSeenAction(createdAt: number | undefined) {
+  if (typeof createdAt !== "number" || !Number.isFinite(createdAt) || createdAt <= 0) return;
+  // Clamp to local now to avoid future-skewed timestamps widening the gap window.
+  const nowSec = Math.floor(Date.now() / 1000);
+  const normalized = Math.min(Math.floor(createdAt), nowSec);
+  lastSeenActionCreatedAtSec = Math.max(lastSeenActionCreatedAtSec, normalized);
+}
+
+function getResubscribeSince(): number {
+  const nowSec = Math.floor(Date.now() / 1000);
+  const anchor = lastSeenActionCreatedAtSec > 0 ? lastSeenActionCreatedAtSec : nowSec;
+  return Math.max(0, anchor - RESUBSCRIBE_REPLAY_WINDOW_SEC);
 }
 
 function flushPendingCompetitorSyncs() {
@@ -184,8 +200,7 @@ useEngineStore.subscribe((state) => {
       void (async () => {
         const recovered = await reconnectIfNeeded();
         if (recovered && !unsubscribeActionStream) {
-          const freshSince = Math.floor(Date.now() / 1000);
-          await startActionSubscription(freshSince);
+          await startActionSubscription(getResubscribeSince());
           void store.syncWorld({ force: true });
           logger.info("Relay health check: recovered — re-subscribed and resynced.");
         }
@@ -229,11 +244,13 @@ async function startActionSubscription(since: number): Promise<void> {
     unsubscribeActionStream = null;
   }
 
+  lastSeenActionCreatedAtSec = Math.max(lastSeenActionCreatedAtSec, since);
   logger.info(`Starting live action subscription (since=${since})`);
 
   unsubscribeActionStream = await subscribeActions({
     since,
     onEvent: (entry) => {
+      updateLastSeenAction(entry.event.created_at);
       const { pubkey } = useAirlineStore.getState();
       // Skip our own events — we already applied them locally.
       if (pubkey && entry.event.author.pubkey === pubkey) return;
@@ -264,8 +281,7 @@ async function startActionSubscription(since: number): Promise<void> {
       setTimeout(async () => {
         try {
           await ensureConnected();
-          const freshSince = Math.floor(Date.now() / 1000);
-          await startActionSubscription(freshSince);
+          await startActionSubscription(getResubscribeSince());
           // Only trigger a full resync if we've completed the initial sync;
           // otherwise the IIFE retry loop will handle it.
           if (initialSyncComplete) {
@@ -337,8 +353,7 @@ if (typeof document !== "undefined") {
         // active subscription.  Checking connectedRelayCount avoids
         // needlessly tearing down a healthy subscription.
         if (!unsubscribeActionStream || connectedRelayCount() === 0) {
-          const freshSince = Math.floor(Date.now() / 1000);
-          await startActionSubscription(freshSince);
+          await startActionSubscription(getResubscribeSince());
           logger.info("Re-subscribed after tab visibility change.");
         }
       } catch {

--- a/packages/store/src/slices/engineSlice.test.ts
+++ b/packages/store/src/slices/engineSlice.test.ts
@@ -2,13 +2,18 @@ import type { AircraftInstance, AirlineEntity, FixedPoint, Route } from "@acars/
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateCreator } from "zustand";
 import type { AirlineState } from "../types";
-import { createEngineSlice } from "./engineSlice";
+import {
+  _getTickLockSkippedCount,
+  _resetTickLockDiagnostics,
+  createEngineSlice,
+} from "./engineSlice";
 
 // Reset mock call counts (but not implementations) before each test so that
 // accumulated calls from one test suite do not pollute assertions in others
 // (e.g. the fast-path test that asserts processFlightEngine was never called).
 beforeEach(() => {
   vi.clearAllMocks();
+  _resetTickLockDiagnostics();
 });
 
 vi.mock("../FlightEngine", () => ({
@@ -399,5 +404,36 @@ describe("engineSlice fast-path", () => {
 
     // Fast-path should clear the stale deletion IDs
     expect(state.fleetDeletedDuringCatchup).toEqual([]);
+  });
+});
+
+describe("engineSlice lock diagnostics", () => {
+  it("increments skipped-lock counter when overlapping processTick calls contend", async () => {
+    const airline = makeAirline(0);
+    const fleet = [makeAircraft("ac-1")];
+    const routes: Route[] = [makeRoute("rt-1", 400)];
+    const { state } = createSliceState({ airline, fleet, routes });
+
+    const { processFlightEngine } = await import("../FlightEngine");
+    vi.mocked(processFlightEngine).mockImplementation(
+      (_tick, currentFleet, _routes, corporateBalance) => ({
+        updatedFleet: currentFleet,
+        corporateBalance,
+        events: [],
+        hasChanges: false,
+      }),
+    );
+
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    try {
+      const first = state.processTick(2001);
+      const second = state.processTick(2002);
+      await Promise.all([first, second]);
+
+      expect(_getTickLockSkippedCount()).toBeGreaterThan(0);
+      expect(debugSpy).toHaveBeenCalled();
+    } finally {
+      debugSpy.mockRestore();
+    }
   });
 });

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -25,10 +25,36 @@ export interface EngineSlice {
 
 const tickMutex = new AsyncMutex();
 const CHECKPOINT_INTERVAL = 1200;
+let skippedTickLockCount = 0;
+const TICK_LOCK_LOG_BURST = 3;
+const TICK_LOCK_LOG_SAMPLE = 100;
+
+/** @internal — test/diagnostic helper */
+export function _getTickLockSkippedCount(): number {
+  return skippedTickLockCount;
+}
+
+/** @internal — test/diagnostic helper */
+export function _resetTickLockDiagnostics(): void {
+  skippedTickLockCount = 0;
+  tickMutex.reset();
+}
 
 export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> = (set, get) => ({
   processTick: async (tick: number) => {
-    if (!tickMutex.tryLock()) return;
+    if (!tickMutex.tryLock()) {
+      skippedTickLockCount += 1;
+      if (
+        skippedTickLockCount <= TICK_LOCK_LOG_BURST ||
+        skippedTickLockCount % TICK_LOCK_LOG_SAMPLE === 0
+      ) {
+        console.debug("[EngineSlice] Tick lock contention; skipping overlapping processTick", {
+          tick,
+          skippedTickLockCount,
+        });
+      }
+      return;
+    }
 
     try {
       const { fleet, airline, routes } = get();


### PR DESCRIPTION
## Summary
- track a last-seen action timestamp watermark and reuse it for reconnect/visibility/relay-health re-subscribe windows with a small overlap
- add lock-contention diagnostics in engine tick processing for overlapping processTick calls
- add regression tests for watermark-based re-subscribe and tick-lock contention diagnostics

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test:run
- pnpm --filter @acars/store test:run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage validating reconnection and timestamp-based resubscription (watermark) behavior.
  * Added diagnostics tests that simulate overlapping processing to verify skip-counting and debug logging.

* **Chores**
  * Improved reconnection/resubscribe logic to base replays on last-seen action timestamps.
  * Exposed internal diagnostics utilities to reset and inspect tick-processing diagnostics for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->