### PR TITLE
fix(store): include authoritative fleet/route IDs in TICK_UPDATE events

### DIFF
--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -170,6 +170,12 @@ export async function replayActionLog(params: {
   let allowActionTimeline = timeline.length === 0;
   let actionChainHash = checkpoint?.actionChainHash ?? "";
 
+  // Track the most recent authoritative fleet/route IDs from TICK_UPDATE.
+  // These override locally-derived IDs at the end of replay, fixing
+  // count divergence when action events are missing from relay delivery.
+  let authoritativeFleetIds: string[] | null = null;
+  let authoritativeRouteIds: string[] | null = null;
+
   if (checkpoint?.fleet) {
     for (const aircraft of checkpoint.fleet) {
       fleetById.set(aircraft.id, { ...aircraft });
@@ -456,6 +462,15 @@ export async function replayActionLog(params: {
           airline = { ...airline, status: status as AirlineEntity["status"] };
         }
 
+        // Track authoritative fleet/route IDs from the TICK_UPDATE payload.
+        // The publishing client includes these from its local state, so they
+        // reflect the true set of aircraft and routes regardless of whether
+        // the viewer received every individual action event.
+        const payloadFleetIds = asStringArray(payload.fleetIds);
+        const payloadRouteIds = asStringArray(payload.routeIds);
+        if (payloadFleetIds.length > 0) authoritativeFleetIds = payloadFleetIds;
+        if (payloadRouteIds.length > 0) authoritativeRouteIds = payloadRouteIds;
+
         if (airline.status === "chapter11" || airline.status === "liquidated") {
           const groundedFleet = Array.from(fleetById.values()).map((aircraft) => {
             if (aircraft.status === "enroute") {
@@ -518,6 +533,22 @@ export async function replayActionLog(params: {
           fleetById.clear();
           for (const aircraft of reconciledFleet) {
             fleetById.set(aircraft.id, aircraft);
+          }
+        }
+
+        // Prune aircraft/routes that the authoritative TICK_UPDATE says no
+        // longer exist (e.g. sold aircraft, closed routes).  This prevents
+        // ghost entries from lingering in the viewer's reconstruction.
+        if (authoritativeFleetIds) {
+          const validFleetSet = new Set(authoritativeFleetIds);
+          for (const id of fleetById.keys()) {
+            if (!validFleetSet.has(id)) fleetById.delete(id);
+          }
+        }
+        if (authoritativeRouteIds) {
+          const validRouteSet = new Set(authoritativeRouteIds);
+          for (const id of routesById.keys()) {
+            if (!validRouteSet.has(id)) routesById.delete(id);
           }
         }
 
@@ -1195,10 +1226,15 @@ export async function replayActionLog(params: {
 
   fleet = Array.from(fleetById.values());
   if (airline) {
+    // Use authoritative fleet/route IDs from the most recent TICK_UPDATE
+    // when available.  This ensures counts match what the airline owner
+    // published, even if the viewer is missing some action events from
+    // relay delivery.  Fall back to locally-derived IDs for old events
+    // that predate this field.
     airline = {
       ...airline,
-      fleetIds: fleet.map((aircraft) => aircraft.id),
-      routeIds: routes.map((route) => route.id),
+      fleetIds: authoritativeFleetIds ?? fleet.map((aircraft) => aircraft.id),
+      routeIds: authoritativeRouteIds ?? routes.map((route) => route.id),
       timeline,
     };
   }

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -147,6 +147,8 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
               status: "chapter11",
               tick,
               corporateBalance: updatedAirline.corporateBalance,
+              fleetIds: groundedFleet.map((ac) => ac.id),
+              routeIds: routes.map((r) => r.id),
               timeline: get().timeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
             },
           },
@@ -311,6 +313,8 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
               payload: {
                 tick: tickUpdateTick,
                 corporateBalance: updatedAirline.corporateBalance,
+                fleetIds: currentFleet.map((ac) => ac.id),
+                routeIds: routes.map((r) => r.id),
                 timeline: currentTimeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
               },
             },
@@ -880,6 +884,8 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             payload: {
               tick: tickUpdateTick,
               corporateBalance: currentBalance,
+              fleetIds: currentFleet.map((ac) => ac.id),
+              routeIds: routes.map((r) => r.id),
               timeline: currentTimeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
             },
           },

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -279,32 +279,58 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
           const resolvedRoutes = replayed.routes;
 
           // Merge strategy: always use the replayed airline entity (it has the
-          // latest name, hubs, balance, etc.) but protect against partial relay
-          // responses that return fewer actions than expected, which can produce
-          // an empty fleet even though the competitor actually has aircraft.
+          // latest name, hubs, balance, etc.) and use authoritative fleet/route
+          // IDs from TICK_UPDATE to guide object reconciliation.
           //
-          // The previous staleness guard compared existingCompetitor.lastTick
-          // (inflated to currentTick by local projection every 3s) against
-          // replayed.lastTick and discarded the replay whenever projection had
-          // run.  This caused newly purchased aircraft to never appear for
-          // competitors because the locally-projected stale fleet always "won."
-          //
-          // New approach: if the replay produced strictly fewer aircraft than
-          // we already know about, keep the existing fleet/routes (partial relay
-          // protection).  Otherwise, take the fresh replay (new aircraft appear).
+          // airline.fleetIds/routeIds now carry authoritative counts from the
+          // most recent TICK_UPDATE, so the leaderboard always shows correct
+          // counts.  For the actual fleet/route objects, we merge replayed and
+          // existing data: replayed objects are preferred (freshest state), but
+          // existing objects fill gaps for IDs the replay missed due to relay
+          // delivery issues.
           const existingCompetitorFleet = existingState.fleetByOwner.get(authorPubkey) || [];
           const existingCompetitorRoutes = existingState.routesByOwner.get(authorPubkey) || [];
 
-          if (
+          const authoritativeFleetSet = new Set(airline.fleetIds);
+          const authoritativeRouteSet = new Set(airline.routeIds);
+
+          if (authoritativeFleetSet.size > 0) {
+            // Merge: start with replayed fleet, fill gaps from existing state,
+            // keep only IDs in the authoritative set.
+            const mergedFleetById = new Map<string, AircraftInstance>();
+            for (const ac of existingCompetitorFleet) {
+              if (authoritativeFleetSet.has(ac.id)) mergedFleetById.set(ac.id, ac);
+            }
+            // Replayed objects overwrite existing (they have fresher state).
+            for (const ac of resolvedFleet) {
+              if (authoritativeFleetSet.has(ac.id)) mergedFleetById.set(ac.id, ac);
+            }
+            resolvedFleet = Array.from(mergedFleetById.values());
+          } else if (
             existingCompetitorFleet.length > 0 &&
             resolvedFleet.length < existingCompetitorFleet.length
           ) {
+            // Fallback for old TICK_UPDATEs without authoritative IDs:
+            // keep existing fleet if replay produced fewer objects.
             resolvedFleet = existingCompetitorFleet;
           }
-          const finalRoutes =
-            existingCompetitorRoutes.length > resolvedRoutes.length
-              ? existingCompetitorRoutes
-              : resolvedRoutes;
+
+          let finalRoutes = resolvedRoutes;
+          if (authoritativeRouteSet.size > 0) {
+            const mergedRoutesById = new Map<string, Route>();
+            for (const r of existingCompetitorRoutes) {
+              if (authoritativeRouteSet.has(r.id)) mergedRoutesById.set(r.id, r);
+            }
+            for (const r of resolvedRoutes) {
+              if (authoritativeRouteSet.has(r.id)) mergedRoutesById.set(r.id, r);
+            }
+            finalRoutes = Array.from(mergedRoutesById.values());
+          } else {
+            finalRoutes =
+              existingCompetitorRoutes.length > resolvedRoutes.length
+                ? existingCompetitorRoutes
+                : resolvedRoutes;
+          }
 
           // Reconcile fleet positions to lastTick — same fix as player identity.
           // Without this, checkpoint fleet has stale arrivalTick/turnaroundEndTick


### PR DESCRIPTION
## Summary
- Adds `fleetIds` and `routeIds` to TICK_UPDATE event payloads, providing authoritative counts from the airline owner's local state
- Viewers now track these authoritative IDs during replay and use them to reconcile fleet/route objects, fixing count divergence when action events are missing from relay delivery
- Implements merge strategy that prefers replayed objects (freshest state) while filling gaps from existing state for IDs the replay missed

## Problem
When action events (aircraft purchases, route closures, etc.) are not delivered by relays to viewers, the reconstructed state would have divergent aircraft/route counts compared to what the airline owner sees. This caused leaderboard inconsistencies and ghost entries.

## Solution
TICK_UPDATE events now include the owner's authoritative `fleetIds` and `routeIds`. Viewers use these to:
1. Prune aircraft/routes that no longer exist (sold aircraft, closed routes)
2. Merge replayed and existing objects, preferring freshest state while keeping authoritative IDs
3. Ensure counts always match what the airline owner published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fleet and route data synchronization to maintain accuracy during game state updates and recovery scenarios.
  
* **Improvements**
  * Implemented authoritative tracking for fleet and route information to ensure consistency across system replays and synchronization events.
  * Enhanced data reconciliation logic to prioritize server-provided fleet and route details while preserving existing data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->