### PR TITLE
fix(nostr): pass explicit retry options to ndk-blossom uploads

### DIFF
--- a/packages/nostr/src/blossom.ts
+++ b/packages/nostr/src/blossom.ts
@@ -43,6 +43,8 @@ export async function uploadToBlossom(
 
   const imeta = await blossom.upload(file, {
     server: DEFAULT_BLOSSOM_SERVER,
+    maxRetries: 3,
+    retryDelay: 1000,
   });
 
   const url = imeta.url;


### PR DESCRIPTION
## Problem

Blossom uploads silently fail with:
```
NDKBlossomUploadError: Upload failed on specified server: https://blossom.primal.net: Request failed after undefined retries
```

## Root Cause

`ndk-blossom` v2.0.2 has a bug in `uploadToServer`: it passes `options.maxRetries` (which is `undefined` when not explicitly set) into `fetchWithRetry`. When spread over `DEFAULT_RETRY_OPTIONS`, the `undefined` value overrides the default `maxRetries: 3`. This causes the retry loop condition `while (attempts <= undefined)` to evaluate to `false`, so **the HTTP request never executes at all**.

## Fix

Pass explicit `maxRetries: 3` and `retryDelay: 1000` in the `blossom.upload()` call options to bypass the bug.

## Testing

- `pnpm --filter @acars/nostr lint` ✅
- `pnpm --filter @acars/nostr typecheck` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload reliability with automatic retry logic for transient failures, enhancing transfer success rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->