### PR TITLE
fix(store): isolate IndexedDB per WORLD_ID

### DIFF
--- a/packages/nostr/src/schema.dtag.test.ts
+++ b/packages/nostr/src/schema.dtag.test.ts
@@ -14,8 +14,8 @@ describe("buildActionDTag", () => {
       payload: { tick: 99 },
     });
 
-    expect(createTag).toBe("airtr:world:v5-beta:action:airline_create");
-    expect(tickTag).toBe("airtr:world:v5-beta:action:tick_update");
+    expect(createTag).toBe("airtr:world:v6-beta:action:airline_create");
+    expect(tickTag).toBe("airtr:world:v6-beta:action:tick_update");
   });
 
   it("keeps action-only d-tags for airline create and tick update even with seq", () => {
@@ -29,8 +29,8 @@ describe("buildActionDTag", () => {
     );
 
     // seq is ignored for singleton actions
-    expect(createTag).toBe("airtr:world:v5-beta:action:airline_create");
-    expect(tickTag).toBe("airtr:world:v5-beta:action:tick_update");
+    expect(createTag).toBe("airtr:world:v6-beta:action:airline_create");
+    expect(tickTag).toBe("airtr:world:v6-beta:action:tick_update");
   });
 
   it("adds entity id and tick for route actions", () => {
@@ -40,7 +40,7 @@ describe("buildActionDTag", () => {
       payload: { routeId: "rt-123", tick: 100 },
     });
 
-    expect(tag).toBe("airtr:world:v5-beta:action:route_open:rt-123:100");
+    expect(tag).toBe("airtr:world:v6-beta:action:route_open:rt-123:100");
   });
 
   it("adds entity id, tick, and seq for route actions when seq is provided", () => {
@@ -49,7 +49,7 @@ describe("buildActionDTag", () => {
       7,
     );
 
-    expect(tag).toBe("airtr:world:v5-beta:action:route_open:rt-123:100:s7");
+    expect(tag).toBe("airtr:world:v6-beta:action:route_open:rt-123:100:s7");
   });
 
   it("adds entity id and tick for aircraft actions", () => {
@@ -59,7 +59,7 @@ describe("buildActionDTag", () => {
       payload: { instanceId: "ac-777", tick: 555 },
     });
 
-    expect(tag).toBe("airtr:world:v5-beta:action:aircraft_purchase:ac-777:555");
+    expect(tag).toBe("airtr:world:v6-beta:action:aircraft_purchase:ac-777:555");
   });
 
   it("adds entity id, tick, and seq for aircraft actions when seq is provided", () => {
@@ -72,7 +72,7 @@ describe("buildActionDTag", () => {
       42,
     );
 
-    expect(tag).toBe("airtr:world:v5-beta:action:aircraft_purchase:ac-777:555:s42");
+    expect(tag).toBe("airtr:world:v6-beta:action:aircraft_purchase:ac-777:555:s42");
   });
 
   it("returns base tag when no identifiers are present", () => {
@@ -82,13 +82,13 @@ describe("buildActionDTag", () => {
       payload: {},
     });
 
-    expect(tag).toBe("airtr:world:v5-beta:action:hub_add");
+    expect(tag).toBe("airtr:world:v6-beta:action:hub_add");
   });
 
   it("returns base tag with only seq when no identifiers are present but seq is provided", () => {
     const tag = buildActionDTag({ schemaVersion: 2, action: "HUB_ADD", payload: {} }, 3);
 
-    expect(tag).toBe("airtr:world:v5-beta:action:hub_add:s3");
+    expect(tag).toBe("airtr:world:v6-beta:action:hub_add:s3");
   });
 
   it("ensures different seq values produce different d-tags for same action", () => {
@@ -97,8 +97,8 @@ describe("buildActionDTag", () => {
     const tag2 = buildActionDTag({ schemaVersion: 2, action: "ROUTE_UPDATE_FARES", payload }, 1);
 
     expect(tag1).not.toBe(tag2);
-    expect(tag1).toBe("airtr:world:v5-beta:action:route_update_fares:rt-abc:200:s0");
-    expect(tag2).toBe("airtr:world:v5-beta:action:route_update_fares:rt-abc:200:s1");
+    expect(tag1).toBe("airtr:world:v6-beta:action:route_update_fares:rt-abc:200:s0");
+    expect(tag2).toBe("airtr:world:v6-beta:action:route_update_fares:rt-abc:200:s1");
   });
 
   it("omits seq suffix when seq is undefined", () => {
@@ -109,6 +109,6 @@ describe("buildActionDTag", () => {
     });
 
     // Without seq, the d-tag should be the same as before (backward compatible)
-    expect(withoutSeq).toBe("airtr:world:v5-beta:action:route_assign_aircraft:rt-1:50");
+    expect(withoutSeq).toBe("airtr:world:v6-beta:action:route_assign_aircraft:rt-1:50");
   });
 });

--- a/packages/nostr/src/schema.ts
+++ b/packages/nostr/src/schema.ts
@@ -60,7 +60,7 @@ export interface ActionLogEntry {
 }
 
 export const ACTION_KIND = 30078;
-export const WORLD_ID = "v5-beta";
+export const WORLD_ID = "v6-beta";
 const ACARS_SCHEMA_VERSION = 1;
 const ACTION_D_PREFIX = `airtr:world:${WORLD_ID}:action:`;
 const CHECKPOINT_D_TAG = `airtr:world:${WORLD_ID}:checkpoint`;

--- a/packages/store/src/db.ts
+++ b/packages/store/src/db.ts
@@ -1,7 +1,10 @@
 import Dexie, { type EntityTable } from "dexie";
 import type { AirlineEntity, AircraftInstance, Route } from "@acars/core";
+import { WORLD_ID } from "@acars/nostr/src/schema";
 
-export const db = new Dexie("AirTRDatabase") as Dexie & {
+const DB_NAME = `AirTRDatabase-${WORLD_ID}`;
+
+export const db = new Dexie(DB_NAME) as Dexie & {
   airline: EntityTable<AirlineEntity, "id">;
   fleet: EntityTable<AircraftInstance, "id">;
   routes: EntityTable<Route, "id">;


### PR DESCRIPTION
## Summary
- scope the local Dexie database name by `WORLD_ID`
- this prevents beta world (`v5-beta`) from hydrating legacy local cache from previous worlds
- avoids accidental carry-over of stale local state into new-world snapshot publishing

## Change
- `packages/store/src/db.ts`
  - from: `new Dexie("AirTRDatabase")`
  - to: `new Dexie(`AirTRDatabase-${WORLD_ID}`)`

## Validation
- `pnpm --filter @acars/store lint`
- `pnpm --filter @acars/store typecheck`
- `pnpm --filter @acars/store test`
- `pnpm --filter @acars/nostr lint`
- `pnpm --filter @acars/nostr typecheck`
- `pnpm --filter @acars/web typecheck`
