### PR TITLE
fix: make route frequencies dynamic and realistic

### DIFF
--- a/apps/web/src/features/competition/components/Leaderboard.test.tsx
+++ b/apps/web/src/features/competition/components/Leaderboard.test.tsx
@@ -93,7 +93,7 @@ describe("Leaderboard", () => {
     render(<Leaderboard />);
     expect(screen.getByText("Test Air")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole("button", { name: /Fleet Size/ }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "fleet" } });
     expect(screen.getAllByText("Fleet Size").length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/features/competition/components/Leaderboard.tsx
+++ b/apps/web/src/features/competition/components/Leaderboard.tsx
@@ -2,8 +2,8 @@ import type { AircraftInstance, FixedPoint, Route } from "@acars/core";
 import { fpFormat } from "@acars/core";
 import { useAirlineStore, useEngineStore } from "@acars/store";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { ArrowDownRight, ArrowUpRight, Trophy } from "lucide-react";
-import { useMemo, useRef, useState } from "react";
+import { ArrowDownRight, ArrowUpRight, ChevronDown, Trophy } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type {
   LeaderboardMetric,
   LeaderboardRow as LeaderboardRowData,
@@ -45,7 +45,7 @@ function formatBrandScore(value: number) {
 function formatMetric(metric: LeaderboardMetric, value: number | FixedPoint) {
   if (metricMeta[metric].isMoney) return fpFormat(value as FixedPoint, 0);
   if (metric === "brand") return formatBrandScore(value);
-  if (metric === "networkDistance") return `${value.toLocaleString()} km`;
+  if (metric === "networkDistance") return `${Math.round(value as number).toLocaleString()} km`;
   return value.toLocaleString();
 }
 
@@ -168,7 +168,11 @@ export function Leaderboard() {
   const routesByOwner = useAirlineStore((s) => s.routesByOwner);
   const viewAs = useAirlineStore((s) => s.viewAs);
   const currentTick = useEngineStore((s) => s.tick);
-  const [metric, setMetric] = useState<LeaderboardMetric>("balance");
+  const [metric, setMetric] = useState<LeaderboardMetric>("networkDistance");
+  const handleMetricChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => setMetric(e.target.value as LeaderboardMetric),
+    [],
+  );
 
   // Build lookup maps separately so toggling metric doesn't rebuild them
   const { aircraftById, routeById } = useMemo(() => {
@@ -216,7 +220,7 @@ export function Leaderboard() {
 
   return (
     <div className="flex h-full w-full flex-col">
-      <div className="mb-6 flex items-center justify-between pr-10">
+      <div className="mb-4 flex items-center justify-between pr-10">
         <div className="flex items-center gap-3">
           <div className="rounded-lg bg-primary/10 p-2">
             <Trophy className="h-6 w-6 text-primary" />
@@ -228,28 +232,20 @@ export function Leaderboard() {
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2 rounded-full border border-border/60 bg-background/60 px-3 py-1 text-[10px] font-semibold uppercase text-muted-foreground">
-          {metricMeta[metric].label}
-        </div>
-      </div>
-
-      <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-        {(Object.keys(metricMeta) as LeaderboardMetric[]).map((key) => {
-          const isActive = key === metric;
-          return (
-            <button
-              key={key}
-              onClick={() => setMetric(key)}
-              type="button"
-              className={`rounded-xl border px-4 py-3 text-left transition ${isActive ? "border-primary/40 bg-primary/10 text-primary" : "border-border/50 bg-background/40 text-muted-foreground hover:bg-accent/10 hover:text-foreground"}`}
-            >
-              <p className="text-[10px] uppercase font-semibold tracking-wider">
+        <div className="relative">
+          <select
+            value={metric}
+            onChange={handleMetricChange}
+            className="appearance-none cursor-pointer rounded-full border border-border/60 bg-background/60 pl-3 pr-8 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground transition hover:border-primary/40 hover:text-foreground focus:border-primary/40 focus:outline-none focus:ring-1 focus:ring-primary/30"
+          >
+            {(Object.keys(metricMeta) as LeaderboardMetric[]).map((key) => (
+              <option key={key} value={key}>
                 {metricMeta[key].label}
-              </p>
-              <p className="text-[10px] text-muted-foreground/70">{metricMeta[key].description}</p>
-            </button>
-          );
-        })}
+              </option>
+            ))}
+          </select>
+          <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        </div>
       </div>
 
       <div ref={parentRef} className="flex-1 overflow-y-auto pr-2 custom-scrollbar">

--- a/apps/web/src/features/fleet/components/FleetManager.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.tsx
@@ -144,11 +144,13 @@ export function FleetManager() {
     );
   }
 
-  const filteredFleet = fleet.filter(
-    (f) =>
-      f.name.toLowerCase().includes(search.toLowerCase()) ||
-      f.modelId.toLowerCase().includes(search.toLowerCase()),
-  );
+  const filteredFleet = [...fleet]
+    .reverse()
+    .filter(
+      (f) =>
+        f.name.toLowerCase().includes(search.toLowerCase()) ||
+        f.modelId.toLowerCase().includes(search.toLowerCase()),
+    );
 
   const handleSubmitListing = async () => {
     if (!listingTarget) return;
@@ -296,12 +298,13 @@ export function FleetManager() {
                         </span>
                       ) : (
                         <span
-                          className={`inline-flex items-center rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-widest ${ac.status === "idle"
-                            ? ac.assignedRouteId
-                              ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
-                              : "bg-primary/20 text-primary border border-primary/30"
-                            : "bg-orange-500/20 text-orange-400 border border-orange-500/30"
-                            }`}
+                          className={`inline-flex items-center rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-widest ${
+                            ac.status === "idle"
+                              ? ac.assignedRouteId
+                                ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
+                                : "bg-primary/20 text-primary border border-primary/30"
+                              : "bg-orange-500/20 text-orange-400 border border-orange-500/30"
+                          }`}
                         >
                           {ac.status === "idle" && ac.assignedRouteId ? "assigned" : ac.status}
                         </span>
@@ -343,19 +346,43 @@ export function FleetManager() {
                           {ac.status === "enroute" && ac.flight ? (
                             <>
                               Enroute:{" "}
-                              <button type="button" onClick={() => navigateToAirport(ac.flight!.originIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.flight.originIata}</button>
+                              <button
+                                type="button"
+                                onClick={() => navigateToAirport(ac.flight!.originIata)}
+                                className="hover:text-primary transition-colors cursor-pointer"
+                              >
+                                {ac.flight.originIata}
+                              </button>
                               {" → "}
-                              <button type="button" onClick={() => navigateToAirport(ac.flight!.destinationIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.flight.destinationIata}</button>
+                              <button
+                                type="button"
+                                onClick={() => navigateToAirport(ac.flight!.destinationIata)}
+                                className="hover:text-primary transition-colors cursor-pointer"
+                              >
+                                {ac.flight.destinationIata}
+                              </button>
                             </>
                           ) : ac.status === "delivery" ? (
                             <>
                               Delivery to{" "}
-                              <button type="button" onClick={() => navigateToAirport(ac.baseAirportIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.baseAirportIata}</button>
+                              <button
+                                type="button"
+                                onClick={() => navigateToAirport(ac.baseAirportIata)}
+                                className="hover:text-primary transition-colors cursor-pointer"
+                              >
+                                {ac.baseAirportIata}
+                              </button>
                             </>
                           ) : (
                             <>
                               At{" "}
-                              <button type="button" onClick={() => navigateToAirport(ac.baseAirportIata)} className="hover:text-primary transition-colors cursor-pointer">{ac.baseAirportIata}</button>
+                              <button
+                                type="button"
+                                onClick={() => navigateToAirport(ac.baseAirportIata)}
+                                className="hover:text-primary transition-colors cursor-pointer"
+                              >
+                                {ac.baseAirportIata}
+                              </button>
                             </>
                           )}
                         </p>
@@ -365,7 +392,13 @@ export function FleetManager() {
                           Base Hub
                         </p>
                         <p className="font-mono text-xs text-accent font-bold">
-                          <button type="button" onClick={() => navigateToAirport(baseHub)} className="hover:text-primary transition-colors cursor-pointer">{baseHub}</button>
+                          <button
+                            type="button"
+                            onClick={() => navigateToAirport(baseHub)}
+                            className="hover:text-primary transition-colors cursor-pointer"
+                          >
+                            {baseHub}
+                          </button>
                         </p>
                       </div>
                       <div>
@@ -482,9 +515,21 @@ export function FleetManager() {
                                 Route
                               </span>
                               <span className="text-xs font-bold text-foreground">
-                                <button type="button" onClick={() => navigateToAirport(lastLanding.originIata!)} className="hover:text-primary transition-colors cursor-pointer">{lastLanding.originIata}</button>
+                                <button
+                                  type="button"
+                                  onClick={() => navigateToAirport(lastLanding.originIata!)}
+                                  className="hover:text-primary transition-colors cursor-pointer"
+                                >
+                                  {lastLanding.originIata}
+                                </button>
                                 {" → "}
-                                <button type="button" onClick={() => navigateToAirport(lastLanding.destinationIata!)} className="hover:text-primary transition-colors cursor-pointer">{lastLanding.destinationIata}</button>
+                                <button
+                                  type="button"
+                                  onClick={() => navigateToAirport(lastLanding.destinationIata!)}
+                                  className="hover:text-primary transition-colors cursor-pointer"
+                                >
+                                  {lastLanding.destinationIata}
+                                </button>
                               </span>
                             </div>
                             <div className="flex flex-col text-right">
@@ -513,24 +558,26 @@ export function FleetManager() {
                                   Load Factor
                                 </span>
                                 <span
-                                  className={`text-[10px] font-mono font-black ${lf >= 0.85
-                                    ? "text-emerald-400"
-                                    : lf >= 0.6
-                                      ? "text-yellow-400"
-                                      : "text-red-400"
-                                    }`}
+                                  className={`text-[10px] font-mono font-black ${
+                                    lf >= 0.85
+                                      ? "text-emerald-400"
+                                      : lf >= 0.6
+                                        ? "text-yellow-400"
+                                        : "text-red-400"
+                                  }`}
                                 >
                                   {Math.round(lf * 100)}%
                                 </span>
                               </div>
                               <div className="h-1 w-full bg-muted/30 rounded-full overflow-hidden mb-3">
                                 <div
-                                  className={`h-full rounded-full transition-all ${lf >= 0.85
-                                    ? "bg-emerald-500"
-                                    : lf >= 0.6
-                                      ? "bg-yellow-500"
-                                      : "bg-red-500"
-                                    }`}
+                                  className={`h-full rounded-full transition-all ${
+                                    lf >= 0.85
+                                      ? "bg-emerald-500"
+                                      : lf >= 0.6
+                                        ? "bg-yellow-500"
+                                        : "bg-red-500"
+                                  }`}
                                   style={{ width: `${Math.round(lf * 100)}%` }}
                                 />
                               </div>

--- a/apps/web/src/features/fleet/components/FleetManager.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.tsx
@@ -30,7 +30,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getRouteDemandSnapshot } from "@/features/network/hooks/useRouteDemand";
 import { useConfirm } from "@/shared/lib/useConfirm";
-import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
+import { navigateToAirport, navigateToAircraft } from "@/shared/lib/permalinkNavigation";
 import { getAircraftBaseHub } from "../utils/aircraftBaseHub";
 import { getAircraftTimer } from "../utils/aircraftTimers";
 import { AircraftDealer } from "./AircraftDealer";
@@ -298,13 +298,12 @@ export function FleetManager() {
                         </span>
                       ) : (
                         <span
-                          className={`inline-flex items-center rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-widest ${
-                            ac.status === "idle"
-                              ? ac.assignedRouteId
-                                ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
-                                : "bg-primary/20 text-primary border border-primary/30"
-                              : "bg-orange-500/20 text-orange-400 border border-orange-500/30"
-                          }`}
+                          className={`inline-flex items-center rounded-full px-3 py-1 text-[10px] font-black uppercase tracking-widest ${ac.status === "idle"
+                            ? ac.assignedRouteId
+                              ? "bg-blue-500/20 text-blue-400 border border-blue-500/30"
+                              : "bg-primary/20 text-primary border border-primary/30"
+                            : "bg-orange-500/20 text-orange-400 border border-orange-500/30"
+                            }`}
                         >
                           {ac.status === "idle" && ac.assignedRouteId ? "assigned" : ac.status}
                         </span>
@@ -319,9 +318,15 @@ export function FleetManager() {
                     </div>
 
                     <div className="relative z-10 flex flex-col h-full justify-end">
-                      <h3 className="text-xl font-black tracking-tighter text-foreground group-hover:text-primary transition-colors">
-                        {ac.name}
-                      </h3>
+                      <button
+                        type="button"
+                        onClick={() => navigateToAircraft(ac.id)}
+                        className="text-left hover:opacity-80 transition-opacity cursor-pointer"
+                      >
+                        <h3 className="text-xl font-black tracking-tighter text-foreground group-hover:text-primary transition-colors">
+                          {ac.name}
+                        </h3>
+                      </button>
                       <p className="text-xs font-bold text-muted-foreground uppercase tracking-widest">
                         {model.manufacturer} <span className="text-accent">{model.name}</span>
                       </p>
@@ -558,26 +563,24 @@ export function FleetManager() {
                                   Load Factor
                                 </span>
                                 <span
-                                  className={`text-[10px] font-mono font-black ${
-                                    lf >= 0.85
-                                      ? "text-emerald-400"
-                                      : lf >= 0.6
-                                        ? "text-yellow-400"
-                                        : "text-red-400"
-                                  }`}
+                                  className={`text-[10px] font-mono font-black ${lf >= 0.85
+                                    ? "text-emerald-400"
+                                    : lf >= 0.6
+                                      ? "text-yellow-400"
+                                      : "text-red-400"
+                                    }`}
                                 >
                                   {Math.round(lf * 100)}%
                                 </span>
                               </div>
                               <div className="h-1 w-full bg-muted/30 rounded-full overflow-hidden mb-3">
                                 <div
-                                  className={`h-full rounded-full transition-all ${
-                                    lf >= 0.85
-                                      ? "bg-emerald-500"
-                                      : lf >= 0.6
-                                        ? "bg-yellow-500"
-                                        : "bg-red-500"
-                                  }`}
+                                  className={`h-full rounded-full transition-all ${lf >= 0.85
+                                    ? "bg-emerald-500"
+                                    : lf >= 0.6
+                                      ? "bg-yellow-500"
+                                      : "bg-red-500"
+                                    }`}
                                   style={{ width: `${Math.round(lf * 100)}%` }}
                                 />
                               </div>

--- a/apps/web/src/features/network/components/AircraftInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AircraftInfoPanel.tsx
@@ -1,5 +1,5 @@
 import type { AircraftInstance, Route } from "@acars/core";
-import { calculateBookValue, fpFormat } from "@acars/core";
+import { calculateBookValue, computeRouteFrequency, fpFormat } from "@acars/core";
 import { airports as AIRPORTS, getAircraftById } from "@acars/data";
 import { FAMILY_ICONS } from "@acars/map";
 import { useAirlineStore, useEngineStore } from "@acars/store";
@@ -91,13 +91,21 @@ function FlightStrip({
     <div className="rounded-xl border border-sky-500/30 bg-sky-500/10 p-4 space-y-3">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <span className="text-sm font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(flight.originIata)}>{flight.originIata}</span>
+          <span
+            className="text-sm font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer"
+            onClick={() => navigateToAirport(flight.originIata)}
+          >
+            {flight.originIata}
+          </span>
           <div className="flex-1 flex items-center gap-1 text-muted-foreground">
             <div className="h-px flex-1 bg-sky-500/40" />
             <Plane className="h-3 w-3 text-sky-300" />
             <div className="h-px flex-1 bg-sky-500/40" />
           </div>
-          <span className="text-sm font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(flight.destinationIata)}>
+          <span
+            className="text-sm font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer"
+            onClick={() => navigateToAirport(flight.destinationIata)}
+          >
             {flight.destinationIata}
           </span>
         </div>
@@ -147,7 +155,9 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
 
   useEffect(() => {
     let armed = false;
-    const timer = setTimeout(() => { armed = true; }, 300);
+    const timer = setTimeout(() => {
+      armed = true;
+    }, 300);
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape" && armed) onClose();
     };
@@ -495,10 +505,16 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
                   </p>
                   <p className="mt-1 text-sm font-mono font-semibold">
                     {aircraft.baseAirportIata ? (
-                      <button type="button" onClick={() => navigateToAirport(aircraft.baseAirportIata)} className="hover:text-primary transition-colors cursor-pointer">
+                      <button
+                        type="button"
+                        onClick={() => navigateToAirport(aircraft.baseAirportIata)}
+                        className="hover:text-primary transition-colors cursor-pointer"
+                      >
                         {aircraft.baseAirportIata}
                       </button>
-                    ) : "—"}
+                    ) : (
+                      "—"
+                    )}
                   </p>
                 </div>
                 <div className="rounded-xl border border-border/60 bg-background/70 p-3">
@@ -506,13 +522,27 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
                     Route
                   </p>
                   <p className="mt-1 text-sm font-mono font-semibold">
-                    {assignedRoute
-                      ? <>
-                        <button type="button" onClick={() => navigateToAirport(assignedRoute.originIata)} className="hover:text-primary transition-colors cursor-pointer">{assignedRoute.originIata}</button>
+                    {assignedRoute ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => navigateToAirport(assignedRoute.originIata)}
+                          className="hover:text-primary transition-colors cursor-pointer"
+                        >
+                          {assignedRoute.originIata}
+                        </button>
                         {" — "}
-                        <button type="button" onClick={() => navigateToAirport(assignedRoute.destinationIata)} className="hover:text-primary transition-colors cursor-pointer">{assignedRoute.destinationIata}</button>
+                        <button
+                          type="button"
+                          onClick={() => navigateToAirport(assignedRoute.destinationIata)}
+                          className="hover:text-primary transition-colors cursor-pointer"
+                        >
+                          {assignedRoute.destinationIata}
+                        </button>
                       </>
-                      : "Unassigned"}
+                    ) : (
+                      "Unassigned"
+                    )}
                   </p>
                 </div>
               </div>
@@ -520,14 +550,22 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
           </>
         ) : (
           /* Route tab */
-          <RouteTab route={assignedRoute} siblings={siblingsOnRoute} />
+          <RouteTab route={assignedRoute} siblings={siblingsOnRoute} aircraft={aircraft} />
         )}
       </div>
     </aside>
   );
 }
 
-function RouteTab({ route, siblings }: { route: Route | null; siblings: AircraftInstance[] }) {
+function RouteTab({
+  route,
+  siblings,
+  aircraft,
+}: {
+  route: Route | null;
+  siblings: AircraftInstance[];
+  aircraft: AircraftInstance;
+}) {
   if (!route) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
@@ -540,6 +578,13 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
 
   const originAirport = airportIndex.get(route.originIata);
   const destAirport = airportIndex.get(route.destinationIata);
+  const acModel = getAircraftById(aircraft.modelId);
+  const frequency = computeRouteFrequency(
+    route.distanceKm,
+    route.assignedAircraftIds.length,
+    acModel?.speedKmh || 800,
+    acModel?.turnaroundTimeMinutes || 35,
+  );
 
   const getLocalTime = (tz: string | undefined) => {
     if (!tz) return null;
@@ -570,7 +615,10 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
         <div className="flex items-center justify-between mb-3">
           <div className="flex items-center gap-3">
             <div className="text-center min-w-0">
-              <span className="text-lg font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(route.originIata)}>
+              <span
+                className="text-lg font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer"
+                onClick={() => navigateToAirport(route.originIata)}
+              >
                 {route.originIata}
               </span>
               {originAirport ? (
@@ -590,7 +638,10 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
               <div className="h-px w-4 bg-border" />
             </div>
             <div className="text-center min-w-0">
-              <span className="text-lg font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer" onClick={() => navigateToAirport(route.destinationIata)}>
+              <span
+                className="text-lg font-mono font-bold text-foreground hover:text-primary transition-colors cursor-pointer"
+                onClick={() => navigateToAirport(route.destinationIata)}
+              >
                 {route.destinationIata}
               </span>
               {destAirport ? (
@@ -606,10 +657,11 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
             </div>
           </div>
           <span
-            className={`rounded-full px-2.5 py-1 text-[10px] uppercase tracking-widest font-semibold ${route.status === "active"
-              ? "bg-emerald-500/20 text-emerald-200"
-              : "bg-muted text-muted-foreground"
-              }`}
+            className={`rounded-full px-2.5 py-1 text-[10px] uppercase tracking-widest font-semibold ${
+              route.status === "active"
+                ? "bg-emerald-500/20 text-emerald-200"
+                : "bg-muted text-muted-foreground"
+            }`}
           >
             {route.status}
           </span>
@@ -628,7 +680,7 @@ function RouteTab({ route, siblings }: { route: Route | null; siblings: Aircraft
             <p className="text-[10px] uppercase tracking-widest text-muted-foreground font-semibold">
               Frequency
             </p>
-            <p className="mt-0.5 text-sm font-mono font-semibold">{route.frequencyPerWeek}x/wk</p>
+            <p className="mt-0.5 text-sm font-mono font-semibold">{frequency}x/wk</p>
           </div>
         </div>
       </div>

--- a/apps/web/src/features/network/components/RouteManager.test.tsx
+++ b/apps/web/src/features/network/components/RouteManager.test.tsx
@@ -105,6 +105,6 @@ describe("RouteManager", () => {
     });
 
     render(<RouteManager />);
-    expect(screen.getByText("Network Manager")).toBeInTheDocument();
+    expect(screen.getByText("Network")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -3,6 +3,7 @@ import {
   calculateDemand,
   calculatePriceElasticity,
   calculateShares,
+  computeRouteFrequency,
   type FixedPoint,
   type FlightOffer,
   fp,
@@ -255,7 +256,10 @@ export function RouteManager() {
     [buildProspects, planningOriginAirport],
   );
 
-  const activeRoutes = useMemo(() => routes.filter((route) => route.status === "active"), [routes]);
+  const activeRoutes = useMemo(
+    () => [...routes].reverse().filter((route) => route.status === "active"),
+    [routes],
+  );
   const suspendedRoutes = useMemo(
     () => routes.filter((route) => route.status === "suspended"),
     [routes],
@@ -264,20 +268,6 @@ export function RouteManager() {
     if (!planningOriginAirport) return [];
     return activeRoutes.filter((route) => route.originIata === planningOriginAirport.iata);
   }, [activeRoutes, planningOriginAirport]);
-
-  const totalDailyDemand = useMemo(() => {
-    if (!planningOriginAirport) return 0;
-    const now = new Date();
-    const prosperity = getProsperityIndex(tick);
-    const weeklyTotal = originActiveRoutes.reduce((acc, route) => {
-      const destination = airportIndex.get(route.destinationIata);
-      if (!destination) return acc;
-      const season = getSeason(destination.latitude, now);
-      const demand = calculateDemand(planningOriginAirport, destination, season, prosperity, 1.0);
-      return acc + demand.economy + demand.business + demand.first;
-    }, 0);
-    return Math.round(weeklyTotal / 7);
-  }, [airportIndex, originActiveRoutes, planningOriginAirport, tick]);
 
   const originHubMeta = planningOriginAirport
     ? HUB_CLASSIFICATIONS[planningOriginAirport.iata]
@@ -372,7 +362,10 @@ export function RouteManager() {
         .filter((item): item is NonNullable<typeof item> => Boolean(item));
       if (assignedFleet.length > 0) {
         const weeklyDemand = fareDemandSnapshot.addressableDemand;
-        const frequency = activeFareRoute.assignedAircraftIds.length * 7;
+        const frequency = computeRouteFrequency(
+          activeFareRoute.distanceKm,
+          activeFareRoute.assignedAircraftIds.length,
+        );
         if (frequency > 0) {
           const pressureMultiplier = fareDemandSnapshot.pressureMultiplier;
           const currentEconomy = resolvedFareInputs.economy;
@@ -482,13 +475,14 @@ export function RouteManager() {
   // --- Virtualization (hooks must come before any conditional return) ---
   const listParentRef = useRef<HTMLDivElement>(null);
 
-  const displayedOpportunities = useMemo(
-    () =>
+  const displayedOpportunities = useMemo(() => {
+    const activeDests = new Set(originActiveRoutes.map((r) => r.destinationIata));
+    const candidates =
       searchQuery.length >= 2
         ? searchResults.map(calculateSearchProspect).filter((m): m is ProspectMarket => Boolean(m))
-        : prospectMarkets,
-    [searchQuery, searchResults, prospectMarkets],
-  );
+        : prospectMarkets;
+    return candidates.filter((m) => !activeDests.has(m.destination.iata));
+  }, [searchQuery, searchResults, prospectMarkets, originActiveRoutes]);
 
   const activeRoutesVirtualizer = useVirtualizer({
     count: activeRoutes.length,
@@ -510,9 +504,9 @@ export function RouteManager() {
     <div className="flex h-full w-full flex-col p-6 overflow-hidden">
       <div className="mb-8 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
-          <h2 className="text-3xl font-bold tracking-tight text-foreground flex items-center gap-3">
-            <Globe className="h-8 w-8 text-primary shrink-0" />
-            Network Manager
+          <h2 className="text-xl sm:text-3xl font-bold tracking-tight text-foreground flex items-center gap-3">
+            <Globe className="h-6 w-6 sm:h-8 sm:w-8 text-primary shrink-0" />
+            Network
           </h2>
           <p className="text-muted-foreground mt-1 text-sm sm:text-base">
             Manage your routes and flight frequencies from {planningOriginAirport.name}.
@@ -555,77 +549,6 @@ export function RouteManager() {
         </div>
       </div>
 
-      {/* Stats Overview */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-        <div className="rounded-2xl border border-border/50 bg-card p-5 shadow-sm">
-          <div className="flex justify-between items-start mb-2">
-            <p className="text-xs uppercase text-muted-foreground font-bold tracking-wider">
-              HQ Hub
-            </p>
-            <MapPin className="h-4 w-4 text-primary" />
-          </div>
-          <p className="text-2xl font-bold text-foreground">{homeAirport.iata}</p>
-          <p className="text-xs text-muted-foreground truncate">
-            {homeAirport.city}, {homeAirport.country}
-          </p>
-          {originCapacityPerHour > 0 && (
-            <p className="mt-2 text-[11px] text-muted-foreground">
-              Capacity {originCapacityPerHour}/hr • Projected {projectedOriginHourly.toFixed(1)}/hr
-            </p>
-          )}
-          {originSlotControlled && !canOpenFromOrigin && (
-            <p className="mt-1 text-[11px] text-amber-400">
-              Slot Controlled • Over capacity for new routes
-            </p>
-          )}
-        </div>
-
-        <div className="rounded-2xl border border-border/50 bg-card p-5 shadow-sm">
-          <div className="flex justify-between items-start mb-2">
-            <p className="text-xs uppercase text-muted-foreground font-bold tracking-wider">
-              Total Daily Demand
-            </p>
-            <TrendingUp className="h-4 w-4 text-accent" />
-          </div>
-          <p className="text-2xl font-bold text-foreground">
-            {totalDailyDemand.toLocaleString()} pax
-          </p>
-          <p className="text-xs text-muted-foreground">
-            across {originActiveRoutes.length} active routes
-          </p>
-        </div>
-
-        <div className="rounded-2xl border border-border/50 bg-card p-5 shadow-sm overflow-hidden relative">
-          <div className="flex justify-between items-start mb-2">
-            <p className="text-xs uppercase text-muted-foreground font-bold tracking-wider">
-              Prosperity Index
-            </p>
-            <TrendingUp
-              className={`h-4 w-4 ${getProsperityIndex(tick) > 1 ? "text-emerald-400" : "text-rose-400"}`}
-            />
-          </div>
-          <p
-            className={`text-2xl font-bold ${getProsperityIndex(tick) > 1 ? "text-emerald-400" : "text-rose-400"}`}
-          >
-            {(getProsperityIndex(tick) * 100).toFixed(1)}%
-          </p>
-          <p className="text-xs text-muted-foreground mt-1">
-            {getProsperityIndex(tick) > 1
-              ? "Market Boom - High Demand"
-              : "Market Recession - Low Demand"}
-          </p>
-          {/* Tiny sparkline-like background */}
-          <div className="absolute bottom-0 left-0 w-full h-1 bg-muted/20">
-            <div
-              className={`h-full opacity-50 ${getProsperityIndex(tick) > 1 ? "bg-emerald-500" : "bg-rose-500"}`}
-              style={{
-                width: `${Math.min(100, ((getProsperityIndex(tick) - 0.85) / 0.3) * 100)}%`,
-              }}
-            />
-          </div>
-        </div>
-      </div>
-
       <div className="flex-1 overflow-hidden flex flex-col pr-2">
         {suspendedRoutes.length > 0 && !isViewingOther && (
           <div className="mb-6 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-5">
@@ -654,7 +577,7 @@ export function RouteManager() {
                       {route.originIata} → {route.destinationIata}
                     </p>
                     <p className="text-[11px] text-muted-foreground">
-                      Distance {route.distanceKm.toLocaleString()} km
+                      Distance {Math.round(route.distanceKm).toLocaleString()} km
                     </p>
                   </div>
                   <div className="flex flex-wrap items-center gap-2">
@@ -732,27 +655,29 @@ export function RouteManager() {
             </div>
           </div>
         )}
-        <div className="mb-6 flex items-center gap-4 bg-muted/30 p-4 rounded-2xl border border-border/50">
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <input
-              type="text"
-              placeholder="Search by IATA, ICAO, City, or Name..."
-              className="w-full bg-background border border-border/50 rounded-xl py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/50 transition-all font-bold"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
+        {tab === "opportunities" && (
+          <div className="mb-6 flex items-center gap-4 bg-muted/30 p-4 rounded-2xl border border-border/50">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <input
+                type="text"
+                placeholder="Search by IATA, ICAO, City, or Name..."
+                className="w-full bg-background border border-border/50 rounded-xl py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/50 transition-all font-bold"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="text-xs font-bold text-muted-foreground hover:text-foreground"
+              >
+                Clear
+              </button>
+            )}
           </div>
-          {searchQuery && (
-            <button
-              type="button"
-              onClick={() => setSearchQuery("")}
-              className="text-xs font-bold text-muted-foreground hover:text-foreground"
-            >
-              Clear
-            </button>
-          )}
-        </div>
+        )}
 
         {tab === "active" ? (
           activeRoutes.length === 0 ? (
@@ -779,9 +704,7 @@ export function RouteManager() {
               >
                 {activeRoutesVirtualizer.getVirtualItems().map((virtualItem) => {
                   const route = activeRoutes[virtualItem.index];
-                  const market = prospectMarkets.find(
-                    (p) => p.destination.iata === route.destinationIata,
-                  );
+                  const destinationAirport = airportIndex.get(route.destinationIata);
                   const assignedCount = route.assignedAircraftIds.length;
                   const demandSnapshot = getRouteDemandSnapshot(route, tick, fleet, routes);
                   const { addressableDemand } = demandSnapshot;
@@ -845,20 +768,20 @@ export function RouteManager() {
                         transform: `translateY(${virtualItem.start}px)`,
                       }}
                     >
-                      <div className="group relative rounded-2xl bg-card border border-border overflow-hidden p-5 transition-all hover:border-primary/50 hover:shadow-md mb-4">
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-6">
+                      <div className="group relative rounded-2xl bg-card border border-border overflow-hidden p-4 sm:p-5 transition-all hover:border-primary/50 hover:shadow-md mb-3">
+                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                          <div className="flex flex-wrap items-center gap-3 sm:gap-6">
                             <div className="flex flex-col">
                               <span className="text-2xl font-black text-primary leading-none tracking-tighter">
                                 {route.originIata} → {route.destinationIata}
                               </span>
                               <span className="text-xs text-muted-foreground font-semibold mt-1">
-                                {market?.destination.city}, {market?.destination.country} •{" "}
-                                {route.distanceKm.toLocaleString()}km
+                                {destinationAirport?.city}, {destinationAirport?.country} •{" "}
+                                {Math.round(route.distanceKm).toLocaleString()}km
                               </span>
                             </div>
 
-                            <div className="h-10 w-px bg-border/50" />
+                            <div className="hidden sm:block h-10 w-px bg-border/50" />
 
                             <div className="flex flex-col">
                               <span className="text-xs text-muted-foreground font-bold uppercase tracking-widest">
@@ -893,7 +816,7 @@ export function RouteManager() {
                             </div>
                           </div>
 
-                          <div className="flex items-center gap-4">
+                          <div className="flex flex-wrap items-center gap-2 sm:gap-4">
                             <div className="flex flex-col text-right">
                               <span className="text-xs text-muted-foreground font-bold uppercase tracking-widest">
                                 Fleet
@@ -954,21 +877,14 @@ export function RouteManager() {
                                   </button>
                                 </>
                               )}
-
-                              <button
-                                type="button"
-                                className="px-4 py-2 bg-accent/20 text-accent-foreground border border-accent/20 rounded-xl text-sm font-bold hover:bg-accent/30 transition-all font-mono"
-                              >
-                                {assignedCount} Planes
-                              </button>
                             </div>
                           </div>
                         </div>
 
                         {/* Market Supply / Demand */}
                         {addressableDemand && (
-                          <div className="mt-4 rounded-2xl border border-border/40 bg-muted/20 p-4">
-                            <div className="flex items-center justify-between mb-3">
+                          <div className="mt-3 rounded-xl sm:rounded-2xl border border-border/40 bg-muted/20 p-3 sm:p-4">
+                            <div className="flex items-center justify-between mb-2 sm:mb-3">
                               <span className="text-[10px] font-bold uppercase text-muted-foreground flex items-center gap-1.5">
                                 <TrendingUp className="h-3 w-3" /> Market Supply
                               </span>
@@ -977,7 +893,7 @@ export function RouteManager() {
                               </span>
                             </div>
 
-                            <div className="grid grid-cols-3 gap-3 text-[10px] font-mono">
+                            <div className="grid grid-cols-3 gap-2 sm:gap-3 text-[10px] font-mono">
                               <div className="flex flex-col gap-1 rounded-lg border border-border/30 bg-background/40 px-2 py-1.5">
                                 <span className="text-[9px] uppercase text-muted-foreground font-semibold">
                                   Total Market
@@ -1071,7 +987,7 @@ export function RouteManager() {
                         )}
 
                         {/* Market Analysis Tab */}
-                        <div className="mt-5 pt-5 border-t border-border/50">
+                        <div className="mt-3 sm:mt-5 pt-3 sm:pt-5 border-t border-border/50">
                           <div className="flex items-center justify-between mb-3">
                             <h4 className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground flex items-center gap-2">
                               <Globe className="h-3 w-3" />
@@ -1100,28 +1016,26 @@ export function RouteManager() {
                           </div>
 
                           {/* Demand class breakdown visualization */}
-                          {market && (
-                            <div className="flex h-1 w-full rounded-full bg-muted/30 overflow-hidden mb-3">
-                              <div
-                                className="h-full bg-zinc-500"
-                                style={{
-                                  width: `${(market.demand.economy / (market.demand.economy + market.demand.business + market.demand.first)) * 100}%`,
-                                }}
-                              />
-                              <div
-                                className="h-full bg-blue-500"
-                                style={{
-                                  width: `${(market.demand.business / (market.demand.economy + market.demand.business + market.demand.first)) * 100}%`,
-                                }}
-                              />
-                              <div
-                                className="h-full bg-yellow-500"
-                                style={{
-                                  width: `${(market.demand.first / (market.demand.economy + market.demand.business + market.demand.first)) * 100}%`,
-                                }}
-                              />
-                            </div>
-                          )}
+                          <div className="flex h-1 w-full rounded-full bg-muted/30 overflow-hidden mb-3">
+                            <div
+                              className="h-full bg-zinc-500"
+                              style={{
+                                width: `${(demandSnapshot.totalDemand.economy / (demandSnapshot.totalDemand.economy + demandSnapshot.totalDemand.business + demandSnapshot.totalDemand.first)) * 100}%`,
+                              }}
+                            />
+                            <div
+                              className="h-full bg-blue-500"
+                              style={{
+                                width: `${(demandSnapshot.totalDemand.business / (demandSnapshot.totalDemand.economy + demandSnapshot.totalDemand.business + demandSnapshot.totalDemand.first)) * 100}%`,
+                              }}
+                            />
+                            <div
+                              className="h-full bg-yellow-500"
+                              style={{
+                                width: `${(demandSnapshot.totalDemand.first / (demandSnapshot.totalDemand.economy + demandSnapshot.totalDemand.business + demandSnapshot.totalDemand.first)) * 100}%`,
+                              }}
+                            />
+                          </div>
 
                           {(() => {
                             const routeKey = `${route.originIata}-${route.destinationIata}`;
@@ -1144,7 +1058,10 @@ export function RouteManager() {
                                   const comp = competitors.get(offer.airlinePubkey);
 
                                   // Calculate estimated share for this offer vs ours
-                                  const ourFrequency = route.assignedAircraftIds.length * 7;
+                                  const ourFrequency = computeRouteFrequency(
+                                    route.distanceKm,
+                                    route.assignedAircraftIds.length,
+                                  );
                                   const ourTravelTime = Math.round((route.distanceKm / 800) * 60); // simplified model speed
 
                                   const ourOffer: FlightOffer = {
@@ -1167,7 +1084,7 @@ export function RouteManager() {
                                   return (
                                     <div
                                       key={`${offer.airlinePubkey}-${offer.frequencyPerWeek}-${offer.fareEconomy}`}
-                                      className="flex items-center justify-between bg-muted/30 rounded-xl px-4 py-2.5 border border-border/50"
+                                      className="flex flex-wrap items-center justify-between gap-2 bg-muted/30 rounded-xl px-3 sm:px-4 py-2 border border-border/50"
                                     >
                                       <div className="flex items-center gap-3">
                                         <div className="h-6 w-6 rounded-full bg-primary/20 flex items-center justify-center text-[10px] font-bold text-primary">
@@ -1263,8 +1180,8 @@ export function RouteManager() {
                     }}
                   >
                     <div className="group relative rounded-2xl bg-card border border-border overflow-hidden p-5 transition-all hover:border-primary/50 mb-4">
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-8">
+                      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                        <div className="flex flex-wrap items-center gap-3 sm:gap-8">
                           <div className="flex flex-col">
                             <div className="flex items-center gap-2">
                               <span className="text-2xl font-black text-foreground tracking-tighter">
@@ -1443,7 +1360,7 @@ export function RouteManager() {
                   {fareEditor.originIata} → {fareEditor.destinationIata}
                 </h3>
                 <p className="text-xs text-muted-foreground mt-1">
-                  Distance: {fareEditor.distanceKm.toLocaleString()} km
+                  Distance: {Math.round(fareEditor.distanceKm).toLocaleString()} km
                 </p>
               </div>
               <button

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -27,6 +27,7 @@ import { airports as ALL_AIRPORTS, HUB_CLASSIFICATIONS } from "@acars/data";
 import { useActiveAirline, useAirlineStore, useEngineStore } from "@acars/store";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
 import {
   AlertCircle,
   ArrowDown,
@@ -573,8 +574,14 @@ export function RouteManager() {
                   className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-500/20 bg-background/70 px-4 py-3"
                 >
                   <div>
-                    <p className="text-sm font-bold text-foreground">
-                      {route.originIata} → {route.destinationIata}
+                    <p className="text-sm font-bold text-foreground flex items-center gap-1.5">
+                      <button type="button" onClick={() => navigateToAirport(route.originIata)} className="hover:text-primary transition-colors cursor-pointer">
+                        {route.originIata}
+                      </button>
+                      <span className="text-muted-foreground">→</span>
+                      <button type="button" onClick={() => navigateToAirport(route.destinationIata)} className="hover:text-primary transition-colors cursor-pointer">
+                        {route.destinationIata}
+                      </button>
                     </p>
                     <p className="text-[11px] text-muted-foreground">
                       Distance {Math.round(route.distanceKm).toLocaleString()} km
@@ -772,8 +779,14 @@ export function RouteManager() {
                         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
                           <div className="flex flex-wrap items-center gap-3 sm:gap-6">
                             <div className="flex flex-col">
-                              <span className="text-2xl font-black text-primary leading-none tracking-tighter">
-                                {route.originIata} → {route.destinationIata}
+                              <span className="text-2xl font-black text-primary leading-none tracking-tighter flex items-center gap-2">
+                                <button type="button" onClick={() => navigateToAirport(route.originIata)} className="hover:text-foreground transition-colors cursor-pointer">
+                                  {route.originIata}
+                                </button>
+                                <span className="text-muted-foreground">→</span>
+                                <button type="button" onClick={() => navigateToAirport(route.destinationIata)} className="hover:text-foreground transition-colors cursor-pointer">
+                                  {route.destinationIata}
+                                </button>
                               </span>
                               <span className="text-xs text-muted-foreground font-semibold mt-1">
                                 {destinationAirport?.city}, {destinationAirport?.country} •{" "}
@@ -1356,8 +1369,14 @@ export function RouteManager() {
                 <p className="text-[10px] uppercase tracking-widest text-muted-foreground font-semibold">
                   Route Pricing
                 </p>
-                <h3 className="text-lg font-bold text-foreground">
-                  {fareEditor.originIata} → {fareEditor.destinationIata}
+                <h3 className="text-lg font-bold text-foreground flex items-center gap-1.5">
+                  <button type="button" onClick={() => { setFareEditor(null); navigateToAirport(fareEditor.originIata); }} className="hover:text-primary transition-colors cursor-pointer">
+                    {fareEditor.originIata}
+                  </button>
+                  <span className="text-muted-foreground">→</span>
+                  <button type="button" onClick={() => { setFareEditor(null); navigateToAirport(fareEditor.destinationIata); }} className="hover:text-primary transition-colors cursor-pointer">
+                    {fareEditor.destinationIata}
+                  </button>
                 </h3>
                 <p className="text-xs text-muted-foreground mt-1">
                   Distance: {Math.round(fareEditor.distanceKm).toLocaleString()} km

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -179,35 +179,38 @@ export function RouteManager() {
     season: Season;
   };
 
-  const calculateSearchProspect = (dest: Airport): ProspectMarket | null => {
-    if (!planningOriginAirport) return null;
-    const now = new Date();
-    const prosperity = getProsperityIndex(tick);
-    const season = getSeason(dest.latitude, now);
-    const distance = haversineDistance(
-      planningOriginAirport.latitude,
-      planningOriginAirport.longitude,
-      dest.latitude,
-      dest.longitude,
-    );
-    const demand = calculateDemand(planningOriginAirport, dest, season, prosperity, 1.0);
-    const fares = getSuggestedFares(distance);
-    const estimatedDailyRevenue = fpAdd(
-      fpAdd(
-        fpScale(fares.economy, demand.economy / 7),
-        fpScale(fares.business, demand.business / 7),
-      ),
-      fpScale(fares.first, demand.first / 7),
-    );
-    return {
-      origin: planningOriginAirport,
-      destination: dest,
-      distance,
-      demand,
-      estimatedDailyRevenue,
-      season,
-    };
-  };
+  const calculateSearchProspect = useCallback(
+    (dest: Airport): ProspectMarket | null => {
+      if (!planningOriginAirport) return null;
+      const now = new Date();
+      const prosperity = getProsperityIndex(tick);
+      const season = getSeason(dest.latitude, now);
+      const distance = haversineDistance(
+        planningOriginAirport.latitude,
+        planningOriginAirport.longitude,
+        dest.latitude,
+        dest.longitude,
+      );
+      const demand = calculateDemand(planningOriginAirport, dest, season, prosperity, 1.0);
+      const fares = getSuggestedFares(distance);
+      const estimatedDailyRevenue = fpAdd(
+        fpAdd(
+          fpScale(fares.economy, demand.economy / 7),
+          fpScale(fares.business, demand.business / 7),
+        ),
+        fpScale(fares.first, demand.first / 7),
+      );
+      return {
+        origin: planningOriginAirport,
+        destination: dest,
+        distance,
+        demand,
+        estimatedDailyRevenue,
+        season,
+      };
+    },
+    [planningOriginAirport, tick],
+  );
 
   const buildProspects = useCallback(
     (origin: Airport | null): ProspectMarket[] => {
@@ -483,7 +486,7 @@ export function RouteManager() {
         ? searchResults.map(calculateSearchProspect).filter((m): m is ProspectMarket => Boolean(m))
         : prospectMarkets;
     return candidates.filter((m) => !activeDests.has(m.destination.iata));
-  }, [searchQuery, searchResults, prospectMarkets, originActiveRoutes]);
+  }, [searchQuery, searchResults, prospectMarkets, originActiveRoutes, calculateSearchProspect]);
 
   const activeRoutesVirtualizer = useVirtualizer({
     count: activeRoutes.length,
@@ -575,11 +578,19 @@ export function RouteManager() {
                 >
                   <div>
                     <p className="text-sm font-bold text-foreground flex items-center gap-1.5">
-                      <button type="button" onClick={() => navigateToAirport(route.originIata)} className="hover:text-primary transition-colors cursor-pointer">
+                      <button
+                        type="button"
+                        onClick={() => navigateToAirport(route.originIata)}
+                        className="hover:text-primary transition-colors cursor-pointer"
+                      >
                         {route.originIata}
                       </button>
                       <span className="text-muted-foreground">→</span>
-                      <button type="button" onClick={() => navigateToAirport(route.destinationIata)} className="hover:text-primary transition-colors cursor-pointer">
+                      <button
+                        type="button"
+                        onClick={() => navigateToAirport(route.destinationIata)}
+                        className="hover:text-primary transition-colors cursor-pointer"
+                      >
                         {route.destinationIata}
                       </button>
                     </p>
@@ -780,11 +791,19 @@ export function RouteManager() {
                           <div className="flex flex-wrap items-center gap-3 sm:gap-6">
                             <div className="flex flex-col">
                               <span className="text-2xl font-black text-primary leading-none tracking-tighter flex items-center gap-2">
-                                <button type="button" onClick={() => navigateToAirport(route.originIata)} className="hover:text-foreground transition-colors cursor-pointer">
+                                <button
+                                  type="button"
+                                  onClick={() => navigateToAirport(route.originIata)}
+                                  className="hover:text-foreground transition-colors cursor-pointer"
+                                >
                                   {route.originIata}
                                 </button>
                                 <span className="text-muted-foreground">→</span>
-                                <button type="button" onClick={() => navigateToAirport(route.destinationIata)} className="hover:text-foreground transition-colors cursor-pointer">
+                                <button
+                                  type="button"
+                                  onClick={() => navigateToAirport(route.destinationIata)}
+                                  className="hover:text-foreground transition-colors cursor-pointer"
+                                >
                                   {route.destinationIata}
                                 </button>
                               </span>
@@ -1029,26 +1048,43 @@ export function RouteManager() {
                           </div>
 
                           {/* Demand class breakdown visualization */}
-                          <div className="flex h-1 w-full rounded-full bg-muted/30 overflow-hidden mb-3">
-                            <div
-                              className="h-full bg-zinc-500"
-                              style={{
-                                width: `${(demandSnapshot.totalDemand.economy / (demandSnapshot.totalDemand.economy + demandSnapshot.totalDemand.business + demandSnapshot.totalDemand.first)) * 100}%`,
-                              }}
-                            />
-                            <div
-                              className="h-full bg-blue-500"
-                              style={{
-                                width: `${(demandSnapshot.totalDemand.business / (demandSnapshot.totalDemand.economy + demandSnapshot.totalDemand.business + demandSnapshot.totalDemand.first)) * 100}%`,
-                              }}
-                            />
-                            <div
-                              className="h-full bg-yellow-500"
-                              style={{
-                                width: `${(demandSnapshot.totalDemand.first / (demandSnapshot.totalDemand.economy + demandSnapshot.totalDemand.business + demandSnapshot.totalDemand.first)) * 100}%`,
-                              }}
-                            />
-                          </div>
+                          {(() => {
+                            const demandTotal =
+                              demandSnapshot.totalDemand.economy +
+                              demandSnapshot.totalDemand.business +
+                              demandSnapshot.totalDemand.first;
+                            return (
+                              <div className="flex h-1 w-full rounded-full bg-muted/30 overflow-hidden mb-3">
+                                <div
+                                  className="h-full bg-zinc-500"
+                                  style={{
+                                    width:
+                                      demandTotal === 0
+                                        ? "0%"
+                                        : `${(demandSnapshot.totalDemand.economy / demandTotal) * 100}%`,
+                                  }}
+                                />
+                                <div
+                                  className="h-full bg-blue-500"
+                                  style={{
+                                    width:
+                                      demandTotal === 0
+                                        ? "0%"
+                                        : `${(demandSnapshot.totalDemand.business / demandTotal) * 100}%`,
+                                  }}
+                                />
+                                <div
+                                  className="h-full bg-yellow-500"
+                                  style={{
+                                    width:
+                                      demandTotal === 0
+                                        ? "0%"
+                                        : `${(demandSnapshot.totalDemand.first / demandTotal) * 100}%`,
+                                  }}
+                                />
+                              </div>
+                            );
+                          })()}
 
                           {(() => {
                             const routeKey = `${route.originIata}-${route.destinationIata}`;
@@ -1370,11 +1406,25 @@ export function RouteManager() {
                   Route Pricing
                 </p>
                 <h3 className="text-lg font-bold text-foreground flex items-center gap-1.5">
-                  <button type="button" onClick={() => { setFareEditor(null); navigateToAirport(fareEditor.originIata); }} className="hover:text-primary transition-colors cursor-pointer">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setFareEditor(null);
+                      navigateToAirport(fareEditor.originIata);
+                    }}
+                    className="hover:text-primary transition-colors cursor-pointer"
+                  >
                     {fareEditor.originIata}
                   </button>
                   <span className="text-muted-foreground">→</span>
-                  <button type="button" onClick={() => { setFareEditor(null); navigateToAirport(fareEditor.destinationIata); }} className="hover:text-primary transition-colors cursor-pointer">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setFareEditor(null);
+                      navigateToAirport(fareEditor.destinationIata);
+                    }}
+                    className="hover:text-primary transition-colors cursor-pointer"
+                  >
                     {fareEditor.destinationIata}
                   </button>
                 </h3>

--- a/apps/web/src/features/network/components/Ticker.test.tsx
+++ b/apps/web/src/features/network/components/Ticker.test.tsx
@@ -80,7 +80,6 @@ describe("Ticker", () => {
     });
 
     render(<Ticker />);
-    expect(screen.getByText("JFK")).toBeInTheDocument();
     expect(screen.getByText("summer")).toBeInTheDocument();
     expect(screen.getByText(/Live Data/i)).toBeInTheDocument();
   });

--- a/apps/web/src/features/network/components/Ticker.tsx
+++ b/apps/web/src/features/network/components/Ticker.tsx
@@ -1,7 +1,5 @@
 import { getProsperityIndex } from "@acars/core";
-import { airports as AIRPORTS } from "@acars/data";
 import { useAirlineStore, useEngineStore } from "@acars/store";
-import { useFinancialPulse } from "@/features/corporate/hooks/useFinancialPulse";
 
 /**
  * A global ticker component that displays live macroeconomic and network status.
@@ -14,13 +12,9 @@ export function Ticker() {
   const progress = useEngineStore((s) => s.tickProgress);
   const catchup = useEngineStore((s) => s.catchupProgress);
 
-  const { competitors, fleetByOwner, routesByOwner, timeline } = useAirlineStore();
-
-  const safeTimeline = Array.isArray(timeline) ? timeline : [];
+  const { competitors, fleetByOwner, routesByOwner } = useAirlineStore();
 
   const prosperity = getProsperityIndex(tick);
-  const pulse = useFinancialPulse(safeTimeline);
-  const recentLoadFactor = pulse.flightCount > 0 ? Math.round(pulse.avgLoadFactor * 100) : null;
 
   if (!homeAirport) return null;
 
@@ -52,46 +46,28 @@ export function Ticker() {
       </div>
 
       <div className="hidden sm:flex items-center space-x-2 border-r border-border pr-6">
-        <span>Total Planes</span>
+        <span>Planes</span>
         <span className="text-foreground font-bold">
           {Array.from(fleetByOwner.values()).reduce((sum, f) => sum + f.length, 0)}
         </span>
       </div>
 
       <div className="hidden sm:flex items-center space-x-2 border-r border-border pr-6">
-        <span>Active Routes</span>
+        <span>Routes</span>
         <span className="text-foreground font-bold">
           {Array.from(routesByOwner.values()).reduce((sum, r) => sum + r.length, 0)}
         </span>
       </div>
 
       <div className="hidden md:flex items-center space-x-2 border-r border-border pr-6">
-        <span>Hub</span>
-        <span className="text-accent">{homeAirport.iata}</span>
-      </div>
-      <div className="hidden md:flex items-center space-x-2 border-r border-border pr-6">
         <span>Season</span>
         <span className="text-info text-blue-400 capitalize">{season}</span>
       </div>
       <div className="hidden md:flex items-center space-x-2 border-r border-border pr-6">
-        <span>Market Economy</span>
+        <span>Economy</span>
         <span className={`font-semibold ${prosperity >= 1 ? "text-green-500" : "text-orange-400"}`}>
           {(prosperity * 100).toFixed(1)}%
         </span>
-      </div>
-      {recentLoadFactor !== null && (
-        <div className="hidden md:flex items-center space-x-2 border-r border-border pr-6">
-          <span>Avg LF</span>
-          <span
-            className={`font-semibold ${recentLoadFactor >= 80 ? "text-green-500" : recentLoadFactor >= 60 ? "text-amber-400" : "text-rose-400"}`}
-          >
-            {recentLoadFactor}%
-          </span>
-        </div>
-      )}
-      <div className="hidden lg:flex items-center space-x-2 border-r border-border pr-6">
-        <span>Database</span>
-        <span className="text-foreground">{AIRPORTS.length} Airports</span>
       </div>
       <div className="flex items-center space-x-2 shrink-0">
         <span>Status</span>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import { createRootRoute, Outlet } from "@tanstack/react-router";
-import React, { Suspense } from "react";
 import { IdentityGate } from "@/features/identity/components/IdentityGate";
 import { Ticker } from "@/features/network/components/Ticker";
 import { WorldMap } from "@/features/network/components/WorldMap";
@@ -12,15 +11,6 @@ type RootSearch = {
   aircraftTab?: "info" | "route";
   tab?: "active" | "opportunities";
 };
-
-const TanStackRouterDevtools =
-  process.env.NODE_ENV === "production"
-    ? () => null
-    : React.lazy(() =>
-        import("@tanstack/router-devtools").then((res) => ({
-          default: res.TanStackRouterDevtools,
-        })),
-      );
 
 export const Route = createRootRoute({
   validateSearch: (search: Record<string, unknown>): RootSearch => {
@@ -64,10 +54,6 @@ export const Route = createRootRoute({
 
         {/* Layer 2: The Global Edge Ticker (Always rendering) */}
         <Ticker />
-
-        <Suspense fallback={null}>
-          <TanStackRouterDevtools position="top-right" />
-        </Suspense>
       </div>
     </AppInitializer>
   ),

--- a/packages/core/src/fleet.ts
+++ b/packages/core/src/fleet.ts
@@ -1,50 +1,81 @@
-import { fpScale } from './fixed-point.js';
-import type { AircraftModel, FixedPoint } from './types.js';
-import { TICKS_PER_HOUR } from './types.js';
+import { fpScale } from "./fixed-point.js";
+import type { AircraftModel, FixedPoint } from "./types.js";
+import { TICKS_PER_HOUR } from "./types.js";
+
+/**
+ * Computes the realistic weekly flight frequency for a route given the number of
+ * assigned aircraft, route distance, aircraft speed and turnaround time.
+ *
+ * Each aircraft can complete N round-trips per week:
+ *   roundTripHours = 2 * (distanceKm / speedKmh) + 2 * (turnaroundMinutes / 60)
+ *   tripsPerWeek = floor(168 / roundTripHours)   // 168 hours in a week
+ *   totalFrequency = assignedAircraft * tripsPerWeek
+ *
+ * Falls back to assignedAircraft * 7 if model info is unavailable.
+ */
+export function computeRouteFrequency(
+  distanceKm: number,
+  assignedAircraftCount: number,
+  speedKmh: number = 800,
+  turnaroundMinutes: number = 35,
+): number {
+  if (assignedAircraftCount <= 0) return 0;
+  if (distanceKm <= 0 || speedKmh <= 0) return assignedAircraftCount * 7;
+
+  const legHours = distanceKm / speedKmh;
+  const turnaroundHours = turnaroundMinutes / 60;
+  const roundTripHours = 2 * legHours + 2 * turnaroundHours;
+
+  // Cap at realistic block hours per day (~16 hours of utilization)
+  const hoursPerWeek = 168; // 7 * 24
+  const tripsPerAircraftPerWeek = Math.max(1, Math.floor(hoursPerWeek / roundTripHours));
+
+  return assignedAircraftCount * tripsPerAircraftPerWeek;
+}
 
 /**
  * Calculates the current book value of an aircraft based on straight-line depreciation,
  * condition penalties, and utilization penalties.
  */
 export function calculateBookValue(
-    model: AircraftModel,
-    flightHoursTotal: number,
-    condition: number, // 0.0 to 1.0
-    manufactureTick: number,
-    currentTick: number
+  model: AircraftModel,
+  flightHoursTotal: number,
+  condition: number, // 0.0 to 1.0
+  manufactureTick: number,
+  currentTick: number,
 ): FixedPoint {
-    // 1. Calculate Age in Years
-    const ticksPerDay = TICKS_PER_HOUR * 24;
-    const ticksPerYear = ticksPerDay * 365;
-    const ageTicks = Math.max(0, currentTick - manufactureTick);
-    const ageYears = Math.floor(ageTicks / ticksPerYear);
+  // 1. Calculate Age in Years
+  const ticksPerDay = TICKS_PER_HOUR * 24;
+  const ticksPerYear = ticksPerDay * 365;
+  const ageTicks = Math.max(0, currentTick - manufactureTick);
+  const ageYears = Math.floor(ageTicks / ticksPerYear);
 
-    // 2. Declining Balance Depreciation (Exponential)
-    // Most aircraft lose 8-12% of their value per year.
-    // We use a 10% annual depreciation rate for a realistic curve.
-    const annualRate = 0.10;
-    const residualPercent = model.residualValuePercent / 100;
-    const residualValue = fpScale(model.price, residualPercent);
+  // 2. Declining Balance Depreciation (Exponential)
+  // Most aircraft lose 8-12% of their value per year.
+  // We use a 10% annual depreciation rate for a realistic curve.
+  const annualRate = 0.1;
+  const residualPercent = model.residualValuePercent / 100;
+  const residualValue = fpScale(model.price, residualPercent);
 
-    // V = P * (1-r)^t
-    let baseValue = fpScale(model.price, Math.pow(1 - annualRate, ageYears));
+  // V = P * (1-r)^t
+  let baseValue = fpScale(model.price, Math.pow(1 - annualRate, ageYears));
 
-    // 3. Apply Condition Penalty (Up to 30% reduction)
-    // 100% condition = 0 penalty. 50% condition = 15% penalty.
-    const conditionPenalty = (1 - condition) * 0.3;
-    baseValue = fpScale(baseValue, 1 - conditionPenalty);
+  // 3. Apply Condition Penalty (Up to 30% reduction)
+  // 100% condition = 0 penalty. 50% condition = 15% penalty.
+  const conditionPenalty = (1 - condition) * 0.3;
+  baseValue = fpScale(baseValue, 1 - conditionPenalty);
 
-    // 4. Heavy Utilization Penalty
-    // Average utilization is model.blockHoursPerDay.
-    // Penalize if the flight hour density is high.
-    const expectedHours = (model.blockHoursPerDay * 365) * ageYears;
-    const utilizationRatio = expectedHours > 100 ? flightHoursTotal / expectedHours : 1.0;
+  // 4. Heavy Utilization Penalty
+  // Average utilization is model.blockHoursPerDay.
+  // Penalize if the flight hour density is high.
+  const expectedHours = model.blockHoursPerDay * 365 * ageYears;
+  const utilizationRatio = expectedHours > 100 ? flightHoursTotal / expectedHours : 1.0;
 
-    if (utilizationRatio > 1.2) {
-        // High wear penalty (extra 10%)
-        baseValue = fpScale(baseValue, 0.9);
-    }
+  if (utilizationRatio > 1.2) {
+    // High wear penalty (extra 10%)
+    baseValue = fpScale(baseValue, 0.9);
+  }
 
-    // 5. Floor at residual value
-    return (baseValue > residualValue ? baseValue : residualValue);
+  // 5. Floor at residual value
+  return baseValue > residualValue ? baseValue : residualValue;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,7 +57,7 @@ export {
   fpToNumber,
 } from "./fixed-point.js";
 // Fleet
-export { calculateBookValue } from "./fleet.js";
+export { calculateBookValue, computeRouteFrequency } from "./fleet.js";
 // Geography
 export { haversineDistance } from "./geo.js";
 // Hubs

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -7,6 +7,7 @@ import {
   calculateHubLandingFee,
   calculatePriceElasticity,
   calculateSupplyPressure,
+  computeRouteFrequency,
   countLandingsBetween,
   detectPriceWar,
   fp,
@@ -300,7 +301,12 @@ export function processFlightEngine(
 
           // Frequency for our offer: how many planes we (the player) have on this route?
           const ourFrequency = route
-            ? Math.max(1, route.assignedAircraftIds.length * 7)
+            ? computeRouteFrequency(
+                route.distanceKm,
+                Math.max(1, route.assignedAircraftIds.length),
+                model.speedKmh || 800,
+                model.turnaroundTimeMinutes,
+              )
             : Math.max(1, ac.flight?.frequencyPerWeek ?? 7);
 
           // Travel time for our current aircraft

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -9,6 +9,7 @@ import type {
 } from "@acars/core";
 import {
   computeCheckpointStateHash,
+  computeRouteFrequency,
   createLogger,
   fp,
   fpAdd,
@@ -393,28 +394,27 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
             const key = `${route.originIata}-${route.destinationIata}`;
             const offers = registry.get(key) || [];
 
-            const frequency = Math.max(0, route.assignedAircraftIds.length * 7);
-            if (frequency === 0) continue;
-
+            let avgSpeed = 800;
             let avgTravelTime = 0;
             if (route.assignedAircraftIds.length > 0) {
-              const modelIds = route.assignedAircraftIds
+              const models = route.assignedAircraftIds
                 .map((id: string) => {
                   const ac = resolvedFleet.find((a: AircraftInstance) => a.id === id);
-                  return ac?.modelId;
+                  return ac ? getAircraftById(ac.modelId) : null;
                 })
                 .filter(Boolean);
-
-              const times = modelIds.map((mid: string | undefined) => {
-                const model = getAircraftById(mid!);
-                if (!model) return 480;
-                return (route.distanceKm / (model.speedKmh || 800)) * 60;
-              });
-              avgTravelTime =
-                times.length > 0
-                  ? times.reduce((a: number, b: number) => a + b, 0) / times.length
-                  : 480;
+              if (models.length > 0) {
+                avgSpeed = models.reduce((sum, m) => sum + (m!.speedKmh || 800), 0) / models.length;
+                avgTravelTime = (route.distanceKm / avgSpeed) * 60;
+              }
             }
+
+            const frequency = computeRouteFrequency(
+              route.distanceKm,
+              route.assignedAircraftIds.length,
+              avgSpeed,
+            );
+            if (frequency === 0) continue;
 
             const offer: FlightOffer = {
               airlinePubkey: airline.ceoPubkey,
@@ -451,27 +451,28 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
             if (route.status !== "active") continue;
             const key = `${route.originIata}-${route.destinationIata}`;
             const offers = registry.get(key) || [];
-            const frequency = Math.max(0, route.assignedAircraftIds.length * 7);
-            if (frequency === 0) continue;
 
+            let avgSpeed = 800;
             let avgTravelTime = 0;
             if (route.assignedAircraftIds.length > 0) {
-              const modelIds = route.assignedAircraftIds
+              const models = route.assignedAircraftIds
                 .map((id: string) => {
                   const ac = preservedFleet.find((a: AircraftInstance) => a.id === id);
-                  return ac?.modelId;
+                  return ac ? getAircraftById(ac.modelId) : null;
                 })
                 .filter(Boolean);
-              const times = modelIds.map((mid: string | undefined) => {
-                const model = getAircraftById(mid!);
-                if (!model) return 480;
-                return (route.distanceKm / (model.speedKmh || 800)) * 60;
-              });
-              avgTravelTime =
-                times.length > 0
-                  ? times.reduce((a: number, b: number) => a + b, 0) / times.length
-                  : 480;
+              if (models.length > 0) {
+                avgSpeed = models.reduce((sum, m) => sum + (m!.speedKmh || 800), 0) / models.length;
+                avgTravelTime = (route.distanceKm / avgSpeed) * 60;
+              }
             }
+
+            const frequency = computeRouteFrequency(
+              route.distanceKm,
+              route.assignedAircraftIds.length,
+              avgSpeed,
+            );
+            if (frequency === 0) continue;
 
             const offer: FlightOffer = {
               airlinePubkey: airline.ceoPubkey,
@@ -866,27 +867,28 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
         // Add new offers from this competitor
         for (const route of resolvedRoutes) {
           if (route.status !== "active") continue;
-          const frequency = Math.max(0, route.assignedAircraftIds.length * 7);
-          if (frequency === 0) continue;
 
+          let avgSpeed = 800;
           let avgTravelTime = 0;
           if (route.assignedAircraftIds.length > 0) {
-            const modelIds = route.assignedAircraftIds
+            const models = route.assignedAircraftIds
               .map((id: string) => {
                 const ac = resolvedFleet.find((a: AircraftInstance) => a.id === id);
-                return ac?.modelId;
+                return ac ? getAircraftById(ac.modelId) : null;
               })
               .filter(Boolean);
-            const times = modelIds.map((mid: string | undefined) => {
-              const model = getAircraftById(mid!);
-              if (!model) return 480;
-              return (route.distanceKm / (model.speedKmh || 800)) * 60;
-            });
-            avgTravelTime =
-              times.length > 0
-                ? times.reduce((a: number, b: number) => a + b, 0) / times.length
-                : 480;
+            if (models.length > 0) {
+              avgSpeed = models.reduce((sum, m) => sum + (m!.speedKmh || 800), 0) / models.length;
+              avgTravelTime = (route.distanceKm / avgSpeed) * 60;
+            }
           }
+
+          const frequency = computeRouteFrequency(
+            route.distanceKm,
+            route.assignedAircraftIds.length,
+            avgSpeed,
+          );
+          if (frequency === 0) continue;
 
           const key = `${route.originIata}-${route.destinationIata}`;
           const offers = updatedRegistry.get(key) || [];


### PR DESCRIPTION
This PR replaces the hardcoded `* 7` assumption for route frequencies with a dynamic calculation (`computeRouteFrequency`).

# Changes
- Added `computeRouteFrequency` to `@acars/core`
- Updated `FlightEngine.ts` to compute expected frequency based on range and model capabilities (speed, turnaround)
- Updated competitor prediction inside `worldSlice.ts`
- Cleaned up the Route Manager UI (removed the bulky header blocks)
- Hide destination search bar in active routes tab
- Reversed the order of routes and fleet lists so the newest elements always show at the top
- **New Navigation Links:** Added ability to click from the Fleet tab directly into an aircraft's permalink, and from the Network tab directly into an airport's permalink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leaderboard metric selector converted from button grid to a dropdown (chevron added); default metric set to network distance; network distances now rounded before display.

* **Improvements**
  * Route frequencies now computed from aircraft specifications for more accurate weekly estimates.
  * Fleet and route lists show newest items first.
  * Aircraft, airport and route entries are now navigable via clickable controls.

* **UI Updates**
  * Ticker simplified with updated labels and removed sections; various layout and typography refinements.

* **Chores**
  * Development tools integration removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->