### PR TITLE
fix(store): use authoritative corporateBalance in TICK_UPDATE replay

### DIFF
--- a/packages/store/src/actionReducer.test.ts
+++ b/packages/store/src/actionReducer.test.ts
@@ -601,4 +601,68 @@ describe("replayActionLog", () => {
     expect(aircraft?.status).toBe("idle");
     expect(aircraft?.flight).toBeNull();
   });
+
+  it("TICK_UPDATE with corporateBalance sets authoritative balance", async () => {
+    const pubkey = "pubkey-auth-bal";
+    const authoritativeBalance = fp(7777777);
+    const actions = [
+      {
+        eventId: "evt-1",
+        authorPubkey: pubkey,
+        createdAt: 1,
+        action: {
+          schemaVersion: 2,
+          action: "AIRLINE_CREATE" as const,
+          payload: { name: "Auth Air", hubs: ["LAX"], corporateBalance: fp(50000000), tick: 1 },
+        },
+      },
+      {
+        eventId: "evt-2",
+        authorPubkey: pubkey,
+        createdAt: 2,
+        action: {
+          schemaVersion: 2,
+          action: "TICK_UPDATE" as const,
+          payload: { tick: 100, corporateBalance: authoritativeBalance },
+        },
+      },
+    ];
+
+    const result = await replayActionLog({ pubkey, actions });
+    expect(result.airline?.corporateBalance).toBe(authoritativeBalance);
+    expect(result.airline?.lastTick).toBe(100);
+  });
+
+  it("TICK_UPDATE without corporateBalance falls back to estimation", async () => {
+    const pubkey = "pubkey-est-bal";
+    const initialBalance = fp(50000000);
+    const actions = [
+      {
+        eventId: "evt-1",
+        authorPubkey: pubkey,
+        createdAt: 1,
+        action: {
+          schemaVersion: 2,
+          action: "AIRLINE_CREATE" as const,
+          payload: { name: "Est Air", hubs: ["SFO"], corporateBalance: initialBalance, tick: 1 },
+        },
+      },
+      {
+        eventId: "evt-2",
+        authorPubkey: pubkey,
+        createdAt: 2,
+        action: {
+          schemaVersion: 2,
+          action: "TICK_UPDATE" as const,
+          payload: { tick: 100 },
+        },
+      },
+    ];
+
+    const result = await replayActionLog({ pubkey, actions });
+    // Without corporateBalance in payload, balance should remain unchanged
+    // (no fleet to generate revenue, so reconcileFleetToTick delta is 0)
+    expect(result.airline?.corporateBalance).toBe(initialBalance);
+    expect(result.airline?.lastTick).toBe(100);
+  });
 });

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -499,7 +499,22 @@ export async function replayActionLog(params: {
             Array.from(routesById.values()),
             actionTick,
           );
-          applyBalanceDelta(balanceDelta);
+          // Use authoritative balance from the TICK_UPDATE payload when
+          // available.  The publishing client computed this via the full
+          // demand engine (QSI, competition, price elasticity), which is
+          // far more accurate than the simplified estimation produced by
+          // reconcileFleetToTick.  Fall back to the estimated delta for
+          // old events that predate this field.
+          const authoritativeBalance = clampFixedPoint(
+            payload.corporateBalance,
+            MIN_BALANCE,
+            MAX_BALANCE,
+          );
+          if (authoritativeBalance != null) {
+            airline = { ...airline, corporateBalance: authoritativeBalance };
+          } else {
+            applyBalanceDelta(balanceDelta);
+          }
           fleetById.clear();
           for (const aircraft of reconciledFleet) {
             fleetById.set(aircraft.id, aircraft);

--- a/packages/store/src/slices/engineSlice.test.ts
+++ b/packages/store/src/slices/engineSlice.test.ts
@@ -948,4 +948,29 @@ describe("TICK_UPDATE publish cadence", () => {
       errorSpy.mockRestore();
     }
   });
+
+  it("includes corporateBalance in TICK_UPDATE payload", async () => {
+    const { processFlightEngine } = await import("../FlightEngine");
+    const updatedBalance = 888888888 as FixedPoint;
+    vi.mocked(processFlightEngine).mockImplementation((_tick, currentFleet) => ({
+      updatedFleet: currentFleet,
+      corporateBalance: updatedBalance,
+      events: [],
+      hasChanges: true,
+    }));
+
+    const route = makeRoute("rt-1", 400);
+    const { state } = createSliceState({
+      airline: makeAirline(999),
+      fleet: [makeAircraft("ac-1")],
+      routes: [route],
+    });
+
+    await state.processTick(1000);
+    expect(vi.mocked(publishAction)).toHaveBeenCalledTimes(1);
+
+    const publishedAction = vi.mocked(publishAction).mock.calls[0][0];
+    expect(publishedAction.action).toBe("TICK_UPDATE");
+    expect(publishedAction.payload.corporateBalance).toBe(updatedBalance);
+  });
 });

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -146,6 +146,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             payload: {
               status: "chapter11",
               tick,
+              corporateBalance: updatedAirline.corporateBalance,
               timeline: get().timeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
             },
           },
@@ -309,6 +310,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
               action: "TICK_UPDATE",
               payload: {
                 tick: tickUpdateTick,
+                corporateBalance: updatedAirline.corporateBalance,
                 timeline: currentTimeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
               },
             },
@@ -877,6 +879,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             action: "TICK_UPDATE",
             payload: {
               tick: tickUpdateTick,
+              corporateBalance: currentBalance,
               timeline: currentTimeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
             },
           },


### PR DESCRIPTION
## Summary
- include `corporateBalance` in all TICK_UPDATE payload publish paths
- use authoritative `corporateBalance` in action replay when present
- preserve backward compatibility by falling back to estimation for old events
- add tests for payload contents and replay behavior

## Validation
- store tests: 138 passed
- pre-commit lint/hooks pass

## Context
Fixes observed liquidity drift where leaderboard and logged-in balances diverged after replaying replaceable NIP-33 TICK_UPDATE events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved corporate balance accuracy during game tick updates by prioritizing authoritative values when available, with fallback to computed calculations when needed.

* **Tests**
  * Added test coverage for corporate balance handling and validation in tick update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->