### PR TITLE
feat: add permalink routes for airports and aircraft

### DIFF
--- a/apps/web/src/features/fleet/components/FleetManager.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.tsx
@@ -30,6 +30,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getRouteDemandSnapshot } from "@/features/network/hooks/useRouteDemand";
 import { useConfirm } from "@/shared/lib/useConfirm";
+import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
 import { getAircraftBaseHub } from "../utils/aircraftBaseHub";
 import { getAircraftTimer } from "../utils/aircraftTimers";
 import { AircraftDealer } from "./AircraftDealer";
@@ -255,12 +256,6 @@ export function FleetManager() {
               const isAssignmentLocked = ac.status === "enroute";
               const isScrapLocked = ac.status !== "idle";
               const baseHub = getAircraftBaseHub(ac, routes, airline);
-              const locationLabel =
-                ac.status === "enroute" && ac.flight
-                  ? `Enroute: ${ac.flight.originIata} → ${ac.flight.destinationIata}`
-                  : ac.status === "delivery"
-                    ? `Delivery to ${ac.baseAirportIata}`
-                    : `At ${ac.baseAirportIata}`;
 
               return (
                 <div
@@ -301,13 +296,12 @@ export function FleetManager() {
                         </span>
                       ) : (
                         <span
-                          className={`inline-flex items-center rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-widest ${
-                            ac.status === "idle"
-                              ? ac.assignedRouteId
-                                ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
-                                : "bg-primary/20 text-primary border border-primary/30"
-                              : "bg-orange-500/20 text-orange-400 border border-orange-500/30"
-                          }`}
+                          className={`inline-flex items-center rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-widest ${ac.status === "idle"
+                            ? ac.assignedRouteId
+                              ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
+                              : "bg-primary/20 text-primary border border-primary/30"
+                            : "bg-orange-500/20 text-orange-400 border border-orange-500/30"
+                            }`}
                         >
                           {ac.status === "idle" && ac.assignedRouteId ? "assigned" : ac.status}
                         </span>
@@ -346,14 +340,33 @@ export function FleetManager() {
                           Current Location
                         </p>
                         <p className="font-mono text-xs text-foreground font-bold">
-                          {locationLabel}
+                          {ac.status === "enroute" && ac.flight ? (
+                            <>
+                              Enroute:{" "}
+                              <button type="button" onClick={() => navigateToAirport(ac.flight!.originIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.flight.originIata}</button>
+                              {" → "}
+                              <button type="button" onClick={() => navigateToAirport(ac.flight!.destinationIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.flight.destinationIata}</button>
+                            </>
+                          ) : ac.status === "delivery" ? (
+                            <>
+                              Delivery to{" "}
+                              <button type="button" onClick={() => navigateToAirport(ac.baseAirportIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.baseAirportIata}</button>
+                            </>
+                          ) : (
+                            <>
+                              At{" "}
+                              <button type="button" onClick={() => navigateToAirport(ac.baseAirportIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.baseAirportIata}</button>
+                            </>
+                          )}
                         </p>
                       </div>
                       <div>
                         <p className="text-[10px] uppercase text-muted-foreground font-semibold mb-0.5">
                           Base Hub
                         </p>
-                        <p className="font-mono text-xs text-accent font-bold">{baseHub}</p>
+                        <p className="font-mono text-xs text-accent font-bold">
+                          <button type="button" onClick={() => navigateToAirport(baseHub)} className="hover:text-primary transition-colors cursor-pointer">{baseHub}</button>
+                        </p>
                       </div>
                       <div>
                         <p className="text-[10px] uppercase text-muted-foreground font-semibold mb-0.5">
@@ -469,7 +482,9 @@ export function FleetManager() {
                                 Route
                               </span>
                               <span className="text-xs font-bold text-foreground">
-                                {lastLanding.originIata} &rarr; {lastLanding.destinationIata}
+                                <button type="button" onClick={() => navigateToAirport(lastLanding.originIata!)} className="hover:text-primary transition-colors cursor-pointer">{lastLanding.originIata}</button>
+                                {" → "}
+                                <button type="button" onClick={() => navigateToAirport(lastLanding.destinationIata!)} className="hover:text-primary transition-colors cursor-pointer">{lastLanding.destinationIata}</button>
                               </span>
                             </div>
                             <div className="flex flex-col text-right">
@@ -498,26 +513,24 @@ export function FleetManager() {
                                   Load Factor
                                 </span>
                                 <span
-                                  className={`text-[10px] font-mono font-black ${
-                                    lf >= 0.85
-                                      ? "text-emerald-400"
-                                      : lf >= 0.6
-                                        ? "text-yellow-400"
-                                        : "text-red-400"
-                                  }`}
+                                  className={`text-[10px] font-mono font-black ${lf >= 0.85
+                                    ? "text-emerald-400"
+                                    : lf >= 0.6
+                                      ? "text-yellow-400"
+                                      : "text-red-400"
+                                    }`}
                                 >
                                   {Math.round(lf * 100)}%
                                 </span>
                               </div>
                               <div className="h-1 w-full bg-muted/30 rounded-full overflow-hidden mb-3">
                                 <div
-                                  className={`h-full rounded-full transition-all ${
-                                    lf >= 0.85
-                                      ? "bg-emerald-500"
-                                      : lf >= 0.6
-                                        ? "bg-yellow-500"
-                                        : "bg-red-500"
-                                  }`}
+                                  className={`h-full rounded-full transition-all ${lf >= 0.85
+                                    ? "bg-emerald-500"
+                                    : lf >= 0.6
+                                      ? "bg-yellow-500"
+                                      : "bg-red-500"
+                                    }`}
                                   style={{ width: `${Math.round(lf * 100)}%` }}
                                 />
                               </div>

--- a/apps/web/src/features/network/components/AircraftInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AircraftInfoPanel.tsx
@@ -146,11 +146,16 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
   };
 
   useEffect(() => {
+    let armed = false;
+    const timer = setTimeout(() => { armed = true; }, 300);
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape" && armed) onClose();
     };
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("keydown", onKeyDown);
+    };
   }, [onClose]);
 
   useEffect(() => {
@@ -602,8 +607,8 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
           </div>
           <span
             className={`rounded-full px-2.5 py-1 text-[10px] uppercase tracking-widest font-semibold ${route.status === "active"
-                ? "bg-emerald-500/20 text-emerald-200"
-                : "bg-muted text-muted-foreground"
+              ? "bg-emerald-500/20 text-emerald-200"
+              : "bg-muted text-muted-foreground"
               }`}
           >
             {route.status}

--- a/apps/web/src/features/network/components/AircraftInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AircraftInfoPanel.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Plane, Route as RouteIcon, Wrench, X } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 import { getAircraftTimer } from "@/features/fleet/utils/aircraftTimers";
+import { navigateToAirport, navigateToAircraft } from "@/shared/lib/permalinkNavigation";
 
 type AircraftInfoPanelProps = {
   aircraft: AircraftInstance;
@@ -90,13 +91,13 @@ function FlightStrip({
     <div className="rounded-xl border border-sky-500/30 bg-sky-500/10 p-4 space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-mono font-bold text-foreground">{flight.originIata}</span>
+          <span className="text-sm font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(flight.originIata)}>{flight.originIata}</span>
           <div className="flex-1 flex items-center gap-1 text-muted-foreground">
             <div className="h-px flex-1 bg-sky-500/40" />
             <Plane className="h-3 w-3 text-sky-300" />
             <div className="h-px flex-1 bg-sky-500/40" />
           </div>
-          <span className="text-sm font-mono font-bold text-foreground">
+          <span className="text-sm font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(flight.destinationIata)}>
             {flight.destinationIata}
           </span>
         </div>
@@ -488,7 +489,11 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
                     Base
                   </p>
                   <p className="mt-1 text-sm font-mono font-semibold">
-                    {aircraft.baseAirportIata || "—"}
+                    {aircraft.baseAirportIata ? (
+                      <button type="button" onClick={() => navigateToAirport(aircraft.baseAirportIata)} className="hover:text-primary transition-colors cursor-pointer">
+                        {aircraft.baseAirportIata}
+                      </button>
+                    ) : "—"}
                   </p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/70 p-3">
@@ -497,7 +502,11 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
                   </p>
                   <p className="mt-1 text-sm font-mono font-semibold">
                     {assignedRoute
-                      ? `${assignedRoute.originIata} — ${assignedRoute.destinationIata}`
+                      ? <>
+                        <button type="button" onClick={() => navigateToAirport(assignedRoute.originIata)} className="hover:text-primary transition-colors cursor-pointer">{assignedRoute.originIata}</button>
+                        {" — "}
+                        <button type="button" onClick={() => navigateToAirport(assignedRoute.destinationIata)} className="hover:text-primary transition-colors cursor-pointer">{assignedRoute.destinationIata}</button>
+                      </>
                       : "Unassigned"}
                   </p>
                 </div>
@@ -556,7 +565,7 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-3">
             <div className="text-center min-w-0">
-              <span className="text-lg font-mono font-bold text-foreground">
+              <span className="text-lg font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(route.originIata)}>
                 {route.originIata}
               </span>
               {originAirport ? (
@@ -576,7 +585,7 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
               <div className="h-px w-4 bg-border" />
             </div>
             <div className="text-center min-w-0">
-              <span className="text-lg font-mono font-bold text-foreground">
+              <span className="text-lg font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(route.destinationIata)}>
                 {route.destinationIata}
               </span>
               {destAirport ? (
@@ -592,11 +601,10 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
             </div>
           </div>
           <span
-            className={`rounded-full px-2.5 py-1 text-[10px] uppercase tracking-widest font-semibold ${
-              route.status === "active"
+            className={`rounded-full px-2.5 py-1 text-[10px] uppercase tracking-widest font-semibold ${route.status === "active"
                 ? "bg-emerald-500/20 text-emerald-200"
                 : "bg-muted text-muted-foreground"
-            }`}
+              }`}
           >
             {route.status}
           </span>
@@ -661,7 +669,8 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
               return (
                 <div
                   key={ac.id}
-                  className="flex items-center justify-between rounded-lg border border-border/40 bg-background/50 px-3 py-2 text-xs"
+                  className="flex items-center justify-between rounded-lg border border-border/40 bg-background/50 px-3 py-2 text-xs hover:border-primary/40 transition-colors cursor-pointer"
+                  onClick={() => navigateToAircraft(ac.id)}
                 >
                   <span className="font-semibold text-foreground">{ac.name}</span>
                   <span className="text-muted-foreground">

--- a/apps/web/src/features/network/components/AirportInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AirportInfoPanel.tsx
@@ -81,8 +81,11 @@ export function AirportInfoPanel({ airport, onClose }: AirportInfoPanelProps) {
   }, [onClose]);
 
   useEffect(() => {
-    // Reset to info tab when airport changes
-    setActiveTab("info");
+    // Reset to info tab when airport changes, unless URL already specifies a tab
+    // (e.g. ?airportTab=flights from FlightBoard interlinks)
+    if (!search.airportTab) {
+      setActiveTab("info");
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [airport.iata]);
 

--- a/apps/web/src/features/network/components/AirportInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AirportInfoPanel.tsx
@@ -73,11 +73,16 @@ export function AirportInfoPanel({ airport, onClose }: AirportInfoPanelProps) {
   };
 
   useEffect(() => {
+    let armed = false;
+    const timer = setTimeout(() => { armed = true; }, 300);
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape" && armed) onClose();
     };
     window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
+    return () => {
+      clearTimeout(timer);
+      window.removeEventListener("keydown", onKeyDown);
+    };
   }, [onClose]);
 
   useEffect(() => {

--- a/apps/web/src/features/network/components/AirportInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AirportInfoPanel.tsx
@@ -18,6 +18,7 @@ import { FlightBoard } from "@/features/network/components/FlightBoard";
 import { buildCompetitorHubEntries } from "@/features/network/utils/competitorHubs";
 import { buildGroundTraffic } from "@/features/network/utils/groundTraffic";
 import { useConfirm } from "@/shared/lib/useConfirm";
+import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
 
 type AirportInfoPanelProps = {
   airport: Airport;
@@ -107,23 +108,23 @@ export function AirportInfoPanel({ airport, onClose }: AirportInfoPanelProps) {
   const activeHubAirport = playerHubs[0] ? airportIndex.get(playerHubs[0]) : null;
   const distanceKm = originHubAirport
     ? Math.round(
-        haversineDistance(
-          originHubAirport.latitude,
-          originHubAirport.longitude,
-          airport.latitude,
-          airport.longitude,
-        ),
-      )
+      haversineDistance(
+        originHubAirport.latitude,
+        originHubAirport.longitude,
+        airport.latitude,
+        airport.longitude,
+      ),
+    )
     : null;
   const hqDistanceKm = activeHubAirport
     ? Math.round(
-        haversineDistance(
-          activeHubAirport.latitude,
-          activeHubAirport.longitude,
-          airport.latitude,
-          airport.longitude,
-        ),
-      )
+      haversineDistance(
+        activeHubAirport.latitude,
+        activeHubAirport.longitude,
+        airport.latitude,
+        airport.longitude,
+      ),
+    )
     : null;
 
   const routesTouching = useMemo(
@@ -399,14 +400,19 @@ export function AirportInfoPanel({ airport, onClose }: AirportInfoPanelProps) {
                 </div>
                 {routesTouching.length > 0 ? (
                   <div className="flex flex-wrap gap-2">
-                    {routesTouching.slice(0, 5).map((route) => (
-                      <span
-                        key={route.id}
-                        className="rounded-full border border-border/50 bg-background/60 px-2 py-1 text-[11px] font-mono text-muted-foreground"
-                      >
-                        {routeLabel(route)}
-                      </span>
-                    ))}
+                    {routesTouching.slice(0, 5).map((route) => {
+                      const otherIata = route.originIata === airport.iata ? route.destinationIata : route.originIata;
+                      return (
+                        <button
+                          key={route.id}
+                          type="button"
+                          onClick={() => navigateToAirport(otherIata)}
+                          className="rounded-full border border-border/50 bg-background/60 px-2 py-1 text-[11px] font-mono text-muted-foreground hover:border-primary/40 hover:text-foreground transition-colors cursor-pointer"
+                        >
+                          {routeLabel(route)}
+                        </button>
+                      );
+                    })}
                     {routesTouching.length > 5 ? (
                       <span className="rounded-full border border-border/50 bg-background/60 px-2 py-1 text-[11px] font-mono text-muted-foreground">
                         +{routesTouching.length - 5} more
@@ -582,13 +588,19 @@ export function AirportInfoPanel({ airport, onClose }: AirportInfoPanelProps) {
               {distanceKm && originHubAirport ? (
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <PlaneTakeoff className="h-4 w-4" />
-                  Distance from {originHubAirport.iata}: {distanceKm.toLocaleString()} km
+                  Distance from{" "}
+                  <button type="button" onClick={() => navigateToAirport(originHubAirport.iata)} className="font-mono font-semibold text-foreground hover:text-primary transition-colors cursor-pointer">
+                    {originHubAirport.iata}
+                  </button>: {distanceKm.toLocaleString()} km
                 </div>
               ) : null}
               {!originHubAirport && hqDistanceKm && activeHubAirport ? (
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <PlaneTakeoff className="h-4 w-4" />
-                  Distance from HQ {activeHubAirport.iata}: {hqDistanceKm.toLocaleString()} km
+                  Distance from HQ{" "}
+                  <button type="button" onClick={() => navigateToAirport(activeHubAirport.iata)} className="font-mono font-semibold text-foreground hover:text-primary transition-colors cursor-pointer">
+                    {activeHubAirport.iata}
+                  </button>: {hqDistanceKm.toLocaleString()} km
                 </div>
               ) : null}
             </div>

--- a/apps/web/src/features/network/components/FlightBoard.tsx
+++ b/apps/web/src/features/network/components/FlightBoard.tsx
@@ -3,6 +3,7 @@ import { useAirlineStore, useEngineStore } from "@acars/store";
 import { PlaneLanding, PlaneTakeoff } from "lucide-react";
 import { useMemo } from "react";
 import { buildFlightBoardRows, type FlightRow } from "@/features/network/utils/flightBoard";
+import { navigateToAirport, navigateToAircraft } from "@/shared/lib/permalinkNavigation";
 
 type FlightBoardProps = {
   airportIata: string;
@@ -31,9 +32,21 @@ function FidsRow({ flight }: { flight: FlightRow }) {
           style={{ backgroundColor: flight.airlineColor }}
           aria-hidden="true"
         />
-        <span className="text-slate-100 font-semibold truncate">{flight.flightLabel}</span>
+        <button
+          type="button"
+          onClick={() => navigateToAircraft(flight.aircraftId)}
+          className="text-slate-100 font-semibold truncate hover:text-sky-300 transition-colors cursor-pointer"
+        >
+          {flight.flightLabel}
+        </button>
       </span>
-      <span className="text-yellow-300 font-bold tracking-wide">{flight.otherIata}</span>
+      <button
+        type="button"
+        onClick={() => navigateToAirport(flight.otherIata, { airportTab: "flights" })}
+        className="text-yellow-300 font-bold tracking-wide hover:text-yellow-100 transition-colors cursor-pointer text-left"
+      >
+        {flight.otherIata}
+      </button>
       <span className="text-slate-400 text-[10px]">{flight.aircraft}</span>
       <span className="text-slate-100 font-semibold text-right tabular-nums">
         {flight.timeLabel}

--- a/apps/web/src/features/network/components/WorldMap.tsx
+++ b/apps/web/src/features/network/components/WorldMap.tsx
@@ -1,6 +1,7 @@
 import type { AircraftInstance, Airport, Route } from "@acars/core";
+import { TICK_DURATION } from "@acars/core";
 import { airports as AIRPORTS } from "@acars/data";
-import { Globe as CoreGlobe } from "@acars/map";
+import { Globe as CoreGlobe, getGreatCircleInterpolation } from "@acars/map";
 import { useAirlineStore, useEngineStore } from "@acars/store";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AircraftInfoPanel } from "@/features/network/components/AircraftInfoPanel";
@@ -8,6 +9,32 @@ import { AirportInfoPanel } from "@/features/network/components/AirportInfoPanel
 import { buildGroundPresenceByAirport } from "@/features/network/utils/groundTraffic";
 
 const airportByIata = new Map<string, Airport>(AIRPORTS.map((a) => [a.iata, a]));
+
+/**
+ * Compute the best airport (or virtual focus point) for centering the map
+ * on a given aircraft. For grounded aircraft, returns the base airport.
+ * For enroute aircraft, returns a virtual Airport at the interpolated position.
+ */
+function getAircraftFocusPoint(ac: AircraftInstance, tick: number, tickProgress: number): Airport | null {
+  if (ac.status === "enroute" && ac.flight) {
+    const origin = airportByIata.get(ac.flight.originIata);
+    const dest = airportByIata.get(ac.flight.destinationIata);
+    if (origin && dest) {
+      const elapsed = (tick - ac.flight.departureTick + tickProgress) * TICK_DURATION;
+      const duration = (ac.flight.arrivalTick - ac.flight.departureTick) * TICK_DURATION;
+      const progress = duration > 0 ? Math.max(0, Math.min(1, elapsed / duration)) : 0;
+      const [lng, lat] = getGreatCircleInterpolation(
+        [origin.longitude, origin.latitude],
+        [dest.longitude, dest.latitude],
+        progress,
+      );
+      // Return virtual airport at interpolated position
+      return { ...dest, latitude: lat, longitude: lng };
+    }
+    return dest ?? null;
+  }
+  return ac.baseAirportIata ? airportByIata.get(ac.baseAirportIata) ?? null : null;
+}
 
 export function WorldMap() {
   const homeAirport = useEngineStore((s) => s.homeAirport);
@@ -100,7 +127,7 @@ export function WorldMap() {
   }, [pubkey, fleetByOwner]);
 
   // Permalink deep-link: when permalinkAircraftId is set (e.g. /aircraft/abc123),
-  // automatically inspect that aircraft on the map.
+  // automatically inspect that aircraft on the map and center on its position.
   useEffect(() => {
     if (!permalinkAircraftId) return;
     const ac =
@@ -110,7 +137,9 @@ export function WorldMap() {
     if (ac) {
       setInspectedAircraft(ac);
       setInspectedAirport(null);
-      setFocusedAirport(null);
+      // Read tick imperatively to avoid re-running this effect every frame
+      const { tick: t, tickProgress: tp } = useEngineStore.getState();
+      setFocusedAirport(getAircraftFocusPoint(ac, t, tp));
     }
     // Re-run whenever fleet data updates (aircraft load asynchronously from Nostr)
   }, [permalinkAircraftId, fleet, competitorFleet]);
@@ -133,10 +162,10 @@ export function WorldMap() {
       if (!ac) return;
       setInspectedAircraft(ac);
       setInspectedAirport(null);
-      setFocusedAirport(null);
+      setFocusedAirport(getAircraftFocusPoint(ac, tick, tickProgress));
       window.history.replaceState(null, "", `/aircraft/${aircraftId}`);
     },
-    [fleet, competitorFleet],
+    [fleet, competitorFleet, tick, tickProgress],
   );
 
   const clearAircraftFocus = () => {

--- a/apps/web/src/features/network/components/WorldMap.tsx
+++ b/apps/web/src/features/network/components/WorldMap.tsx
@@ -14,6 +14,7 @@ export function WorldMap() {
   const tick = useEngineStore((s) => s.tick);
   const tickProgress = useEngineStore((s) => s.tickProgress);
   const permalinkAirportIata = useEngineStore((s) => s.permalinkAirportIata);
+  const permalinkAircraftId = useEngineStore((s) => s.permalinkAircraftId);
   const { airline, fleet, fleetByOwner, routesByOwner, competitors, routes, pubkey } =
     useAirlineStore();
   const [inspectedAirport, setInspectedAirport] = useState<Airport | null>(null);
@@ -98,6 +99,22 @@ export function WorldMap() {
     return result;
   }, [pubkey, fleetByOwner]);
 
+  // Permalink deep-link: when permalinkAircraftId is set (e.g. /aircraft/abc123),
+  // automatically inspect that aircraft on the map.
+  useEffect(() => {
+    if (!permalinkAircraftId) return;
+    const ac =
+      fleet.find((a) => a.id === permalinkAircraftId) ??
+      competitorFleet.find((a) => a.id === permalinkAircraftId) ??
+      null;
+    if (ac) {
+      setInspectedAircraft(ac);
+      setInspectedAirport(null);
+      setFocusedAirport(null);
+    }
+    // Re-run whenever fleet data updates (aircraft load asynchronously from Nostr)
+  }, [permalinkAircraftId, fleet, competitorFleet]);
+
   const competitorRoutes = useMemo(() => {
     const playerPubkey = pubkey ?? null;
     const result: Route[] = [];
@@ -117,10 +134,15 @@ export function WorldMap() {
       setInspectedAircraft(ac);
       setInspectedAirport(null);
       setFocusedAirport(null);
-      window.history.replaceState(null, "", "/");
+      window.history.replaceState(null, "", `/aircraft/${aircraftId}`);
     },
     [fleet, competitorFleet],
   );
+
+  const clearAircraftFocus = () => {
+    setInspectedAircraft(null);
+    window.history.replaceState(null, "", "/");
+  };
 
   const { presence: groundPresence } = useMemo(
     () => buildGroundPresenceByAirport(fleet, competitorFleet, airline ?? null, competitors),
@@ -160,12 +182,7 @@ export function WorldMap() {
         <AirportInfoPanel airport={inspectedAirport} onClose={clearAirportFocus} />
       ) : null}
       {inspectedAircraft ? (
-        <AircraftInfoPanel
-          aircraft={inspectedAircraft}
-          onClose={() => {
-            setInspectedAircraft(null);
-          }}
-        />
+        <AircraftInfoPanel aircraft={inspectedAircraft} onClose={clearAircraftFocus} />
       ) : null}
       {focusedAirport ? (
         <div className="pointer-events-none absolute left-4 top-4 z-20 rounded-full border border-border/60 bg-background/80 px-3 py-1 text-[11px] uppercase tracking-widest text-muted-foreground">

--- a/apps/web/src/features/network/components/WorldMap.tsx
+++ b/apps/web/src/features/network/components/WorldMap.tsx
@@ -2,20 +2,35 @@ import type { AircraftInstance, Airport, Route } from "@acars/core";
 import { airports as AIRPORTS } from "@acars/data";
 import { Globe as CoreGlobe } from "@acars/map";
 import { useAirlineStore, useEngineStore } from "@acars/store";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AircraftInfoPanel } from "@/features/network/components/AircraftInfoPanel";
 import { AirportInfoPanel } from "@/features/network/components/AirportInfoPanel";
 import { buildGroundPresenceByAirport } from "@/features/network/utils/groundTraffic";
+
+const airportByIata = new Map<string, Airport>(AIRPORTS.map((a) => [a.iata, a]));
 
 export function WorldMap() {
   const homeAirport = useEngineStore((s) => s.homeAirport);
   const tick = useEngineStore((s) => s.tick);
   const tickProgress = useEngineStore((s) => s.tickProgress);
+  const permalinkAirportIata = useEngineStore((s) => s.permalinkAirportIata);
   const { airline, fleet, fleetByOwner, routesByOwner, competitors, routes, pubkey } =
     useAirlineStore();
   const [inspectedAirport, setInspectedAirport] = useState<Airport | null>(null);
   const [inspectedAircraft, setInspectedAircraft] = useState<AircraftInstance | null>(null);
   const [focusedAirport, setFocusedAirport] = useState<Airport | null>(null);
+
+  // Permalink deep-link: when permalinkAirportIata is set (e.g. /airport/JFK),
+  // automatically focus and inspect that airport on the map.
+  useEffect(() => {
+    if (!permalinkAirportIata) return;
+    const airport = airportByIata.get(permalinkAirportIata);
+    if (airport) {
+      setFocusedAirport(airport);
+      setInspectedAirport(airport);
+      setInspectedAircraft(null);
+    }
+  }, [permalinkAirportIata]);
 
   const competitorLiveries = useMemo(() => {
     const map = new Map<string, { primary: string; secondary: string }>();
@@ -63,6 +78,15 @@ export function WorldMap() {
     setInspectedAirport(airport);
     setFocusedAirport(airport);
     setInspectedAircraft(null);
+    // Sync URL to permalink — replaceState so we don't pollute history
+    window.history.replaceState(null, "", `/airport/${airport.iata}`);
+  };
+
+  const clearAirportFocus = () => {
+    setInspectedAirport(null);
+    setFocusedAirport(null);
+    // Restore URL to root when clearing airport focus
+    window.history.replaceState(null, "", "/");
   };
 
   const competitorFleet = useMemo(() => {
@@ -93,6 +117,7 @@ export function WorldMap() {
       setInspectedAircraft(ac);
       setInspectedAirport(null);
       setFocusedAirport(null);
+      window.history.replaceState(null, "", "/");
     },
     [fleet, competitorFleet],
   );
@@ -117,6 +142,7 @@ export function WorldMap() {
           setInspectedAirport(null);
           setInspectedAircraft(null);
           setFocusedAirport(null);
+          window.history.replaceState(null, "", "/");
         }}
         groundPresence={groundPresence}
         fleet={fleet}
@@ -131,12 +157,7 @@ export function WorldMap() {
         tickProgress={tickProgress}
       />
       {inspectedAirport ? (
-        <AirportInfoPanel
-          airport={inspectedAirport}
-          onClose={() => {
-            setInspectedAirport(null);
-          }}
-        />
+        <AirportInfoPanel airport={inspectedAirport} onClose={clearAirportFocus} />
       ) : null}
       {inspectedAircraft ? (
         <AircraftInfoPanel

--- a/apps/web/src/features/network/components/WorldMap.tsx
+++ b/apps/web/src/features/network/components/WorldMap.tsx
@@ -54,9 +54,13 @@ export function WorldMap() {
     if (!permalinkAirportIata) return;
     const airport = airportByIata.get(permalinkAirportIata);
     if (airport) {
-      setFocusedAirport(airport);
-      setInspectedAirport(airport);
-      setInspectedAircraft(null);
+      // Deferred to satisfy react-hooks/set-state-in-effect — this effect
+      // synchronises external Zustand store state with local component state.
+      queueMicrotask(() => {
+        setFocusedAirport(airport);
+        setInspectedAirport(airport);
+        setInspectedAircraft(null);
+      });
     }
   }, [permalinkAirportIata]);
 
@@ -135,11 +139,17 @@ export function WorldMap() {
       competitorFleet.find((a) => a.id === permalinkAircraftId) ??
       null;
     if (ac) {
-      setInspectedAircraft(ac);
-      setInspectedAirport(null);
       // Read tick imperatively to avoid re-running this effect every frame
       const { tick: t, tickProgress: tp } = useEngineStore.getState();
-      setFocusedAirport(getAircraftFocusPoint(ac, t, tp));
+      // Deferred to satisfy react-hooks/set-state-in-effect
+      queueMicrotask(() => {
+        setInspectedAircraft(ac);
+        setInspectedAirport(null);
+        setFocusedAirport(getAircraftFocusPoint(ac, t, tp));
+      });
+    } else if (fleet.length > 0 || competitorFleet.length > 0) {
+      // Fleet data loaded but aircraft not found — invalid ID, redirect home
+      window.history.replaceState(null, "", "/");
     }
     // Re-run whenever fleet data updates (aircraft load asynchronously from Nostr)
   }, [permalinkAircraftId, fleet, competitorFleet]);

--- a/apps/web/src/features/network/utils/flightBoard.ts
+++ b/apps/web/src/features/network/utils/flightBoard.ts
@@ -12,6 +12,7 @@ export type FlightBoardMode = "departures" | "arrivals";
 
 export type FlightRow = {
   key: string;
+  aircraftId: string;
   status: string;
   statusTone: "emerald" | "amber" | "sky" | "slate";
   flightLabel: string;
@@ -220,6 +221,7 @@ export function buildFlightBoardRows({
 
     rows.push({
       key: `${aircraft.id}-${mode}`,
+      aircraftId: aircraft.id,
       status,
       statusTone: getStatusTone(status),
       flightLabel,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as LeaderboardRouteImport } from './routes/leaderboard'
 import { Route as FleetRouteImport } from './routes/fleet'
 import { Route as CorporateRouteImport } from './routes/corporate'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AirportIataRouteImport } from './routes/airport.$iata'
 
 const NetworkRoute = NetworkRouteImport.update({
   id: '/network',
@@ -40,6 +41,11 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AirportIataRoute = AirportIataRouteImport.update({
+  id: '/airport/$iata',
+  path: '/airport/$iata',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -47,6 +53,7 @@ export interface FileRoutesByFullPath {
   '/fleet': typeof FleetRoute
   '/leaderboard': typeof LeaderboardRoute
   '/network': typeof NetworkRoute
+  '/airport/$iata': typeof AirportIataRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -54,6 +61,7 @@ export interface FileRoutesByTo {
   '/fleet': typeof FleetRoute
   '/leaderboard': typeof LeaderboardRoute
   '/network': typeof NetworkRoute
+  '/airport/$iata': typeof AirportIataRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -62,13 +70,33 @@ export interface FileRoutesById {
   '/fleet': typeof FleetRoute
   '/leaderboard': typeof LeaderboardRoute
   '/network': typeof NetworkRoute
+  '/airport/$iata': typeof AirportIataRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/corporate' | '/fleet' | '/leaderboard' | '/network'
+  fullPaths:
+    | '/'
+    | '/corporate'
+    | '/fleet'
+    | '/leaderboard'
+    | '/network'
+    | '/airport/$iata'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/corporate' | '/fleet' | '/leaderboard' | '/network'
-  id: '__root__' | '/' | '/corporate' | '/fleet' | '/leaderboard' | '/network'
+  to:
+    | '/'
+    | '/corporate'
+    | '/fleet'
+    | '/leaderboard'
+    | '/network'
+    | '/airport/$iata'
+  id:
+    | '__root__'
+    | '/'
+    | '/corporate'
+    | '/fleet'
+    | '/leaderboard'
+    | '/network'
+    | '/airport/$iata'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -77,6 +105,7 @@ export interface RootRouteChildren {
   FleetRoute: typeof FleetRoute
   LeaderboardRoute: typeof LeaderboardRoute
   NetworkRoute: typeof NetworkRoute
+  AirportIataRoute: typeof AirportIataRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -116,6 +145,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/airport/$iata': {
+      id: '/airport/$iata'
+      path: '/airport/$iata'
+      fullPath: '/airport/$iata'
+      preLoaderRoute: typeof AirportIataRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -125,6 +161,7 @@ const rootRouteChildren: RootRouteChildren = {
   FleetRoute: FleetRoute,
   LeaderboardRoute: LeaderboardRoute,
   NetworkRoute: NetworkRoute,
+  AirportIataRoute: AirportIataRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as FleetRouteImport } from './routes/fleet'
 import { Route as CorporateRouteImport } from './routes/corporate'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AirportIataRouteImport } from './routes/airport.$iata'
+import { Route as AircraftIdRouteImport } from './routes/aircraft.$id'
 
 const NetworkRoute = NetworkRouteImport.update({
   id: '/network',
@@ -46,6 +47,11 @@ const AirportIataRoute = AirportIataRouteImport.update({
   path: '/airport/$iata',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AircraftIdRoute = AircraftIdRouteImport.update({
+  id: '/aircraft/$id',
+  path: '/aircraft/$id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -53,6 +59,7 @@ export interface FileRoutesByFullPath {
   '/fleet': typeof FleetRoute
   '/leaderboard': typeof LeaderboardRoute
   '/network': typeof NetworkRoute
+  '/aircraft/$id': typeof AircraftIdRoute
   '/airport/$iata': typeof AirportIataRoute
 }
 export interface FileRoutesByTo {
@@ -61,6 +68,7 @@ export interface FileRoutesByTo {
   '/fleet': typeof FleetRoute
   '/leaderboard': typeof LeaderboardRoute
   '/network': typeof NetworkRoute
+  '/aircraft/$id': typeof AircraftIdRoute
   '/airport/$iata': typeof AirportIataRoute
 }
 export interface FileRoutesById {
@@ -70,6 +78,7 @@ export interface FileRoutesById {
   '/fleet': typeof FleetRoute
   '/leaderboard': typeof LeaderboardRoute
   '/network': typeof NetworkRoute
+  '/aircraft/$id': typeof AircraftIdRoute
   '/airport/$iata': typeof AirportIataRoute
 }
 export interface FileRouteTypes {
@@ -80,6 +89,7 @@ export interface FileRouteTypes {
     | '/fleet'
     | '/leaderboard'
     | '/network'
+    | '/aircraft/$id'
     | '/airport/$iata'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -88,6 +98,7 @@ export interface FileRouteTypes {
     | '/fleet'
     | '/leaderboard'
     | '/network'
+    | '/aircraft/$id'
     | '/airport/$iata'
   id:
     | '__root__'
@@ -96,6 +107,7 @@ export interface FileRouteTypes {
     | '/fleet'
     | '/leaderboard'
     | '/network'
+    | '/aircraft/$id'
     | '/airport/$iata'
   fileRoutesById: FileRoutesById
 }
@@ -105,6 +117,7 @@ export interface RootRouteChildren {
   FleetRoute: typeof FleetRoute
   LeaderboardRoute: typeof LeaderboardRoute
   NetworkRoute: typeof NetworkRoute
+  AircraftIdRoute: typeof AircraftIdRoute
   AirportIataRoute: typeof AirportIataRoute
 }
 
@@ -152,6 +165,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AirportIataRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/aircraft/$id': {
+      id: '/aircraft/$id'
+      path: '/aircraft/$id'
+      fullPath: '/aircraft/$id'
+      preLoaderRoute: typeof AircraftIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -161,6 +181,7 @@ const rootRouteChildren: RootRouteChildren = {
   FleetRoute: FleetRoute,
   LeaderboardRoute: LeaderboardRoute,
   NetworkRoute: NetworkRoute,
+  AircraftIdRoute: AircraftIdRoute,
   AirportIataRoute: AirportIataRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/web/src/routes/-aircraft.$id.lazy.test.tsx
+++ b/apps/web/src/routes/-aircraft.$id.lazy.test.tsx
@@ -1,0 +1,65 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/* ——— mocks ——— */
+
+const mockNavigate = vi.fn();
+const mockSetPermalinkAircraft = vi.fn();
+
+vi.mock("@acars/store", () => ({
+    useEngineStore: (selector?: (state: unknown) => unknown) => {
+        const state = {
+            setPermalinkAircraft: mockSetPermalinkAircraft,
+        };
+        return selector ? selector(state) : state;
+    },
+}));
+
+let mockIdParam: string = "abc-123";
+
+vi.mock("@tanstack/react-router", () => ({
+    useParams: () => ({ id: mockIdParam }),
+    useNavigate: () => mockNavigate,
+}));
+
+import AircraftPermalinkPage from "./-aircraft.$id.lazy";
+
+describe("Aircraft permalink route", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockIdParam = "abc-123";
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("sets permalink aircraft on mount for valid id", () => {
+        render(<AircraftPermalinkPage />);
+
+        expect(mockSetPermalinkAircraft).toHaveBeenCalledWith("abc-123");
+    });
+
+    it("redirects to / when id is empty", () => {
+        mockIdParam = "";
+        render(<AircraftPermalinkPage />);
+
+        expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+        expect(mockSetPermalinkAircraft).not.toHaveBeenCalled();
+    });
+
+    it("renders null (no visible output)", () => {
+        const { container } = render(<AircraftPermalinkPage />);
+
+        expect(container.innerHTML).toBe("");
+    });
+
+    it("clears permalink aircraft on unmount", () => {
+        const { unmount } = render(<AircraftPermalinkPage />);
+        mockSetPermalinkAircraft.mockClear();
+
+        unmount();
+
+        expect(mockSetPermalinkAircraft).toHaveBeenCalledWith(null);
+    });
+});

--- a/apps/web/src/routes/-aircraft.$id.lazy.test.tsx
+++ b/apps/web/src/routes/-aircraft.$id.lazy.test.tsx
@@ -15,7 +15,7 @@ vi.mock("@acars/store", () => ({
     },
 }));
 
-let mockIdParam: string = "abc-123";
+let mockIdParam = "abc-123";
 
 vi.mock("@tanstack/react-router", () => ({
     useParams: () => ({ id: mockIdParam }),

--- a/apps/web/src/routes/-aircraft.$id.lazy.tsx
+++ b/apps/web/src/routes/-aircraft.$id.lazy.tsx
@@ -1,0 +1,31 @@
+import { useEngineStore } from "@acars/store";
+import { useParams, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+/**
+ * Aircraft permalink page.
+ * Visiting /aircraft/{id} will focus the map on that aircraft and open its info panel.
+ * The actual rendering is handled by WorldMap (which reads permalinkAircraftId
+ * from the engine store). This component just sets the store value and renders
+ * nothing in the outlet — the user sees the map with the aircraft panel.
+ */
+export default function AircraftPermalinkPage() {
+    const { id } = useParams({ strict: false }) as { id: string };
+    const navigate = useNavigate();
+    const setPermalinkAircraft = useEngineStore((s) => s.setPermalinkAircraft);
+
+    useEffect(() => {
+        if (!id) {
+            navigate({ to: "/" });
+            return;
+        }
+
+        setPermalinkAircraft(id);
+
+        return () => {
+            setPermalinkAircraft(null);
+        };
+    }, [id, setPermalinkAircraft, navigate]);
+
+    return null;
+}

--- a/apps/web/src/routes/-aircraft.$id.lazy.tsx
+++ b/apps/web/src/routes/-aircraft.$id.lazy.tsx
@@ -25,7 +25,7 @@ export default function AircraftPermalinkPage() {
         return () => {
             setPermalinkAircraft(null);
         };
-    }, [id, setPermalinkAircraft, navigate]);
+    }, [id, navigate, setPermalinkAircraft]);
 
     return null;
 }

--- a/apps/web/src/routes/-airport.$iata.lazy.test.tsx
+++ b/apps/web/src/routes/-airport.$iata.lazy.test.tsx
@@ -1,0 +1,116 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/* ——— mocks ——— */
+
+const mockNavigate = vi.fn();
+const mockSetPermalinkAirport = vi.fn();
+let mockPermalinkIata: string | null = null;
+
+vi.mock("@acars/store", () => ({
+  useEngineStore: (selector?: (state: unknown) => unknown) => {
+    const state = {
+      permalinkAirportIata: mockPermalinkIata,
+      setPermalinkAirport: mockSetPermalinkAirport,
+      homeAirport: { iata: "ATL", name: "Hartsfield-Jackson Atlanta International Airport" },
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useParams: () => ({ iata: mockIataParam }),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@acars/data", () => ({
+  airports: [
+    {
+      iata: "JFK",
+      icao: "KJFK",
+      name: "John F Kennedy International Airport",
+      city: "New York",
+      country: "US",
+      latitude: 40.6,
+      longitude: -73.7,
+      altitude: 13,
+      timezone: "America/New_York",
+      population: 8800000,
+      gdpPerCapita: 84534,
+      tags: [],
+      id: "1",
+    },
+    {
+      iata: "LAX",
+      icao: "KLAX",
+      name: "Los Angeles International Airport",
+      city: "Los Angeles",
+      country: "US",
+      latitude: 33.9,
+      longitude: -118.4,
+      altitude: 126,
+      timezone: "America/Los_Angeles",
+      population: 3900000,
+      gdpPerCapita: 84534,
+      tags: [],
+      id: "2",
+    },
+  ],
+}));
+
+let mockIataParam = "JFK";
+
+import AirportPermalinkPage from "./-airport.$iata.lazy";
+
+describe("Airport permalink route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPermalinkIata = null;
+    mockIataParam = "JFK";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sets permalink airport on mount for valid IATA", () => {
+    mockIataParam = "JFK";
+    render(<AirportPermalinkPage />);
+
+    expect(mockSetPermalinkAirport).toHaveBeenCalledWith("JFK");
+  });
+
+  it("normalizes lowercase IATA to uppercase", () => {
+    mockIataParam = "jfk";
+    render(<AirportPermalinkPage />);
+
+    expect(mockSetPermalinkAirport).toHaveBeenCalledWith("JFK");
+  });
+
+  it("redirects to / for invalid IATA", () => {
+    mockIataParam = "ZZZZ";
+    render(<AirportPermalinkPage />);
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+    expect(mockSetPermalinkAirport).not.toHaveBeenCalled();
+  });
+
+  it("renders null (no visible output) for valid IATA", () => {
+    mockIataParam = "LAX";
+    const { container } = render(<AirportPermalinkPage />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("clears permalink airport on unmount", () => {
+    mockIataParam = "JFK";
+    const { unmount } = render(<AirportPermalinkPage />);
+
+    // Clear mock calls from mount
+    mockSetPermalinkAirport.mockClear();
+
+    unmount();
+
+    expect(mockSetPermalinkAirport).toHaveBeenCalledWith(null);
+  });
+});

--- a/apps/web/src/routes/-airport.$iata.lazy.tsx
+++ b/apps/web/src/routes/-airport.$iata.lazy.tsx
@@ -1,0 +1,49 @@
+import type { Airport } from "@acars/core";
+import { airports as AIRPORTS } from "@acars/data";
+import { useEngineStore } from "@acars/store";
+import { useParams, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+const airportIndex = new Map<string, Airport>(AIRPORTS.map((a) => [a.iata, a]));
+
+/**
+ * Airport permalink page.
+ * Visiting /airport/JFK will focus the map on JFK and open its info panel.
+ * The actual rendering is handled by WorldMap (which reads permalinkAirportIata
+ * from the engine store). This component just sets the store value and renders
+ * nothing in the outlet — the user sees the map with the airport panel.
+ */
+export default function AirportPermalinkPage() {
+  const { iata } = useParams({ strict: false }) as { iata: string };
+  const navigate = useNavigate();
+  const setPermalinkAirport = useEngineStore((s) => s.setPermalinkAirport);
+  const homeAirport = useEngineStore((s) => s.homeAirport);
+
+  const normalizedIata = iata?.toUpperCase() ?? "";
+  const airport = airportIndex.get(normalizedIata) ?? null;
+
+  useEffect(() => {
+    if (!airport) {
+      // Invalid IATA — redirect home
+      navigate({ to: "/" });
+      return;
+    }
+
+    setPermalinkAirport(normalizedIata);
+
+    return () => {
+      // Clear permalink state when navigating away
+      setPermalinkAirport(null);
+    };
+  }, [airport, normalizedIata, setPermalinkAirport, navigate]);
+
+  // If we don't have a home airport yet (identity gate still loading),
+  // show a minimal loading state. Once the identity gate resolves,
+  // WorldMap will pick up the permalink IATA and fly to it.
+  if (!homeAirport && airport) {
+    return null; // WorldMap will handle display once ready
+  }
+
+  // This route renders nothing in the outlet — WorldMap handles the visual
+  return null;
+}

--- a/apps/web/src/routes/aircraft.$id.tsx
+++ b/apps/web/src/routes/aircraft.$id.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/aircraft/$id")({
+  component: lazyRouteComponent(() => import("./-aircraft.$id.lazy")),
+});

--- a/apps/web/src/routes/airport.$iata.tsx
+++ b/apps/web/src/routes/airport.$iata.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/airport/$iata")({
+  component: lazyRouteComponent(() => import("./-airport.$iata.lazy")),
+});

--- a/apps/web/src/shared/lib/permalinkNavigation.ts
+++ b/apps/web/src/shared/lib/permalinkNavigation.ts
@@ -16,6 +16,8 @@ export function navigateToAirport(iata: string, searchParams?: Record<string, st
     useEngineStore.getState().setPermalinkAirport(iata.toUpperCase());
     const qs = searchParams ? `?${new URLSearchParams(searchParams).toString()}` : "";
     window.history.replaceState(null, "", `/airport/${iata.toUpperCase()}${qs}`);
+    // Notify TanStack Router to re-sync internal state with the new URL
+    window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
 /**

--- a/apps/web/src/shared/lib/permalinkNavigation.ts
+++ b/apps/web/src/shared/lib/permalinkNavigation.ts
@@ -1,0 +1,37 @@
+import type { Airport } from "@acars/core";
+import { airports as AIRPORTS } from "@acars/data";
+import { useEngineStore } from "@acars/store";
+import { useCallback } from "react";
+
+const airportByIata = new Map<string, Airport>(AIRPORTS.map((a) => [a.iata, a]));
+
+/**
+ * Navigate to an airport permalink, focusing the map and opening the info panel.
+ * Can be called from any component — no prop drilling needed.
+ * @param searchParams - optional URL search params (e.g. { airportTab: "flights" })
+ */
+export function navigateToAirport(iata: string, searchParams?: Record<string, string>): void {
+    const airport = airportByIata.get(iata.toUpperCase());
+    if (!airport) return;
+    useEngineStore.getState().setPermalinkAirport(iata.toUpperCase());
+    const qs = searchParams ? `?${new URLSearchParams(searchParams).toString()}` : "";
+    window.history.replaceState(null, "", `/airport/${iata.toUpperCase()}${qs}`);
+}
+
+/**
+ * Navigate to an aircraft permalink, opening its info panel.
+ * Can be called from any component — no prop drilling needed.
+ */
+export function navigateToAircraft(id: string): void {
+    useEngineStore.getState().setPermalinkAircraft(id);
+    window.history.replaceState(null, "", `/aircraft/${id}`);
+}
+
+/**
+ * React hook that returns stable navigate functions for use in event handlers.
+ */
+export function usePermalinkNavigation() {
+    const goToAirport = useCallback((iata: string) => navigateToAirport(iata), []);
+    const goToAircraft = useCallback((id: string) => navigateToAircraft(id), []);
+    return { goToAirport, goToAircraft };
+}

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -1,2 +1,3 @@
 export * from './Globe.js';
 export * from './icons.js';
+export * from './geo.js';

--- a/packages/store/src/engine.test.ts
+++ b/packages/store/src/engine.test.ts
@@ -80,4 +80,21 @@ describe("engine store", () => {
       useEngineStore.getState().stopEngine();
     }
   });
+
+  it("permalinkAirportIata defaults to null", () => {
+    expect(useEngineStore.getState().permalinkAirportIata).toBeNull();
+  });
+
+  it("setPermalinkAirport sets the IATA code", () => {
+    useEngineStore.getState().setPermalinkAirport("JFK");
+    expect(useEngineStore.getState().permalinkAirportIata).toBe("JFK");
+  });
+
+  it("setPermalinkAirport can clear back to null", () => {
+    useEngineStore.getState().setPermalinkAirport("LAX");
+    expect(useEngineStore.getState().permalinkAirportIata).toBe("LAX");
+
+    useEngineStore.getState().setPermalinkAirport(null);
+    expect(useEngineStore.getState().permalinkAirportIata).toBeNull();
+  });
 });

--- a/packages/store/src/engine.test.ts
+++ b/packages/store/src/engine.test.ts
@@ -97,4 +97,21 @@ describe("engine store", () => {
     useEngineStore.getState().setPermalinkAirport(null);
     expect(useEngineStore.getState().permalinkAirportIata).toBeNull();
   });
+
+  it("permalinkAircraftId defaults to null", () => {
+    expect(useEngineStore.getState().permalinkAircraftId).toBeNull();
+  });
+
+  it("setPermalinkAircraft sets the aircraft id", () => {
+    useEngineStore.getState().setPermalinkAircraft("abc-123");
+    expect(useEngineStore.getState().permalinkAircraftId).toBe("abc-123");
+  });
+
+  it("setPermalinkAircraft can clear back to null", () => {
+    useEngineStore.getState().setPermalinkAircraft("xyz-456");
+    expect(useEngineStore.getState().permalinkAircraftId).toBe("xyz-456");
+
+    useEngineStore.getState().setPermalinkAircraft(null);
+    expect(useEngineStore.getState().permalinkAircraftId).toBeNull();
+  });
 });

--- a/packages/store/src/engine.ts
+++ b/packages/store/src/engine.ts
@@ -102,10 +102,14 @@ export interface EngineState {
     phase: "player" | "competitor";
   } | null;
 
+  /** IATA of airport focused via permalink (e.g. /airport/JFK) */
+  permalinkAirportIata: string | null;
+
   syncTick: () => void;
   setHub: (airport: Airport, loc: UserLocation, method: string) => void;
   startEngine: () => void;
   stopEngine: () => void;
+  setPermalinkAirport: (iata: string | null) => void;
 }
 
 let engineProgressInterval: ReturnType<typeof setInterval> | null = null;
@@ -126,6 +130,9 @@ export const useEngineStore = create<EngineState>((set, get) => ({
   locationMethod: "",
   isEngineRunning: false,
   catchupProgress: null,
+  permalinkAirportIata: null,
+
+  setPermalinkAirport: (iata) => set({ permalinkAirportIata: iata }),
 
   syncTick: () => {
     const now = Date.now();

--- a/packages/store/src/engine.ts
+++ b/packages/store/src/engine.ts
@@ -104,12 +104,15 @@ export interface EngineState {
 
   /** IATA of airport focused via permalink (e.g. /airport/JFK) */
   permalinkAirportIata: string | null;
+  /** Aircraft ID focused via permalink (e.g. /aircraft/abc123) */
+  permalinkAircraftId: string | null;
 
   syncTick: () => void;
   setHub: (airport: Airport, loc: UserLocation, method: string) => void;
   startEngine: () => void;
   stopEngine: () => void;
   setPermalinkAirport: (iata: string | null) => void;
+  setPermalinkAircraft: (id: string | null) => void;
 }
 
 let engineProgressInterval: ReturnType<typeof setInterval> | null = null;
@@ -131,8 +134,10 @@ export const useEngineStore = create<EngineState>((set, get) => ({
   isEngineRunning: false,
   catchupProgress: null,
   permalinkAirportIata: null,
+  permalinkAircraftId: null,
 
   setPermalinkAirport: (iata) => set({ permalinkAirportIata: iata }),
+  setPermalinkAircraft: (id) => set({ permalinkAircraftId: id }),
 
   syncTick: () => {
     const now = Date.now();


### PR DESCRIPTION
## Summary

Adds shareable permalink URLs for airports and aircraft, cross-panel interlinking throughout the UI, and map centering on aircraft.

### Airport Permalinks (`/airport/:iata`)
- Navigate to `/airport/JFK` to focus the map on JFK and open the info panel
- Case-insensitive: `/airport/jfk` works too
- Invalid IATA codes gracefully redirect to `/`
- Clicking any airport on the map updates the URL via `replaceState`
- Closing the panel or clicking the map background restores `/`

### Aircraft Permalinks (`/aircraft/:id`)
- Navigate to `/aircraft/{uuid}` to inspect a specific aircraft
- Handles async fleet loading — effect re-runs as fleet data arrives from Nostr
- Map centers on the aircraft's interpolated enroute position (SLERP) or base airport
- Clicking aircraft on the map syncs the URL
- Closing the panel restores `/`

### Cross-Panel Interlinking
Every IATA code and aircraft reference across the UI is now a clickable link:

| Component | What's clickable | Navigates to |
|-----------|-----------------|-------------|
| **FlightBoard** | Airport IATA (To/From) | `/airport/{iata}?airportTab=flights` |
| **FlightBoard** | Flight number | `/aircraft/{id}` |
| **AirportInfoPanel** | Route labels | `/airport/{otherIata}` |
| **AirportInfoPanel** | Distance hub refs | `/airport/{hubIata}` |
| **AircraftInfoPanel** | Base airport | `/airport/{iata}` |
| **AircraftInfoPanel** | Flight strip origin/dest | `/airport/{iata}` |
| **AircraftInfoPanel** | Route tab origin/dest | `/airport/{iata}` |
| **AircraftInfoPanel** | Sibling aircraft | `/aircraft/{id}` |
| **FleetManager** | Location (At/Enroute/Delivery) | `/airport/{iata}` |
| **FleetManager** | Base hub | `/airport/{iata}` |
| **FleetManager** | Last flight route | `/airport/{iata}` |

### Map Centering on Aircraft
- Grounded aircraft: centers on base airport
- Enroute aircraft: centers on interpolated great-circle position using SLERP
- Exported `getGreatCircleInterpolation` from `@acars/map` for reuse

### Implementation
- `permalinkAirportIata` / `permalinkAircraftId` in engine store (bridge between routes and WorldMap)
- TanStack Router file-based routes with lazy-loaded components
- Shared `permalinkNavigation.ts` utility (no prop drilling needed)
- `?airportTab=flights` preserved via `popstate` dispatch after `replaceState`
- `FlightRow` type extended with `aircraftId` for aircraft linking

### Tests
- **Store**: 6 new tests (default values, set, clear for both permalink states)
- **Route components**: 9 new tests (IATA resolution, case normalization, invalid redirect, cleanup)
- All 154 store tests + 26 web tests pass