### PR TITLE
fix: real-time competitor sync — cache live events and add retry

### DIFF
--- a/packages/store/src/airline.test.ts
+++ b/packages/store/src/airline.test.ts
@@ -161,7 +161,7 @@ describe("airline store – event buffering during initial sync", () => {
     });
   });
 
-  it("deduplicates buffer entries and skips competitors already captured by syncWorld", async () => {
+  it("deduplicates by pubkey and replays buffered entries for known competitors", async () => {
     const { _getEventBuffer } = await import("./airline.js");
 
     // Simulate a burst of events from the same pubkey before sync finishes.
@@ -201,13 +201,16 @@ describe("airline store – event buffering during initial sync", () => {
       vi.useRealTimers();
     }
 
-    const syncedPubkeys = syncCompetitorSpy.mock.calls.map((c) => c[0] as string);
+    const cccCalls = syncCompetitorSpy.mock.calls.filter((c) => c[0] === "competitor-ccc");
+    const dddCalls = syncCompetitorSpy.mock.calls.filter((c) => c[0] === "competitor-ddd");
 
-    // competitor-ccc was already captured by syncWorld → must NOT be re-synced.
-    expect(syncedPubkeys).not.toContain("competitor-ccc");
+    // Known competitors are still replayed; burst entries are batched into one sync call.
+    expect(cccCalls).toHaveLength(1);
+    expect((cccCalls[0]?.[1] as unknown[])?.length).toBe(5);
 
-    // competitor-ddd is genuinely new → must be synced exactly once.
-    expect(syncedPubkeys.filter((pk) => pk === "competitor-ddd")).toHaveLength(1);
+    // Distinct competitor receives one sync with one buffered event.
+    expect(dddCalls).toHaveLength(1);
+    expect((dddCalls[0]?.[1] as unknown[])?.length).toBe(1);
   });
 });
 

--- a/packages/store/src/airline.test.ts
+++ b/packages/store/src/airline.test.ts
@@ -212,6 +212,40 @@ describe("airline store – event buffering during initial sync", () => {
     expect(dddCalls).toHaveLength(1);
     expect((dddCalls[0]?.[1] as unknown[])?.length).toBe(1);
   });
+
+  it("deduplicates buffered duplicate event ids before sync", async () => {
+    const { _getEventBuffer } = await import("./airline.js");
+
+    capturedOnEvent!({
+      event: { id: "evt-dupe-1", author: { pubkey: "competitor-eee" } },
+      action: { action: "purchase_aircraft" },
+    } as never);
+    capturedOnEvent!({
+      event: { id: "evt-dupe-1", author: { pubkey: "competitor-eee" } },
+      action: { action: "purchase_aircraft" },
+    } as never);
+    capturedOnEvent!({
+      event: { id: "evt-dupe-2", author: { pubkey: "competitor-eee" } },
+      action: { action: "open_route" },
+    } as never);
+
+    syncWorldCompetitors = new Map([["competitor-eee", {}]]);
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    try {
+      resolveSyncWorld!();
+      await vi.waitFor(() => expect(_getEventBuffer()).toHaveLength(0), {
+        timeout: 3000,
+      });
+      await vi.advanceTimersByTimeAsync(1100);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    const eeeCalls = syncCompetitorSpy.mock.calls.filter((c) => c[0] === "competitor-eee");
+    expect(eeeCalls).toHaveLength(1);
+    expect((eeeCalls[0]?.[1] as unknown[])?.length).toBe(2);
+  });
 });
 
 describe("airline store – reconnect resubscribe watermark", () => {

--- a/packages/store/src/airline.ts
+++ b/packages/store/src/airline.ts
@@ -1,4 +1,5 @@
 import { createLogger } from "@acars/core";
+import type { ActionLogEntry } from "@acars/nostr";
 import {
   connectedRelayCount,
   ensureConnected,
@@ -116,21 +117,21 @@ const runtimeEnv = (
 ).process?.env?.NODE_ENV;
 const enableRealtimeSyncLogs = runtimeEnv !== "production";
 
-// Batching: collect competitor pubkeys that need targeted sync, flush after
+// Batching: collect competitor events that need targeted sync, flush after
 // a short window so rapid-fire events from the same player coalesce.
 const LIVE_SYNC_BATCH_MS = 1000;
-let pendingCompetitorSyncs = new Set<string>();
+let pendingCompetitorSyncs = new Map<string, ActionLogEntry[]>();
 let batchFlushTimer: ReturnType<typeof setTimeout> | null = null;
 const RESUBSCRIBE_REPLAY_WINDOW_SEC = 5;
 let lastSeenActionCreatedAtSec = 0;
 
 // Buffer for live events that arrive before the initial sync completes.
 // Flushed (with deduplication) once initialSyncComplete is set to true.
-const eventBuffer: string[] = [];
+const eventBuffer: Array<{ pubkey: string; entry: ActionLogEntry }> = [];
 
 /** @internal — test-only accessor for the pre-sync event buffer */
 export function _getEventBuffer(): string[] {
-  return [...eventBuffer];
+  return eventBuffer.map((e) => e.pubkey);
 }
 
 function updateLastSeenAction(createdAt: number | undefined) {
@@ -149,19 +150,23 @@ function getResubscribeSince(): number {
 
 function flushPendingCompetitorSyncs() {
   batchFlushTimer = null;
-  const pubkeys = pendingCompetitorSyncs;
-  pendingCompetitorSyncs = new Set();
+  const pending = pendingCompetitorSyncs;
+  pendingCompetitorSyncs = new Map();
 
-  for (const pubkey of pubkeys) {
+  for (const [pubkey, liveEvents] of pending) {
     if (enableRealtimeSyncLogs) {
-      logger.info(`Live sync: fetching competitor ${pubkey.slice(0, 8)}...`);
+      logger.info(
+        `Live sync: fetching competitor ${pubkey.slice(0, 8)}... (${liveEvents.length} cached event(s))`,
+      );
     }
-    void useAirlineStore.getState().syncCompetitor(pubkey);
+    void useAirlineStore.getState().syncCompetitor(pubkey, liveEvents);
   }
 }
 
-function queueCompetitorSync(pubkey: string) {
-  pendingCompetitorSyncs.add(pubkey);
+function queueCompetitorSync(pubkey: string, entry?: ActionLogEntry) {
+  const existing = pendingCompetitorSyncs.get(pubkey) || [];
+  if (entry) existing.push(entry);
+  pendingCompetitorSyncs.set(pubkey, existing);
   if (!batchFlushTimer) {
     batchFlushTimer = setTimeout(flushPendingCompetitorSyncs, LIVE_SYNC_BATCH_MS);
   }
@@ -226,12 +231,18 @@ const RESUBSCRIBE_DELAY_MS = 2000;
 function flushEventBuffer() {
   if (eventBuffer.length === 0) return;
   const { competitors } = useAirlineStore.getState();
-  const seen = new Set<string>();
-  for (const pk of eventBuffer) {
-    if (seen.has(pk)) continue;
-    seen.add(pk);
-    if (!competitors.has(pk)) {
-      queueCompetitorSync(pk);
+  // Group buffered entries by pubkey
+  const byPubkey = new Map<string, ActionLogEntry[]>();
+  for (const { pubkey: pk, entry } of eventBuffer) {
+    const existing = byPubkey.get(pk) || [];
+    existing.push(entry);
+    byPubkey.set(pk, existing);
+  }
+  for (const [pk, entries] of byPubkey) {
+    // Skip competitors already captured by syncWorld
+    if (competitors.has(pk)) continue;
+    for (const entry of entries) {
+      queueCompetitorSync(pk, entry);
     }
   }
   eventBuffer.length = 0;
@@ -259,7 +270,7 @@ async function startActionSubscription(since: number): Promise<void> {
       // Buffer events that arrive before the initial sync finishes so they
       // are not silently dropped.  They will be replayed once sync completes.
       if (!initialSyncComplete) {
-        eventBuffer.push(competitorPubkey);
+        eventBuffer.push({ pubkey: competitorPubkey, entry });
         return;
       }
 
@@ -269,7 +280,7 @@ async function startActionSubscription(since: number): Promise<void> {
 
       // Queue a targeted sync for just this competitor.
       // Events arriving within LIVE_SYNC_BATCH_MS are coalesced.
-      queueCompetitorSync(competitorPubkey);
+      queueCompetitorSync(competitorPubkey, entry);
     },
     onClose: () => {
       // Subscription died unexpectedly (relay disconnect, WebSocket close).

--- a/packages/store/src/airline.ts
+++ b/packages/store/src/airline.ts
@@ -225,12 +225,11 @@ const RESUBSCRIBE_DELAY_MS = 2000;
 
 /**
  * Replay events buffered during the initial sync window.
- * Deduplicates by pubkey and skips competitors already captured by syncWorld.
+ * Deduplicates by pubkey and replays all buffered entries.
  * Mirrors the flushPendingCompetitorSyncs pattern.
  */
 function flushEventBuffer() {
   if (eventBuffer.length === 0) return;
-  const { competitors } = useAirlineStore.getState();
   // Group buffered entries by pubkey
   const byPubkey = new Map<string, ActionLogEntry[]>();
   for (const { pubkey: pk, entry } of eventBuffer) {
@@ -239,8 +238,6 @@ function flushEventBuffer() {
     byPubkey.set(pk, existing);
   }
   for (const [pk, entries] of byPubkey) {
-    // Skip competitors already captured by syncWorld
-    if (competitors.has(pk)) continue;
     for (const entry of entries) {
       queueCompetitorSync(pk, entry);
     }

--- a/packages/store/src/airline.ts
+++ b/packages/store/src/airline.ts
@@ -165,7 +165,12 @@ function flushPendingCompetitorSyncs() {
 
 function queueCompetitorSync(pubkey: string, entry?: ActionLogEntry) {
   const existing = pendingCompetitorSyncs.get(pubkey) || [];
-  if (entry) existing.push(entry);
+  if (entry) {
+    const eventId = entry.event.id;
+    if (!eventId || !existing.some((e) => e.event.id === eventId)) {
+      existing.push(entry);
+    }
+  }
   pendingCompetitorSyncs.set(pubkey, existing);
   if (!batchFlushTimer) {
     batchFlushTimer = setTimeout(flushPendingCompetitorSyncs, LIVE_SYNC_BATCH_MS);

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -616,3 +616,91 @@ describe("syncWorld", () => {
     expect(loadActionLog).toHaveBeenCalledTimes(2);
   });
 });
+
+describe("syncCompetitor", () => {
+  beforeEach(async () => {
+    _resetWorldFlags();
+    const nostr = await import("@acars/nostr");
+    (nostr.loadActionLog as unknown as ReturnType<typeof vi.fn>).mockReset();
+    (nostr.loadCheckpoints as unknown as ReturnType<typeof vi.fn>).mockReset();
+    (nostr.loadCheckpoints as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(new Map());
+  });
+
+  it("replays liveEvents when targeted relay fetch is empty", async () => {
+    const { loadActionLog } = await import("@acars/nostr");
+    const pubkey = "comp-live-events";
+
+    (loadActionLog as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([]) // competitor-targeted
+      .mockResolvedValueOnce([]); // global actions
+
+    const { state } = createSliceState({
+      competitors: new Map(),
+      fleetByOwner: buildFleetIndex([]),
+      routesByOwner: buildRoutesIndex([]),
+    });
+
+    await state.syncCompetitor(pubkey, [
+      {
+        event: { id: "live-evt-1", author: { pubkey }, created_at: 1 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRLINE_CREATE",
+          payload: {
+            name: "Live Events Air",
+            hubs: ["JFK"],
+            corporateBalance: 1000000000000,
+            tick: 10,
+          },
+        },
+      },
+      {
+        event: { id: "live-evt-2", author: { pubkey }, created_at: 2 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-live-events",
+            modelId: "atr72-600",
+            price: 1000000,
+            deliveryHubIata: "JFK",
+            tick: 20,
+          },
+        },
+      },
+    ]);
+
+    expect(state.competitors.has(pubkey)).toBe(true);
+    expect(state.fleetByOwner.get(pubkey)?.map((ac) => ac.id)).toContain("ac-live-events");
+  });
+
+  it("retries once when liveEvents exist but replay yields no airline", async () => {
+    const { loadActionLog } = await import("@acars/nostr");
+    const pubkey = "comp-retry-live-events";
+    const loadActionLogMock = loadActionLog as unknown as ReturnType<typeof vi.fn>;
+    loadActionLogMock.mockResolvedValue([]);
+
+    const { state } = createSliceState({
+      competitors: new Map(),
+      fleetByOwner: buildFleetIndex([]),
+      routesByOwner: buildRoutesIndex([]),
+    });
+
+    await state.syncCompetitor(pubkey, [
+      {
+        event: { id: "live-tick-only", author: { pubkey }, created_at: 1 },
+        action: {
+          schemaVersion: 2,
+          action: "TICK_UPDATE",
+          payload: { tick: 123 },
+        },
+      },
+    ]);
+
+    const competitorTargetCalls = loadActionLogMock.mock.calls.filter(
+      (call) => call[0]?.authors?.[0] === pubkey,
+    );
+    expect(competitorTargetCalls).toHaveLength(2);
+    expect(state.competitors.has(pubkey)).toBe(false);
+  }, 10000);
+});

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -674,6 +674,42 @@ describe("syncCompetitor", () => {
     expect(state.fleetByOwner.get(pubkey)?.map((ac) => ac.id)).toContain("ac-live-events");
   });
 
+  it("uses recent cached global actions even when cache is empty", async () => {
+    const { loadActionLog } = await import("@acars/nostr");
+    const pubkey = "comp-empty-cache";
+    const loadActionLogMock = loadActionLog as unknown as ReturnType<typeof vi.fn>;
+    loadActionLogMock
+      .mockResolvedValueOnce([]) // syncWorld global
+      .mockResolvedValueOnce([
+        // syncCompetitor targeted
+        {
+          event: { id: "evt-create-empty-cache", author: { pubkey }, created_at: 1 },
+          action: {
+            schemaVersion: 2,
+            action: "AIRLINE_CREATE",
+            payload: {
+              name: "Empty Cache Air",
+              hubs: ["JFK"],
+              corporateBalance: 1000000000000,
+              tick: 10,
+            },
+          },
+        },
+      ]);
+
+    const { state } = createSliceState({
+      competitors: new Map(),
+      fleetByOwner: buildFleetIndex([]),
+      routesByOwner: buildRoutesIndex([]),
+    });
+
+    await state.syncWorld();
+    await state.syncCompetitor(pubkey);
+
+    expect(loadActionLogMock).toHaveBeenCalledTimes(2);
+    expect(state.competitors.has(pubkey)).toBe(true);
+  });
+
   it("merges liveEvents with targeted fetch and ignores duplicate event ids", async () => {
     const { loadActionLog } = await import("@acars/nostr");
     const pubkey = "comp-merge-live-events";
@@ -734,6 +770,67 @@ describe("syncCompetitor", () => {
 
     expect(state.competitors.has(pubkey)).toBe(true);
     expect(state.fleetByOwner.get(pubkey)?.map((ac) => ac.id)).toContain("ac-live-merged");
+  });
+
+  it("preserves existing fleet/routes when replay returns partial competitor state", async () => {
+    const { loadActionLog } = await import("@acars/nostr");
+    const pubkey = "comp-partial-replay";
+    const loadActionLogMock = loadActionLog as unknown as ReturnType<typeof vi.fn>;
+    loadActionLogMock
+      .mockResolvedValueOnce([
+        {
+          event: { id: "evt-create-partial", author: { pubkey }, created_at: 1 },
+          action: {
+            schemaVersion: 2,
+            action: "AIRLINE_CREATE",
+            payload: {
+              name: "Partial Replay Air",
+              hubs: ["JFK"],
+              corporateBalance: 1000000000000,
+              tick: 10,
+            },
+          },
+        },
+      ]) // competitor-targeted
+      .mockResolvedValueOnce([]); // global actions
+
+    const existingAirline = makeAirline(pubkey, 50);
+    existingAirline.fleetIds = ["ac-existing-1", "ac-existing-2"];
+    existingAirline.routeIds = ["route-existing-1"];
+    const existingFleet = [
+      makeAircraft("ac-existing-1", pubkey),
+      makeAircraft("ac-existing-2", pubkey),
+    ];
+    const existingRoutes: Route[] = [
+      {
+        id: "route-existing-1",
+        originIata: "JFK",
+        destinationIata: "LAX",
+        airlinePubkey: pubkey,
+        distanceKm: 3974,
+        assignedAircraftIds: ["ac-existing-1"],
+        fareEconomy: 100000 as FixedPoint,
+        fareBusiness: 200000 as FixedPoint,
+        fareFirst: 300000 as FixedPoint,
+        status: "active",
+      },
+    ];
+
+    const { state } = createSliceState({
+      competitors: new Map([[pubkey, existingAirline]]),
+      fleetByOwner: buildFleetIndex(existingFleet),
+      routesByOwner: buildRoutesIndex(existingRoutes),
+    });
+
+    await state.syncCompetitor(pubkey);
+
+    expect(state.competitors.has(pubkey)).toBe(true);
+    expect(state.fleetByOwner.get(pubkey)?.map((ac) => ac.id)).toEqual(
+      expect.arrayContaining(["ac-existing-1", "ac-existing-2"]),
+    );
+    expect(state.routesByOwner.get(pubkey)?.map((route) => route.id)).toEqual(
+      expect.arrayContaining(["route-existing-1"]),
+    );
   });
 
   it("retries once when liveEvents exist but replay yields no airline", async () => {

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -674,6 +674,68 @@ describe("syncCompetitor", () => {
     expect(state.fleetByOwner.get(pubkey)?.map((ac) => ac.id)).toContain("ac-live-events");
   });
 
+  it("merges liveEvents with targeted fetch and ignores duplicate event ids", async () => {
+    const { loadActionLog } = await import("@acars/nostr");
+    const pubkey = "comp-merge-live-events";
+
+    (loadActionLog as unknown as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce([
+        {
+          event: { id: "evt-create-1", author: { pubkey }, created_at: 1 },
+          action: {
+            schemaVersion: 2,
+            action: "AIRLINE_CREATE",
+            payload: {
+              name: "Merge Live Air",
+              hubs: ["JFK"],
+              corporateBalance: 1000000000000,
+              tick: 10,
+            },
+          },
+        },
+      ]) // competitor-targeted
+      .mockResolvedValueOnce([]); // global actions
+
+    const { state } = createSliceState({
+      competitors: new Map(),
+      fleetByOwner: buildFleetIndex([]),
+      routesByOwner: buildRoutesIndex([]),
+    });
+
+    await state.syncCompetitor(pubkey, [
+      {
+        event: { id: "evt-create-1", author: { pubkey }, created_at: 1 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRLINE_CREATE",
+          payload: {
+            name: "Merge Live Air",
+            hubs: ["JFK"],
+            corporateBalance: 1000000000000,
+            tick: 10,
+          },
+        },
+      },
+      {
+        event: { id: "evt-live-purchase-1", author: { pubkey }, created_at: 2 },
+        action: {
+          schemaVersion: 2,
+          action: "AIRCRAFT_PURCHASE",
+          payload: {
+            instanceId: "ac-live-merged",
+            modelId: "atr72-600",
+            price: 1000000,
+            deliveryHubIata: "JFK",
+            tick: 20,
+          },
+        },
+      },
+    ]);
+
+    expect(state.competitors.has(pubkey)).toBe(true);
+    expect(state.fleetByOwner.get(pubkey)?.map((ac) => ac.id)).toContain("ac-live-merged");
+  });
+
   it("retries once when liveEvents exist but replay yields no airline", async () => {
     const { loadActionLog } = await import("@acars/nostr");
     const pubkey = "comp-retry-live-events";
@@ -686,21 +748,29 @@ describe("syncCompetitor", () => {
       routesByOwner: buildRoutesIndex([]),
     });
 
-    await state.syncCompetitor(pubkey, [
-      {
-        event: { id: "live-tick-only", author: { pubkey }, created_at: 1 },
-        action: {
-          schemaVersion: 2,
-          action: "TICK_UPDATE",
-          payload: { tick: 123 },
+    vi.useFakeTimers();
+    try {
+      const syncPromise = state.syncCompetitor(pubkey, [
+        {
+          event: { id: "live-tick-only", author: { pubkey }, created_at: 1 },
+          action: {
+            schemaVersion: 2,
+            action: "TICK_UPDATE",
+            payload: { tick: 123 },
+          },
         },
-      },
-    ]);
+      ]);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(3000);
+      await syncPromise;
+    } finally {
+      vi.useRealTimers();
+    }
 
     const competitorTargetCalls = loadActionLogMock.mock.calls.filter(
       (call) => call[0]?.authors?.[0] === pubkey,
     );
     expect(competitorTargetCalls).toHaveLength(2);
     expect(state.competitors.has(pubkey)).toBe(false);
-  }, 10000);
+  });
 });

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -651,7 +651,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       try {
         // Reuse cached global actions if recent enough, otherwise fetch fresh.
         const useCachedGlobalActions =
-          cachedGlobalActions.length > 0 &&
+          cachedGlobalActionsTimestamp > 0 &&
           Date.now() - cachedGlobalActionsTimestamp < GLOBAL_ACTIONS_CACHE_TTL_MS;
         const globalActionsPromise = useCachedGlobalActions
           ? Promise.resolve(cachedGlobalActions)
@@ -732,9 +732,36 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           continue; // retry if attempts remain
         }
 
-        const airline = replayed.airline;
-        let resolvedFleet = replayed.fleet;
-        const resolvedRoutes = replayed.routes;
+        const freshState = get();
+        const existingAirline = freshState.competitors.get(competitorPubkey);
+        const existingFleet = freshState.fleetByOwner.get(competitorPubkey) || [];
+        const existingRoutes = freshState.routesByOwner.get(competitorPubkey) || [];
+
+        const airline =
+          existingAirline == null
+            ? replayed.airline
+            : {
+                ...existingAirline,
+                ...replayed.airline,
+              };
+        let resolvedFleet =
+          existingFleet.length === 0
+            ? replayed.fleet
+            : Array.from(
+                new Map<string, AircraftInstance>([
+                  ...existingFleet.map((ac) => [ac.id, ac] as const),
+                  ...replayed.fleet.map((ac) => [ac.id, ac] as const),
+                ]).values(),
+              );
+        const resolvedRoutes =
+          existingRoutes.length === 0
+            ? replayed.routes
+            : Array.from(
+                new Map<string, Route>([
+                  ...existingRoutes.map((route) => [route.id, route] as const),
+                  ...replayed.routes.map((route) => [route.id, route] as const),
+                ]).values(),
+              );
 
         // Reconcile fleet positions to lastTick
         if (
@@ -781,7 +808,6 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
         }
 
         // Merge into existing state — only replace this competitor's data
-        const freshState = get();
         const updatedCompetitors = new Map(freshState.competitors);
         updatedCompetitors.set(competitorPubkey, airline);
 

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -9,6 +9,7 @@ import type {
 } from "@acars/core";
 import {
   computeCheckpointStateHash,
+  createLogger,
   fp,
   fpAdd,
   fpFormat,
@@ -21,6 +22,7 @@ import {
 } from "@acars/core";
 import { getAircraftById, getHubPricingForIata } from "@acars/data";
 import { getNDK, loadActionLog, loadCheckpoints, MARKETPLACE_KIND, NDKEvent } from "@acars/nostr";
+import type { ActionLogEntry } from "@acars/nostr";
 import type { StateCreator } from "zustand";
 import { replayActionLog } from "../actionReducer";
 import { useEngineStore } from "../engine";
@@ -38,7 +40,7 @@ export interface WorldSlice {
   routesByOwner: Map<string, Route[]>;
   viewAs: (pubkey: string | null) => void;
   syncWorld: (options?: { force?: boolean }) => Promise<void>;
-  syncCompetitor: (competitorPubkey: string) => Promise<void>;
+  syncCompetitor: (competitorPubkey: string, liveEvents?: ActionLogEntry[]) => Promise<void>;
   /**
    * Re-project all competitor fleets to the given tick using the pure
    * `reconcileFleetToTick` function.  Called every tick from the pipeline
@@ -50,6 +52,13 @@ export interface WorldSlice {
 let isSyncingWorld = false;
 let pendingSyncWorldOptions: { force?: boolean } | null = null;
 const MONTH_TICKS = TICKS_PER_MONTH;
+const worldLogger = createLogger("WorldSync");
+
+// Cached global actions from the last syncWorld() call.
+// Reused by syncCompetitor() to avoid redundant 10K-event fetches.
+let cachedGlobalActions: ActionLogEntry[] = [];
+let cachedGlobalActionsTimestamp = 0;
+const GLOBAL_ACTIONS_CACHE_TTL_MS = 60_000;
 
 /** @internal — test-only helper to reset module-level concurrency flags */
 export function _resetWorldFlags() {
@@ -219,6 +228,11 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
       try {
         const existingState = get();
         const actions = await loadActionLog({ limit: 500, maxPages: 20 });
+
+        // Cache global actions for syncCompetitor() reuse
+        cachedGlobalActions = actions;
+        cachedGlobalActionsTimestamp = Date.now();
+
         const authorPubkeys = Array.from(
           new Set(actions.map((entry) => entry.event.author.pubkey)),
         );
@@ -618,173 +632,226 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
     }
   },
 
-  syncCompetitor: async (competitorPubkey: string) => {
+  syncCompetitor: async (competitorPubkey: string, liveEvents?: ActionLogEntry[]) => {
     const existingState = get();
     if (competitorPubkey === existingState.pubkey) return;
 
-    try {
-      // Targeted fetch for this competitor plus global marketplace buys for replay filtering.
-      const [actions, checkpoints, globalActions] = await Promise.all([
-        loadActionLog({
-          authors: [competitorPubkey],
-          limit: 500,
-          maxPages: 20,
-        }),
-        loadCheckpoints([competitorPubkey]),
-        loadActionLog({ limit: 500, maxPages: 20 }),
-      ]);
+    const maxAttempts = liveEvents && liveEvents.length > 0 ? 2 : 1;
 
-      if (actions.length === 0 && checkpoints.size === 0) return;
-
-      const checkpoint = await verifyCheckpointInternalConsistency(
-        checkpoints.get(competitorPubkey) ?? null,
-        competitorPubkey,
-      );
-      let scopedEntries = actions;
-      if (checkpoint) {
-        scopedEntries = scopeActionsToCheckpoint(actions, checkpoint);
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) {
+        worldLogger.info(
+          `Retrying sync for ${competitorPubkey.slice(0, 8)}... (attempt ${attempt + 1})`,
+        );
+        await new Promise((r) => setTimeout(r, 3000));
       }
 
-      const rejectedBuyEventIds = computeRejectedBuyEventIds(globalActions);
+      try {
+        // Reuse cached global actions if recent enough, otherwise fetch fresh.
+        const globalActionsPromise =
+          cachedGlobalActions.length > 0 &&
+          Date.now() - cachedGlobalActionsTimestamp < GLOBAL_ACTIONS_CACHE_TTL_MS
+            ? Promise.resolve(cachedGlobalActions)
+            : loadActionLog({ limit: 500, maxPages: 20 });
 
-      const replayed = await replayActionLog({
-        pubkey: competitorPubkey,
-        actions: scopedEntries.map((entry) => ({
-          action: entry.action,
-          eventId: entry.event.id,
-          authorPubkey: entry.event.author.pubkey,
-          createdAt: entry.event.created_at ?? null,
-        })),
-        checkpoint,
-        rejectedEventIds: rejectedBuyEventIds,
-      });
+        // Targeted fetch for this competitor plus global marketplace buys for replay filtering.
+        const [fetchedActions, checkpoints, globalActions] = await Promise.all([
+          loadActionLog({
+            authors: [competitorPubkey],
+            limit: 500,
+            maxPages: 20,
+          }),
+          loadCheckpoints([competitorPubkey]),
+          globalActionsPromise,
+        ]);
 
-      if (!replayed.airline) return;
-
-      const airline = replayed.airline;
-      let resolvedFleet = replayed.fleet;
-      const resolvedRoutes = replayed.routes;
-
-      // Reconcile fleet positions to lastTick
-      if (
-        airline.status !== "chapter11" &&
-        airline.status !== "liquidated" &&
-        airline.lastTick != null &&
-        resolvedFleet.length > 0
-      ) {
-        const { fleet: reconciledFleet, balanceDelta } = reconcileFleetToTick(
-          resolvedFleet,
-          resolvedRoutes,
-          airline.lastTick,
-        );
-        resolvedFleet = reconciledFleet;
-        airline.corporateBalance = fpAdd(airline.corporateBalance, balanceDelta);
-      }
-
-      // Project fleet forward to the current tick so the stored state is
-      // up-to-date.  This replaces the old processGlobalTick catch-up.
-      const currentTick = useEngineStore.getState().tick;
-      if (
-        airline.status !== "chapter11" &&
-        airline.status !== "liquidated" &&
-        currentTick > 0 &&
-        (airline.lastTick == null || currentTick > airline.lastTick)
-      ) {
-        const { fleet: projectedFleet, balanceDelta } = reconcileFleetToTick(
-          resolvedFleet,
-          resolvedRoutes,
-          currentTick,
-        );
-        resolvedFleet = projectedFleet;
-        airline.corporateBalance = fpAdd(airline.corporateBalance, balanceDelta);
-        // Apply monthly recurring costs (hub opex, lease payments) for any
-        // month boundaries crossed during projection — mirrors syncWorld logic.
-        airline.corporateBalance = applyMonthlyCosts(
-          airline.corporateBalance,
-          airline.hubs,
-          resolvedFleet,
-          airline.lastTick ?? 0,
-          currentTick,
-        );
-        airline.lastTick = currentTick;
-      }
-
-      // Merge into existing state — only replace this competitor's data
-      const freshState = get();
-      const updatedCompetitors = new Map(freshState.competitors);
-      updatedCompetitors.set(competitorPubkey, airline);
-
-      // Update unified fleet/routes maps: replace this competitor's entry in-place
-      const updatedFleetByOwner = new Map(freshState.fleetByOwner);
-      updatedFleetByOwner.set(competitorPubkey, resolvedFleet);
-
-      const updatedRoutesByOwner = new Map(freshState.routesByOwner);
-      updatedRoutesByOwner.set(competitorPubkey, resolvedRoutes);
-
-      // Rebuild route registry: remove old offers from this competitor, add new ones
-      const updatedRegistry = new Map(freshState.globalRouteRegistry);
-      // Remove all offers from this competitor
-      for (const [key, offers] of updatedRegistry) {
-        const filtered = offers.filter((o) => o.airlinePubkey !== competitorPubkey);
-        if (filtered.length > 0) {
-          updatedRegistry.set(key, filtered);
-        } else {
-          updatedRegistry.delete(key);
+        // Merge live-received events into the fetched action log.
+        // This ensures events not yet indexed by relays are still replayed.
+        const seenIds = new Set(fetchedActions.map((e) => e.event.id));
+        const mergedActions = [...fetchedActions];
+        if (liveEvents) {
+          for (const entry of liveEvents) {
+            if (!seenIds.has(entry.event.id)) {
+              mergedActions.push(entry);
+              seenIds.add(entry.event.id);
+            }
+          }
         }
-      }
-      // Add new offers from this competitor
-      for (const route of resolvedRoutes) {
-        if (route.status !== "active") continue;
-        const frequency = Math.max(0, route.assignedAircraftIds.length * 7);
-        if (frequency === 0) continue;
+        // Sort by timestamp for deterministic replay
+        mergedActions.sort((a, b) => {
+          const aTime = a.event.created_at ?? 0;
+          const bTime = b.event.created_at ?? 0;
+          if (aTime !== bTime) return aTime - bTime;
+          return a.event.id.localeCompare(b.event.id);
+        });
 
-        let avgTravelTime = 0;
-        if (route.assignedAircraftIds.length > 0) {
-          const modelIds = route.assignedAircraftIds
-            .map((id: string) => {
-              const ac = resolvedFleet.find((a: AircraftInstance) => a.id === id);
-              return ac?.modelId;
-            })
-            .filter(Boolean);
-          const times = modelIds.map((mid: string | undefined) => {
-            const model = getAircraftById(mid!);
-            if (!model) return 480;
-            return (route.distanceKm / (model.speedKmh || 800)) * 60;
-          });
-          avgTravelTime =
-            times.length > 0
-              ? times.reduce((a: number, b: number) => a + b, 0) / times.length
-              : 480;
+        if (mergedActions.length === 0 && checkpoints.size === 0) {
+          worldLogger.info(
+            `No actions or checkpoints found for ${competitorPubkey.slice(0, 8)}...` +
+              (liveEvents?.length ? ` (had ${liveEvents.length} live event(s))` : ""),
+          );
+          continue; // retry if we had live events
         }
 
-        const key = `${route.originIata}-${route.destinationIata}`;
-        const offers = updatedRegistry.get(key) || [];
-        const offer: FlightOffer = {
-          airlinePubkey: airline.ceoPubkey,
-          fareEconomy: route.fareEconomy,
-          fareBusiness: route.fareBusiness,
-          fareFirst: route.fareFirst,
-          frequencyPerWeek: frequency,
-          travelTimeMinutes: Math.round(avgTravelTime) || 480,
-          stops: 0,
-          serviceScore: 0.7,
-          brandScore: airline.brandScore || 0.5,
-        };
-        offers.push(offer);
-        updatedRegistry.set(key, offers);
-      }
+        const checkpoint = await verifyCheckpointInternalConsistency(
+          checkpoints.get(competitorPubkey) ?? null,
+          competitorPubkey,
+        );
+        let scopedEntries = mergedActions;
+        if (checkpoint) {
+          scopedEntries = scopeActionsToCheckpoint(mergedActions, checkpoint);
+        }
 
-      set({
-        competitors: updatedCompetitors,
-        fleetByOwner: updatedFleetByOwner,
-        routesByOwner: updatedRoutesByOwner,
-        globalRouteRegistry: updatedRegistry,
-      });
-    } catch (error) {
-      console.error(
-        `[WorldSlice] Failed to sync competitor ${competitorPubkey.slice(0, 8)}...:`,
-        error,
-      );
+        const rejectedBuyEventIds = computeRejectedBuyEventIds(globalActions);
+
+        const replayed = await replayActionLog({
+          pubkey: competitorPubkey,
+          actions: scopedEntries.map((entry) => ({
+            action: entry.action,
+            eventId: entry.event.id,
+            authorPubkey: entry.event.author.pubkey,
+            createdAt: entry.event.created_at ?? null,
+          })),
+          checkpoint,
+          rejectedEventIds: rejectedBuyEventIds,
+        });
+
+        if (!replayed.airline) {
+          worldLogger.warn(
+            `Replay produced no airline for ${competitorPubkey.slice(0, 8)}... ` +
+              `(${scopedEntries.length} scoped actions, checkpoint: ${checkpoint ? "yes" : "no"})`,
+          );
+          continue; // retry if attempts remain
+        }
+
+        const airline = replayed.airline;
+        let resolvedFleet = replayed.fleet;
+        const resolvedRoutes = replayed.routes;
+
+        // Reconcile fleet positions to lastTick
+        if (
+          airline.status !== "chapter11" &&
+          airline.status !== "liquidated" &&
+          airline.lastTick != null &&
+          resolvedFleet.length > 0
+        ) {
+          const { fleet: reconciledFleet, balanceDelta } = reconcileFleetToTick(
+            resolvedFleet,
+            resolvedRoutes,
+            airline.lastTick,
+          );
+          resolvedFleet = reconciledFleet;
+          airline.corporateBalance = fpAdd(airline.corporateBalance, balanceDelta);
+        }
+
+        // Project fleet forward to the current tick so the stored state is
+        // up-to-date.  This replaces the old processGlobalTick catch-up.
+        const currentTick = useEngineStore.getState().tick;
+        if (
+          airline.status !== "chapter11" &&
+          airline.status !== "liquidated" &&
+          currentTick > 0 &&
+          (airline.lastTick == null || currentTick > airline.lastTick)
+        ) {
+          const { fleet: projectedFleet, balanceDelta } = reconcileFleetToTick(
+            resolvedFleet,
+            resolvedRoutes,
+            currentTick,
+          );
+          resolvedFleet = projectedFleet;
+          airline.corporateBalance = fpAdd(airline.corporateBalance, balanceDelta);
+          // Apply monthly recurring costs (hub opex, lease payments) for any
+          // month boundaries crossed during projection — mirrors syncWorld logic.
+          airline.corporateBalance = applyMonthlyCosts(
+            airline.corporateBalance,
+            airline.hubs,
+            resolvedFleet,
+            airline.lastTick ?? 0,
+            currentTick,
+          );
+          airline.lastTick = currentTick;
+        }
+
+        // Merge into existing state — only replace this competitor's data
+        const freshState = get();
+        const updatedCompetitors = new Map(freshState.competitors);
+        updatedCompetitors.set(competitorPubkey, airline);
+
+        // Update unified fleet/routes maps: replace this competitor's entry in-place
+        const updatedFleetByOwner = new Map(freshState.fleetByOwner);
+        updatedFleetByOwner.set(competitorPubkey, resolvedFleet);
+
+        const updatedRoutesByOwner = new Map(freshState.routesByOwner);
+        updatedRoutesByOwner.set(competitorPubkey, resolvedRoutes);
+
+        // Rebuild route registry: remove old offers from this competitor, add new ones
+        const updatedRegistry = new Map(freshState.globalRouteRegistry);
+        // Remove all offers from this competitor
+        for (const [key, offers] of updatedRegistry) {
+          const filtered = offers.filter((o) => o.airlinePubkey !== competitorPubkey);
+          if (filtered.length > 0) {
+            updatedRegistry.set(key, filtered);
+          } else {
+            updatedRegistry.delete(key);
+          }
+        }
+        // Add new offers from this competitor
+        for (const route of resolvedRoutes) {
+          if (route.status !== "active") continue;
+          const frequency = Math.max(0, route.assignedAircraftIds.length * 7);
+          if (frequency === 0) continue;
+
+          let avgTravelTime = 0;
+          if (route.assignedAircraftIds.length > 0) {
+            const modelIds = route.assignedAircraftIds
+              .map((id: string) => {
+                const ac = resolvedFleet.find((a: AircraftInstance) => a.id === id);
+                return ac?.modelId;
+              })
+              .filter(Boolean);
+            const times = modelIds.map((mid: string | undefined) => {
+              const model = getAircraftById(mid!);
+              if (!model) return 480;
+              return (route.distanceKm / (model.speedKmh || 800)) * 60;
+            });
+            avgTravelTime =
+              times.length > 0
+                ? times.reduce((a: number, b: number) => a + b, 0) / times.length
+                : 480;
+          }
+
+          const key = `${route.originIata}-${route.destinationIata}`;
+          const offers = updatedRegistry.get(key) || [];
+          const offer: FlightOffer = {
+            airlinePubkey: airline.ceoPubkey,
+            fareEconomy: route.fareEconomy,
+            fareBusiness: route.fareBusiness,
+            fareFirst: route.fareFirst,
+            frequencyPerWeek: frequency,
+            travelTimeMinutes: Math.round(avgTravelTime) || 480,
+            stops: 0,
+            serviceScore: 0.7,
+            brandScore: airline.brandScore || 0.5,
+          };
+          offers.push(offer);
+          updatedRegistry.set(key, offers);
+        }
+
+        set({
+          competitors: updatedCompetitors,
+          fleetByOwner: updatedFleetByOwner,
+          routesByOwner: updatedRoutesByOwner,
+          globalRouteRegistry: updatedRegistry,
+        });
+
+        // Success — no need to retry
+        return;
+      } catch (error) {
+        worldLogger.warn(
+          `Failed to sync competitor ${competitorPubkey.slice(0, 8)}... (attempt ${attempt + 1}/${maxAttempts}):`,
+          error,
+        );
+      }
     }
   },
 });

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -64,6 +64,8 @@ const GLOBAL_ACTIONS_CACHE_TTL_MS = 60_000;
 export function _resetWorldFlags() {
   isSyncingWorld = false;
   pendingSyncWorldOptions = null;
+  cachedGlobalActions = [];
+  cachedGlobalActionsTimestamp = 0;
 }
 
 const buildFleetIndex = (fleet: AircraftInstance[]) => {
@@ -648,11 +650,12 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
 
       try {
         // Reuse cached global actions if recent enough, otherwise fetch fresh.
-        const globalActionsPromise =
+        const useCachedGlobalActions =
           cachedGlobalActions.length > 0 &&
-          Date.now() - cachedGlobalActionsTimestamp < GLOBAL_ACTIONS_CACHE_TTL_MS
-            ? Promise.resolve(cachedGlobalActions)
-            : loadActionLog({ limit: 500, maxPages: 20 });
+          Date.now() - cachedGlobalActionsTimestamp < GLOBAL_ACTIONS_CACHE_TTL_MS;
+        const globalActionsPromise = useCachedGlobalActions
+          ? Promise.resolve(cachedGlobalActions)
+          : loadActionLog({ limit: 500, maxPages: 20 });
 
         // Targeted fetch for this competitor plus global marketplace buys for replay filtering.
         const [fetchedActions, checkpoints, globalActions] = await Promise.all([
@@ -664,6 +667,11 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           loadCheckpoints([competitorPubkey]),
           globalActionsPromise,
         ]);
+
+        if (!useCachedGlobalActions) {
+          cachedGlobalActions = globalActions;
+          cachedGlobalActionsTimestamp = Date.now();
+        }
 
         // Merge live-received events into the fetched action log.
         // This ensures events not yet indexed by relays are still replayed.

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -820,9 +820,10 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
 
         // Rebuild route registry: remove old offers from this competitor, add new ones
         const updatedRegistry = new Map(freshState.globalRouteRegistry);
+        const ownerPubkey = airline.ceoPubkey;
         // Remove all offers from this competitor
         for (const [key, offers] of updatedRegistry) {
-          const filtered = offers.filter((o) => o.airlinePubkey !== competitorPubkey);
+          const filtered = offers.filter((o) => o.airlinePubkey !== ownerPubkey);
           if (filtered.length > 0) {
             updatedRegistry.set(key, filtered);
           } else {
@@ -857,7 +858,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           const key = `${route.originIata}-${route.destinationIata}`;
           const offers = updatedRegistry.get(key) || [];
           const offer: FlightOffer = {
-            airlinePubkey: airline.ceoPubkey,
+            airlinePubkey: ownerPubkey,
             fareEconomy: route.fareEconomy,
             fareBusiness: route.fareBusiness,
             fareFirst: route.fareFirst,

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -8,7 +8,7 @@ import type {
   Route,
   TimelineEvent,
 } from "@acars/core";
-import type { MarketplaceListing } from "@acars/nostr";
+import type { ActionLogEntry, MarketplaceListing } from "@acars/nostr";
 import type { CreateAirlineParams } from "./slices/identitySlice";
 import type { HubAction } from "./slices/networkSlice";
 
@@ -75,6 +75,6 @@ export interface AirlineState {
   routesByOwner: Map<string, Route[]>;
   viewAs: (pubkey: string | null) => void;
   syncWorld: (options?: { force?: boolean }) => Promise<void>;
-  syncCompetitor: (competitorPubkey: string) => Promise<void>;
+  syncCompetitor: (competitorPubkey: string, liveEvents?: ActionLogEntry[]) => Promise<void>;
   projectCompetitorFleet: (tick: number) => void;
 }


### PR DESCRIPTION
## Summary
- Caches live Nostr events to prevent refetch on every tick
- Adds retry logic for competitor sync failures
- Improves reliability of real-time competitor state updates

## Context
This was originally part of PR #46 but split into a separate PR for cleaner review.

## Files Changed
- `packages/store/src/airline.ts` — Event caching and retry logic
- `packages/store/src/slices/worldSlice.ts` — Sync improvements
- `packages/store/src/types.ts` — Type updates

## Note
Split from PR #46 to separate code changes from documentation (ACDP → PR #48).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live events are now buffered per competitor, preserved per-entry, de-duplicated, and synced as batched replays.

* **Bug Fixes**
  * Safer replay and retry flows with non-fatal warnings, preserved competitor state on partial results, and more deterministic merging.

* **Performance Improvements**
  * Shared global actions cache and per-competitor batching reduce redundant work and improve sync efficiency.

* **Tests**
  * Added/updated tests for per-competitor replay, deduplication, retries, and live-event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->