### PR TITLE
feat(network): display livery images in aircraft info panel

### DIFF
--- a/apps/web/src/features/fleet/components/AircraftLiveryImage.tsx
+++ b/apps/web/src/features/fleet/components/AircraftLiveryImage.tsx
@@ -9,6 +9,8 @@ interface AircraftLiveryImageProps {
   isOwner: boolean;
   /** Fallback content rendered when no image is available (e.g., SVG silhouette) */
   fallback: React.ReactNode;
+  /** Override the default `object-cover` fit on the <img>. Use `object-contain` to avoid cropping. */
+  objectFit?: "object-cover" | "object-contain";
 }
 
 export function AircraftLiveryImage({
@@ -17,6 +19,7 @@ export function AircraftLiveryImage({
   model,
   isOwner,
   fallback,
+  objectFit = "object-cover",
 }: AircraftLiveryImageProps) {
   const { imageUrl, isGenerating, error } = useAircraftImage(aircraft, airline, model, isOwner);
 
@@ -26,7 +29,7 @@ export function AircraftLiveryImage({
         src={imageUrl}
         alt={`${airline?.name ?? "Airline"} ${model.manufacturer} ${model.name} livery`}
         loading="lazy"
-        className="absolute inset-0 h-full w-full object-cover"
+        className={`absolute inset-0 h-full w-full ${objectFit}`}
       />
     );
   }

--- a/apps/web/src/features/network/components/AircraftInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AircraftInfoPanel.tsx
@@ -6,8 +6,9 @@ import { useAirlineStore, useEngineStore } from "@acars/store";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { Plane, Route as RouteIcon, Wrench, X } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
+import { AircraftLiveryImage } from "@/features/fleet/components/AircraftLiveryImage";
 import { getAircraftTimer } from "@/features/fleet/utils/aircraftTimers";
-import { navigateToAirport, navigateToAircraft } from "@/shared/lib/permalinkNavigation";
+import { navigateToAircraft, navigateToAirport } from "@/shared/lib/permalinkNavigation";
 
 type AircraftInfoPanelProps = {
   aircraft: AircraftInstance;
@@ -228,7 +229,7 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
 
   return (
     <aside
-      className="pointer-events-auto fixed z-30 w-[min(480px,calc(100vw-2rem))] max-h-[80vh] rounded-2xl border border-border bg-background/90 shadow-[0_30px_90px_rgba(0,0,0,0.65)] backdrop-blur-2xl overflow-hidden left-4 right-4 bottom-4 sm:left-auto sm:right-4 sm:bottom-auto sm:top-1/2 sm:-translate-y-1/2"
+      className="pointer-events-auto fixed z-30 flex flex-col w-[min(480px,calc(100vw-2rem))] max-h-[80vh] rounded-2xl border border-border bg-background/90 shadow-[0_30px_90px_rgba(0,0,0,0.65)] backdrop-blur-2xl overflow-hidden left-4 right-4 bottom-4 sm:left-auto sm:right-4 sm:bottom-auto sm:top-1/2 sm:-translate-y-1/2"
       aria-live="polite"
     >
       {/* Header */}
@@ -277,8 +278,25 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
         </button>
       </div>
 
+      {/* Livery hero image */}
+      {model ? (
+        <div className="relative h-40 w-full overflow-hidden bg-zinc-900/40">
+          <AircraftLiveryImage
+            aircraft={aircraft}
+            airline={ownerAirline}
+            model={model}
+            isOwner={isPlayerAircraft}
+            fallback={
+              <div className="absolute inset-0 flex items-center justify-center text-zinc-800/20 select-none">
+                <AircraftSilhouette familyId={familyId} className="h-32 w-32 rotate-12" />
+              </div>
+            }
+          />
+        </div>
+      ) : null}
+
       {/* Content */}
-      <div className="max-h-[70vh] overflow-y-auto overscroll-contain px-5 py-4 space-y-5">
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-5 py-4 space-y-5">
         {/* Status badge */}
         <div className="flex flex-wrap items-center gap-2">
           <span

--- a/apps/web/src/features/network/components/AircraftInfoPanel.tsx
+++ b/apps/web/src/features/network/components/AircraftInfoPanel.tsx
@@ -280,12 +280,13 @@ export function AircraftInfoPanel({ aircraft, onClose }: AircraftInfoPanelProps)
 
       {/* Livery hero image */}
       {model ? (
-        <div className="relative h-40 w-full overflow-hidden bg-zinc-900/40">
+        <div className="relative w-full overflow-hidden bg-zinc-900/40 h-56">
           <AircraftLiveryImage
             aircraft={aircraft}
             airline={ownerAirline}
             model={model}
             isOwner={isPlayerAircraft}
+            objectFit="object-contain"
             fallback={
               <div className="absolute inset-0 flex items-center justify-center text-zinc-800/20 select-none">
                 <AircraftSilhouette familyId={familyId} className="h-32 w-32 rotate-12" />


### PR DESCRIPTION
## Summary

- Reuses the existing `AircraftLiveryImage` component from the fleet panel to display AI-generated Blossom-stored livery images as a hero banner in the `AircraftInfoPanel`
- Falls back to the SVG silhouette when no livery image is available (same pattern as fleet cards)
- Switches the panel to flex column layout so the scrollable content area properly fills remaining space below the image

## Details

The `AircraftInfoPanel` (the sidebar that appears when clicking an aircraft on the map) now shows the same livery images that are generated and persisted via the fleet panel pipeline:

1. If the aircraft already has a `liveryImageUrl` (Blossom URL) → displays it immediately
2. If the viewer is the aircraft owner and no image exists → triggers generation via the existing `useAircraftImage` hook
3. If no image and not the owner → shows the SVG silhouette fallback

No new dependencies or API changes — this is purely wiring the existing image infrastructure into the info panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Aircraft livery images now display in the aircraft information panel with automatic fallback to a silhouette when unavailable.
  * Enhanced panel layout with flexible, scrollable content region for improved visibility and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->