### PR TITLE
fix(store): preserve route stagger across reload

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -158,6 +158,7 @@ export interface AircraftInstance {
   deliveryAtTick?: number; // When it arrives at truth
   listingPrice?: FixedPoint | null; // If set, the aircraft is listed on the used marketplace
   routeAssignedAtTick?: number; // When this aircraft was assigned to its current route (cycle anchor)
+  routeAssignedAtIata?: string; // Which airport the aircraft was at when assigned (for cycle direction)
 
   // Flight state
   flight: FlightState | null;

--- a/packages/store/src/FlightEngine.test.ts
+++ b/packages/store/src/FlightEngine.test.ts
@@ -49,6 +49,8 @@ const makeAircraft = (overrides: Partial<AircraftInstance> = {}): AircraftInstan
     flightHoursTotal: overrides.flightHoursTotal ?? 0,
     flightHoursSinceCheck: overrides.flightHoursSinceCheck ?? 0,
     condition: overrides.condition ?? 1.0,
+    routeAssignedAtTick: overrides.routeAssignedAtTick,
+    routeAssignedAtIata: overrides.routeAssignedAtIata,
   };
 };
 
@@ -1279,5 +1281,164 @@ describe("reconcileFleetToTick — delivery aircraft", () => {
     // targetTick == cycleStartTick, code does `if (targetTick <= cycleStartTick) return idle`
     const { fleet: result } = reconcileFleetToTick([aircraft], [route], 5000);
     expect(result[0].status).toBe("idle");
+  });
+});
+
+describe("reconcileFleetToTick — destination-aware stagger", () => {
+  it("idle aircraft at destination gets inbound-start cycle via routeAssignedAtIata", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-stag1",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-origin", "ac-dest"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    // Aircraft A at origin (JFK) — standard outbound-first cycle
+    const acOrigin = makeAircraft({
+      id: "ac-origin",
+      assignedRouteId: "route-stag1",
+      status: "idle",
+      baseAirportIata: "JFK",
+      flight: null,
+      routeAssignedAtTick: 1000,
+      routeAssignedAtIata: "JFK",
+    });
+
+    // Aircraft B at destination (LAX) — should start with inbound leg
+    const acDest = makeAircraft({
+      id: "ac-dest",
+      assignedRouteId: "route-stag1",
+      status: "idle",
+      baseAirportIata: "LAX",
+      flight: null,
+      routeAssignedAtTick: 1000,
+      routeAssignedAtIata: "LAX",
+    });
+
+    // At any target tick, the two aircraft should be ~halfTrip apart in the cycle
+    const targetTick = 1000 + roundTrip * 7 + 1;
+    const { fleet: result } = reconcileFleetToTick([acOrigin, acDest], [route], targetTick);
+
+    // Verify they ended up at different phases (roughly half a round trip apart)
+    expect(result[0].status).not.toBe("idle");
+    expect(result[1].status).not.toBe("idle");
+
+    // The flight directions should differ — one outbound, one inbound (or similar offset)
+    expect(result[0].flight?.direction).not.toBe(result[1].flight?.direction);
+  });
+
+  it("stale enroute state is overridden when routeAssignedAtTick > departureTick", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-stag2",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-stale"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    // Aircraft has stale enroute flight state from tick 500, but was reassigned at tick 2000
+    const aircraft = makeAircraft({
+      id: "ac-stale",
+      assignedRouteId: "route-stag2",
+      status: "enroute",
+      baseAirportIata: "LAX",
+      routeAssignedAtTick: 2000,
+      routeAssignedAtIata: "LAX",
+      flight: {
+        originIata: "JFK",
+        destinationIata: "LAX",
+        departureTick: 500,
+        arrivalTick: 500 + durationTicks,
+        direction: "outbound",
+      },
+    });
+
+    const targetTick = 2000 + roundTrip * 3 + 1;
+    const { fleet: result } = reconcileFleetToTick([aircraft], [route], targetTick);
+
+    // Should NOT use the stale departureTick=500, should use routeAssignedAtTick=2000
+    // With routeAssignedAtIata=LAX (destination), the phase offset puts it
+    // at the inbound-start position, not the outbound-start position.
+    expect(result[0].status).not.toBe("idle");
+    expect(result[0].flight).not.toBeNull();
+
+    // Verify: compute expected position from routeAssignedAtTick with destination offset
+    const elapsed = targetTick - 2000;
+    const halfTrip = durationTicks + turnaroundTicks;
+    const rawPos = ((elapsed % roundTrip) + roundTrip) % roundTrip;
+    const expectedPos = (rawPos + halfTrip) % roundTrip;
+
+    // The phase should match the destination-offset calculation, not the stale one
+    if (expectedPos < durationTicks) {
+      expect(result[0].flight?.direction).toBe("outbound");
+    } else if (expectedPos < durationTicks + turnaroundTicks) {
+      expect(result[0].status).toBe("turnaround");
+    } else if (expectedPos < durationTicks * 2 + turnaroundTicks) {
+      expect(result[0].flight?.direction).toBe("inbound");
+    } else {
+      expect(result[0].status).toBe("turnaround");
+    }
+  });
+
+  it("staggered aircraft maintain separation after reconcileFleetToTick across reload", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-stag3",
+      originIata: "BOG",
+      destinationIata: "CCS",
+      distanceKm: 1000,
+      assignedAircraftIds: ["ac-a", "ac-b"],
+    });
+    const durationTicks = Math.ceil((1000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    // Simulate: Player assigns A at BOG and B at CCS at different times.
+    // The phase offset from routeAssignedAtIata should preserve the stagger
+    // even though both aircraft are idle when reconciled.
+    const acA = makeAircraft({
+      id: "ac-a",
+      assignedRouteId: "route-stag3",
+      status: "idle",
+      baseAirportIata: "BOG",
+      flight: null,
+      routeAssignedAtTick: 100,
+      routeAssignedAtIata: "BOG",
+    });
+
+    // B assigned later at CCS. The tick offset (500) is arbitrary and NOT
+    // equal to halfTrip, ensuring the test isn't trivially symmetric.
+    const acB = makeAircraft({
+      id: "ac-b",
+      assignedRouteId: "route-stag3",
+      status: "idle",
+      baseAirportIata: "CCS",
+      flight: null,
+      routeAssignedAtTick: 600,
+      routeAssignedAtIata: "CCS",
+    });
+
+    // Simulate "next day" — many round trips later
+    const targetTick = 600 + roundTrip * 20 + Math.floor(durationTicks / 2);
+    const { fleet: result } = reconcileFleetToTick([acA, acB], [route], targetTick);
+
+    // Both should be actively flying
+    expect(result[0].status).not.toBe("idle");
+    expect(result[1].status).not.toBe("idle");
+
+    // They should not be at the same cycle phase — the destination phase
+    // offset ensures B's cycle is shifted relative to A's.
+    const aFlight = result[0].flight!;
+    const bFlight = result[1].flight!;
+    expect(aFlight.direction).not.toBe(bFlight.direction);
   });
 });

--- a/packages/store/src/FlightEngine.test.ts
+++ b/packages/store/src/FlightEngine.test.ts
@@ -1332,7 +1332,46 @@ describe("reconcileFleetToTick — destination-aware stagger", () => {
     expect(result[0].flight?.direction).not.toBe(result[1].flight?.direction);
   });
 
-  it("stale enroute state is overridden when routeAssignedAtTick > departureTick", () => {
+  it("falls back to baseAirportIata when routeAssignedAtIata is missing", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-stag-fallback",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-origin-fallback", "ac-dest-fallback"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    const acOrigin = makeAircraft({
+      id: "ac-origin-fallback",
+      assignedRouteId: "route-stag-fallback",
+      status: "idle",
+      baseAirportIata: "JFK",
+      flight: null,
+      routeAssignedAtTick: 1000,
+    });
+
+    const acDest = makeAircraft({
+      id: "ac-dest-fallback",
+      assignedRouteId: "route-stag-fallback",
+      status: "idle",
+      baseAirportIata: "LAX",
+      flight: null,
+      routeAssignedAtTick: 1000,
+    });
+
+    const targetTick = 1000 + roundTrip * 4 + 1;
+    const { fleet: result } = reconcileFleetToTick([acOrigin, acDest], [route], targetTick);
+
+    expect(result[0].status).not.toBe("idle");
+    expect(result[1].status).not.toBe("idle");
+    expect(result[0].flight?.direction).not.toBe(result[1].flight?.direction);
+  });
+
+  it("stale enroute state is overridden when routeAssignedAtTick >= departureTick", () => {
     const model = getAircraftById("a320neo")!;
     const route = makeRoute({
       id: "route-stag2",
@@ -1378,6 +1417,58 @@ describe("reconcileFleetToTick — destination-aware stagger", () => {
     const expectedPos = (rawPos + halfTrip) % roundTrip;
 
     // The phase should match the destination-offset calculation, not the stale one
+    if (expectedPos < durationTicks) {
+      expect(result[0].flight?.direction).toBe("outbound");
+    } else if (expectedPos < durationTicks + turnaroundTicks) {
+      expect(result[0].status).toBe("turnaround");
+    } else if (expectedPos < durationTicks * 2 + turnaroundTicks) {
+      expect(result[0].flight?.direction).toBe("inbound");
+    } else {
+      expect(result[0].status).toBe("turnaround");
+    }
+  });
+
+  it("stale enroute state is overridden when routeAssignedAtTick equals departureTick", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-stag2-eq",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-stale-eq"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+    const routeAssignedAtTick = 2000;
+
+    const aircraft = makeAircraft({
+      id: "ac-stale-eq",
+      assignedRouteId: "route-stag2-eq",
+      status: "enroute",
+      baseAirportIata: "LAX",
+      routeAssignedAtTick,
+      routeAssignedAtIata: "LAX",
+      flight: {
+        originIata: "JFK",
+        destinationIata: "LAX",
+        departureTick: routeAssignedAtTick,
+        arrivalTick: routeAssignedAtTick + durationTicks,
+        direction: "outbound",
+      },
+    });
+
+    const targetTick = routeAssignedAtTick + roundTrip * 2 + 1;
+    const { fleet: result } = reconcileFleetToTick([aircraft], [route], targetTick);
+
+    expect(result[0].status).not.toBe("idle");
+    expect(result[0].flight).not.toBeNull();
+
+    const elapsed = targetTick - routeAssignedAtTick;
+    const halfTrip = durationTicks + turnaroundTicks;
+    const rawPos = ((elapsed % roundTrip) + roundTrip) % roundTrip;
+    const expectedPos = (rawPos + halfTrip) % roundTrip;
+
     if (expectedPos < durationTicks) {
       expect(result[0].flight?.direction).toBe("outbound");
     } else if (expectedPos < durationTicks + turnaroundTicks) {

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -910,11 +910,11 @@ export function reconcileFleetToTick(
       // If the aircraft was reassigned after its current flight started, the
       // flight state is stale (from before the reassignment). Treat it like
       // an idle aircraft and use routeAssignedAtTick as the new cycle anchor.
-      if (ac.routeAssignedAtTick != null && ac.routeAssignedAtTick > ac.flight.departureTick) {
+      if (ac.routeAssignedAtTick != null && ac.routeAssignedAtTick >= ac.flight.departureTick) {
         const cycleStartTick = ac.routeAssignedAtTick;
         if (targetTick <= cycleStartTick) return ac;
-        const startedAtDest =
-          ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+        const startedAtIata = ac.routeAssignedAtIata ?? ac.baseAirportIata ?? null;
+        const startedAtDest = startedAtIata != null && startedAtIata === route.destinationIata;
         const stalePhaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
         const elapsed = targetTick - cycleStartTick;
         const rawPos = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
@@ -958,11 +958,11 @@ export function reconcileFleetToTick(
     } else if (ac.status === "turnaround" && ac.flight) {
       // If the aircraft was reassigned after its current flight started,
       // use routeAssignedAtTick as the new cycle anchor (same logic as enroute).
-      if (ac.routeAssignedAtTick != null && ac.routeAssignedAtTick > ac.flight.departureTick) {
+      if (ac.routeAssignedAtTick != null && ac.routeAssignedAtTick >= ac.flight.departureTick) {
         const cycleStartTick = ac.routeAssignedAtTick;
         if (targetTick <= cycleStartTick) return ac;
-        const startedAtDest =
-          ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+        const startedAtIata = ac.routeAssignedAtIata ?? ac.baseAirportIata ?? null;
+        const startedAtDest = startedAtIata != null && startedAtIata === route.destinationIata;
         const stalePhaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
         const elapsed = targetTick - cycleStartTick;
         const rawPos = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
@@ -1018,8 +1018,8 @@ export function reconcileFleetToTick(
       // If the aircraft was at the destination when assigned, its first leg
       // is inbound (not outbound). Offset by half a round-trip so the cycle
       // model places it correctly.
-      const startedAtDest =
-        ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+      const startedAtIata = ac.routeAssignedAtIata ?? ac.baseAirportIata ?? null;
+      const startedAtDest = startedAtIata != null && startedAtIata === route.destinationIata;
       const phaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
 
       const elapsed = targetTick - cycleStartTick;
@@ -1062,8 +1062,8 @@ export function reconcileFleetToTick(
         }
 
         const elapsed = targetTick - cycleStartTick;
-        const startedAtDest =
-          ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+        const startedAtIata = ac.routeAssignedAtIata ?? ac.baseAirportIata ?? null;
+        const startedAtDest = startedAtIata != null && startedAtIata === route.destinationIata;
         const delPhaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
         const rawDelPos = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
         const positionInCycle = (rawDelPos + delPhaseOffset) % roundTripTicks;

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -907,6 +907,46 @@ export function reconcileFleetToTick(
     let refPhaseOffset: number; // offset within the round-trip cycle
 
     if (ac.status === "enroute" && ac.flight) {
+      // If the aircraft was reassigned after its current flight started, the
+      // flight state is stale (from before the reassignment). Treat it like
+      // an idle aircraft and use routeAssignedAtTick as the new cycle anchor.
+      if (ac.routeAssignedAtTick != null && ac.routeAssignedAtTick > ac.flight.departureTick) {
+        const cycleStartTick = ac.routeAssignedAtTick;
+        if (targetTick <= cycleStartTick) return ac;
+        const startedAtDest =
+          ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+        const stalePhaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
+        const elapsed = targetTick - cycleStartTick;
+        const rawPos = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
+        const positionInCycle = (rawPos + stalePhaseOffset) % roundTripTicks;
+        const updated = { ...ac };
+        applyCyclePhase(
+          updated,
+          route,
+          targetTick,
+          positionInCycle,
+          durationTicks,
+          turnaroundTicks,
+        );
+        updated.lastTickProcessed = targetTick;
+        const referenceTick =
+          typeof ac.lastTickProcessed === "number" ? ac.lastTickProcessed : cycleStartTick;
+        let landings = countLandingsBetween(
+          cycleStartTick,
+          referenceTick,
+          targetTick,
+          durationTicks,
+          turnaroundTicks,
+        );
+        const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
+        landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
+        applyFlightHours(updated, landings * hoursPerLeg);
+        balanceDelta = fpAdd(
+          balanceDelta,
+          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+        );
+        return updated;
+      }
       // Aircraft was mid-flight. Its cycle started at departureTick.
       refTick = ac.flight.departureTick;
       if (ac.flight.direction === "outbound") {
@@ -916,6 +956,45 @@ export function reconcileFleetToTick(
         refPhaseOffset = durationTicks + turnaroundTicks;
       }
     } else if (ac.status === "turnaround" && ac.flight) {
+      // If the aircraft was reassigned after its current flight started,
+      // use routeAssignedAtTick as the new cycle anchor (same logic as enroute).
+      if (ac.routeAssignedAtTick != null && ac.routeAssignedAtTick > ac.flight.departureTick) {
+        const cycleStartTick = ac.routeAssignedAtTick;
+        if (targetTick <= cycleStartTick) return ac;
+        const startedAtDest =
+          ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+        const stalePhaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
+        const elapsed = targetTick - cycleStartTick;
+        const rawPos = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
+        const positionInCycle = (rawPos + stalePhaseOffset) % roundTripTicks;
+        const updated = { ...ac };
+        applyCyclePhase(
+          updated,
+          route,
+          targetTick,
+          positionInCycle,
+          durationTicks,
+          turnaroundTicks,
+        );
+        updated.lastTickProcessed = targetTick;
+        const referenceTick =
+          typeof ac.lastTickProcessed === "number" ? ac.lastTickProcessed : cycleStartTick;
+        let landings = countLandingsBetween(
+          cycleStartTick,
+          referenceTick,
+          targetTick,
+          durationTicks,
+          turnaroundTicks,
+        );
+        const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
+        landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
+        applyFlightHours(updated, landings * hoursPerLeg);
+        balanceDelta = fpAdd(
+          balanceDelta,
+          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+        );
+        return updated;
+      }
       // Aircraft was in turnaround. Turnaround started at arrivalTick.
       const arrivalTick = ac.flight.arrivalTick;
       if (ac.flight.direction === "outbound") {
@@ -936,8 +1015,16 @@ export function reconcileFleetToTick(
       const cycleStartTick = ac.routeAssignedAtTick ?? ac.purchasedAtTick;
       if (targetTick <= cycleStartTick) return ac;
 
+      // If the aircraft was at the destination when assigned, its first leg
+      // is inbound (not outbound). Offset by half a round-trip so the cycle
+      // model places it correctly.
+      const startedAtDest =
+        ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+      const phaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
+
       const elapsed = targetTick - cycleStartTick;
-      const positionInCycle = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
+      const rawPos = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
+      const positionInCycle = (rawPos + phaseOffset) % roundTripTicks;
 
       const updated = { ...ac };
       applyCyclePhase(updated, route, targetTick, positionInCycle, durationTicks, turnaroundTicks);
@@ -975,7 +1062,11 @@ export function reconcileFleetToTick(
         }
 
         const elapsed = targetTick - cycleStartTick;
-        const positionInCycle = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
+        const startedAtDest =
+          ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+        const delPhaseOffset = startedAtDest ? durationTicks + turnaroundTicks : 0;
+        const rawDelPos = ((elapsed % roundTripTicks) + roundTripTicks) % roundTripTicks;
+        const positionInCycle = (rawDelPos + delPhaseOffset) % roundTripTicks;
         const updated = { ...ac };
         applyCyclePhase(
           updated,

--- a/packages/store/src/actionReducer.test.ts
+++ b/packages/store/src/actionReducer.test.ts
@@ -422,6 +422,7 @@ describe("replayActionLog", () => {
             instanceId: "ac-1",
             modelId: "a320neo",
             price: fp(50000000),
+            deliveryHubIata: "JFK",
             tick: 2,
           },
         },
@@ -495,7 +496,109 @@ describe("replayActionLog", () => {
 
     expect(aircraft?.assignedRouteId).toBe("rt-b");
     expect(aircraft?.routeAssignedAtTick).toBe(200);
+    expect(aircraft?.routeAssignedAtIata).toBe("JFK"); // baseAirportIata at assignment time
     expect(routeA?.assignedAircraftIds).not.toContain("ac-1");
     expect(routeB?.assignedAircraftIds).toContain("ac-1");
+  });
+
+  it("ROUTE_ASSIGN_AIRCRAFT clears stale flight state when actionTick > departureTick", async () => {
+    const pubkey = "pubkey-stale";
+    const actions = [
+      {
+        eventId: "e1",
+        authorPubkey: pubkey,
+        createdAt: 100,
+        action: {
+          schemaVersion: 2,
+          action: "AIRLINE_CREATE",
+          payload: { name: "Test Airline", hubs: ["JFK"] },
+        },
+      },
+      {
+        eventId: "e2",
+        authorPubkey: pubkey,
+        createdAt: 101,
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-1",
+            modelId: "a320neo",
+            name: "Test A320",
+            purchaseType: "buy",
+            deliveryHubIata: "JFK",
+            tick: 100,
+          },
+        },
+      },
+      {
+        eventId: "e3",
+        authorPubkey: pubkey,
+        createdAt: 102,
+        action: {
+          schemaVersion: 2,
+          action: "ROUTE_OPEN",
+          payload: {
+            routeId: "rt-a",
+            originIata: "JFK",
+            destinationIata: "LAX",
+            distanceKm: 3983,
+            tick: 100,
+          },
+        },
+      },
+      {
+        eventId: "e4",
+        authorPubkey: pubkey,
+        createdAt: 103,
+        action: {
+          schemaVersion: 2,
+          action: "ROUTE_ASSIGN_AIRCRAFT",
+          payload: { aircraftId: "ac-1", routeId: "rt-a", tick: 100 },
+        },
+      },
+      // TICK_UPDATE to reconcile fleet — this gives the aircraft a flight state
+      {
+        eventId: "e5",
+        authorPubkey: pubkey,
+        createdAt: 104,
+        action: {
+          schemaVersion: 2,
+          action: "TICK_UPDATE",
+          payload: { tick: 5000, timeline: [] },
+        },
+      },
+      // Unassign then reassign at a later tick (stagger scenario)
+      {
+        eventId: "e6",
+        authorPubkey: pubkey,
+        createdAt: 105,
+        action: {
+          schemaVersion: 2,
+          action: "ROUTE_UNASSIGN_AIRCRAFT",
+          payload: { aircraftId: "ac-1", routeId: "rt-a", tick: 6000 },
+        },
+      },
+      {
+        eventId: "e7",
+        authorPubkey: pubkey,
+        createdAt: 106,
+        action: {
+          schemaVersion: 2,
+          action: "ROUTE_ASSIGN_AIRCRAFT",
+          payload: { aircraftId: "ac-1", routeId: "rt-a", tick: 6000 },
+        },
+      },
+    ];
+
+    const result = await replayActionLog({ pubkey, actions });
+    const aircraft = result.fleet.find((ac) => ac.id === "ac-1");
+
+    // The TICK_UPDATE at tick 5000 gave the aircraft a flight state with a
+    // departureTick in the past. The ROUTE_ASSIGN at tick 6000 should have
+    // cleared that stale flight state.
+    expect(aircraft?.routeAssignedAtTick).toBe(6000);
+    expect(aircraft?.status).toBe("idle");
+    expect(aircraft?.flight).toBeNull();
   });
 });

--- a/packages/store/src/actionReducer.test.ts
+++ b/packages/store/src/actionReducer.test.ts
@@ -501,7 +501,7 @@ describe("replayActionLog", () => {
     expect(routeB?.assignedAircraftIds).toContain("ac-1");
   });
 
-  it("ROUTE_ASSIGN_AIRCRAFT clears stale flight state when actionTick > departureTick", async () => {
+  it("ROUTE_ASSIGN_AIRCRAFT clears stale flight state when actionTick >= departureTick", async () => {
     const pubkey = "pubkey-stale";
     const actions = [
       {

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -726,7 +726,7 @@ export async function replayActionLog(params: {
         aircraft.routeAssignedAtIata = aircraft.baseAirportIata;
         // Clear stale flight state from a previous cycle so reconcileFleetToTick
         // uses routeAssignedAtTick as the new cycle anchor instead of old departureTick.
-        if (aircraft.flight && actionTick > aircraft.flight.departureTick) {
+        if (aircraft.flight && actionTick >= aircraft.flight.departureTick) {
           aircraft.status = "idle";
           aircraft.flight = null;
           aircraft.turnaroundEndTick = undefined;

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -723,6 +723,15 @@ export async function replayActionLog(params: {
         }
         aircraft.assignedRouteId = routeId;
         aircraft.routeAssignedAtTick = actionTick;
+        aircraft.routeAssignedAtIata = aircraft.baseAirportIata;
+        // Clear stale flight state from a previous cycle so reconcileFleetToTick
+        // uses routeAssignedAtTick as the new cycle anchor instead of old departureTick.
+        if (aircraft.flight && actionTick > aircraft.flight.departureTick) {
+          aircraft.status = "idle";
+          aircraft.flight = null;
+          aircraft.turnaroundEndTick = undefined;
+          aircraft.arrivalTickProcessed = undefined;
+        }
         if (!route.assignedAircraftIds.includes(aircraftId)) {
           route.assignedAircraftIds = [...route.assignedAircraftIds, aircraftId];
         }

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -607,7 +607,13 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
           }
           if (cycleAnchor != null && cycleAnchor < targetTick) {
             const elapsed = targetTick - cycleAnchor;
-            const positionInCycle = elapsed % roundTripTicks;
+            // If the aircraft was at the destination when assigned, offset by
+            // half a round-trip so the cycle starts with an inbound leg.
+            const assignedAtDest =
+              ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+            const sweepPhaseOffset = assignedAtDest ? durationTicks + turnaroundTicks : 0;
+            const rawSweepPos = elapsed % roundTripTicks;
+            const positionInCycle = (rawSweepPos + sweepPhaseOffset) % roundTripTicks;
             const cycleStartTick = targetTick - positionInCycle;
             const phase = getCyclePhase(
               cycleStartTick,

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -609,8 +609,9 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             const elapsed = targetTick - cycleAnchor;
             // If the aircraft was at the destination when assigned, offset by
             // half a round-trip so the cycle starts with an inbound leg.
+            const assignedAtAirportIata = ac.routeAssignedAtIata ?? ac.baseAirportIata;
             const assignedAtDest =
-              ac.routeAssignedAtIata != null && ac.routeAssignedAtIata === route.destinationIata;
+              assignedAtAirportIata != null && assignedAtAirportIata === route.destinationIata;
             const sweepPhaseOffset = assignedAtDest ? durationTicks + turnaroundTicks : 0;
             const rawSweepPos = elapsed % roundTripTicks;
             const positionInCycle = (rawSweepPos + sweepPhaseOffset) % roundTripTicks;

--- a/packages/store/src/slices/networkSlice.test.ts
+++ b/packages/store/src/slices/networkSlice.test.ts
@@ -459,6 +459,8 @@ describe("assignAircraftToRoute", () => {
     const route = updatedRoutes.find((rt) => rt.id === "rt-1");
 
     expect(aircraft?.assignedRouteId).toBe("rt-1");
+    expect(aircraft?.routeAssignedAtTick).toBe(100);
+    expect(aircraft?.routeAssignedAtIata).toBe("BOG");
     expect(route?.assignedAircraftIds).toContain("ac-1");
   });
 

--- a/packages/store/src/slices/networkSlice.ts
+++ b/packages/store/src/slices/networkSlice.ts
@@ -1,4 +1,4 @@
-import type { FixedPoint, Route, TimelineEvent } from "@acars/core";
+import type { AircraftInstance, FixedPoint, Route, TimelineEvent } from "@acars/core";
 import {
   fp,
   fpAdd,

--- a/packages/store/src/slices/networkSlice.ts
+++ b/packages/store/src/slices/networkSlice.ts
@@ -755,11 +755,27 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
       }
     }
 
+    const currentTick = useEngineStore.getState().tick;
     const updatedFleet = fleet.map((ac) => {
-      if (ac.id === aircraftId) {
-        return { ...ac, assignedRouteId: routeId };
+      if (ac.id !== aircraftId) return ac;
+
+      if (routeId && routeId !== ac.assignedRouteId) {
+        const nextAircraft: AircraftInstance = {
+          ...ac,
+          assignedRouteId: routeId,
+          routeAssignedAtTick: currentTick,
+          routeAssignedAtIata: ac.baseAirportIata,
+        };
+        if (nextAircraft.flight && currentTick >= nextAircraft.flight.departureTick) {
+          nextAircraft.status = "idle";
+          nextAircraft.flight = null;
+          nextAircraft.turnaroundEndTick = undefined;
+          nextAircraft.arrivalTickProcessed = undefined;
+        }
+        return nextAircraft;
       }
-      return ac;
+
+      return { ...ac, assignedRouteId: routeId };
     });
 
     const updatedRoutes = routes.map((rt) => {
@@ -771,7 +787,6 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
     });
 
     const currentTimeline = [...get().timeline];
-    const currentTick = useEngineStore.getState().tick;
     const simulatedTimestamp = GENESIS_TIME + currentTick * TICK_DURATION;
 
     const aircraftName = aircraft?.name || "Aircraft";
@@ -797,7 +812,17 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
     };
 
     // Capture the previous assignment state for surgical rollback
-    const previousAircraftAssignment = aircraft ? aircraft.assignedRouteId : null;
+    const previousAircraft = aircraft
+      ? {
+          assignedRouteId: aircraft.assignedRouteId,
+          routeAssignedAtTick: aircraft.routeAssignedAtTick,
+          routeAssignedAtIata: aircraft.routeAssignedAtIata,
+          status: aircraft.status,
+          flight: aircraft.flight,
+          turnaroundEndTick: aircraft.turnaroundEndTick,
+          arrivalTickProcessed: aircraft.arrivalTickProcessed,
+        }
+      : null;
     const previousRouteAssignments = new Map(
       routes.map((rt) => [rt.id, [...rt.assignedAircraftIds]]),
     );
@@ -825,11 +850,20 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
       });
     } catch (e) {
       set((state) => {
-        // Merge-safe rollback: only revert the specific aircraft assignment
+        // Merge-safe rollback: only revert the specific aircraft assignment state
         // and route assignedAircraftIds, preserving concurrent updates.
         const restoredFleet = state.fleet.map((ac) => {
-          if (ac.id === aircraftId) {
-            return { ...ac, assignedRouteId: previousAircraftAssignment };
+          if (ac.id === aircraftId && previousAircraft) {
+            return {
+              ...ac,
+              assignedRouteId: previousAircraft.assignedRouteId,
+              routeAssignedAtTick: previousAircraft.routeAssignedAtTick,
+              routeAssignedAtIata: previousAircraft.routeAssignedAtIata,
+              status: previousAircraft.status,
+              flight: previousAircraft.flight,
+              turnaroundEndTick: previousAircraft.turnaroundEndTick,
+              arrivalTickProcessed: previousAircraft.arrivalTickProcessed,
+            };
           }
           return ac;
         });


### PR DESCRIPTION
## Summary
- preserve manual aircraft staggering across reload/replay
- record assignment airport on route assignment
- apply destination-aware cycle offsets in reconciliation and recovery
- clear stale flight state on reassignment and add regression coverage

## Validation
- npx vitest run packages/store/src/FlightEngine.test.ts packages/store/src/actionReducer.test.ts
- npx vitest run packages/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assignments now record assignment tick and airport, anchoring aircraft cycle positions and enabling destination-aware phase offsets.

* **Bug Fixes**
  * Clears stale in-flight state when a later assignment occurs so reconcilation uses the new assignment anchor; fixes inconsistent positioning after reassignment.

* **Tests**
  * Added extensive tests covering assignment anchoring, destination-based staggering, catch-up reconciliation, and stale-state clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->