### PR TITLE
fix: keep bankruptcy views consistent across accounts

### DIFF
--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -221,6 +221,34 @@ describe("projectCompetitorFleet", () => {
     // No changes should have been made since the only competitor is ahead
     expect(set).not.toHaveBeenCalled();
   });
+
+  it("does not project bankrupt competitors", () => {
+    const tick = 200;
+    const pubkey = "comp-bankrupt";
+    const airline = { ...makeAirline(pubkey, tick - 50), status: "chapter11" as const };
+    const aircraft: AircraftInstance = {
+      ...makeAircraft("ac-bankrupt", pubkey),
+      status: "enroute",
+      assignedRouteId: "rt-1",
+      flight: {
+        originIata: "JFK",
+        destinationIata: "LAX",
+        departureTick: 100,
+        arrivalTick: 150,
+      },
+    };
+
+    const { state, set } = createSliceState({
+      competitors: new Map([[pubkey, airline]]),
+      fleetByOwner: buildFleetIndex([aircraft]),
+      routesByOwner: buildRoutesIndex([]),
+    });
+
+    state.projectCompetitorFleet(tick);
+
+    expect(set).not.toHaveBeenCalled();
+    expect(state.fleetByOwner.get(pubkey)?.[0].id).toBe("ac-bankrupt");
+  });
 });
 
 describe("syncWorld", () => {

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -148,6 +148,11 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       const compFleet = fleetByOwner.get(pubkey) || [];
       const compRoutes = routesByOwner.get(pubkey) || [];
 
+      // Match player semantics: bankrupt/liquidated airlines do not advance.
+      if (airline.status === "chapter11" || airline.status === "liquidated") {
+        continue;
+      }
+
       if (compFleet.length === 0) {
         continue;
       }
@@ -272,7 +277,12 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           // Without this, checkpoint fleet has stale arrivalTick/turnaroundEndTick
           // values while lastTick was pushed ahead by TICK_UPDATE actions, causing
           // all competitor aircraft to land and depart simultaneously on load.
-          if (airline.lastTick != null && resolvedFleet.length > 0) {
+          if (
+            airline.status !== "chapter11" &&
+            airline.status !== "liquidated" &&
+            airline.lastTick != null &&
+            resolvedFleet.length > 0
+          ) {
             const { fleet: reconciledFleet, balanceDelta } = reconcileFleetToTick(
               resolvedFleet,
               finalRoutes,
@@ -417,6 +427,13 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           for (const [competitorPubkey, airline] of competitors) {
             const compFleet = allFleetByOwner.get(competitorPubkey) || [];
             const compRoutes = allRoutesByOwner.get(competitorPubkey) || [];
+
+            // Match player semantics: bankrupt/liquidated airlines do not advance.
+            if (airline.status === "chapter11" || airline.status === "liquidated") {
+              updatedFleetByOwner.set(competitorPubkey, compFleet);
+              updatedRoutesByOwner.set(competitorPubkey, compRoutes);
+              continue;
+            }
 
             // Apply monthly costs even for competitors with zero aircraft.
             // They may have hub opex that needs to be charged.
@@ -587,7 +604,12 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       const resolvedRoutes = replayed.routes;
 
       // Reconcile fleet positions to lastTick
-      if (airline.lastTick != null && resolvedFleet.length > 0) {
+      if (
+        airline.status !== "chapter11" &&
+        airline.status !== "liquidated" &&
+        airline.lastTick != null &&
+        resolvedFleet.length > 0
+      ) {
         const { fleet: reconciledFleet, balanceDelta } = reconcileFleetToTick(
           resolvedFleet,
           resolvedRoutes,
@@ -600,7 +622,12 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       // Project fleet forward to the current tick so the stored state is
       // up-to-date.  This replaces the old processGlobalTick catch-up.
       const currentTick = useEngineStore.getState().tick;
-      if (currentTick > 0 && (airline.lastTick == null || currentTick > airline.lastTick)) {
+      if (
+        airline.status !== "chapter11" &&
+        airline.status !== "liquidated" &&
+        currentTick > 0 &&
+        (airline.lastTick == null || currentTick > airline.lastTick)
+      ) {
         const { fleet: projectedFleet, balanceDelta } = reconcileFleetToTick(
           resolvedFleet,
           resolvedRoutes,


### PR DESCRIPTION
## Summary
- make competitor projection bankruptcy-aware in world slice
- skip reconcile/project for chapter11 and liquidated airlines to match owner semantics
- add regression test that bankrupt competitors are not projected

## Why
Relay data for ANZ shows latest `TICK_UPDATE` with `status: chapter11`.
Owner view correctly stops advancing in chapter11, but competitor projection previously kept advancing, causing cross-account drift.

## Validation
- `npx vitest run packages/store/src/slices/worldSlice.test.ts`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where bankrupt and liquidated airlines continued to progress in the simulation. These airlines now remain frozen with their aircraft and routes unchanged following bankruptcy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->