### PR TITLE
feat(web): diverse scene variations for aircraft livery images

### DIFF
--- a/apps/web/src/features/fleet/hooks/useAircraftImage.ts
+++ b/apps/web/src/features/fleet/hooks/useAircraftImage.ts
@@ -1,13 +1,13 @@
-import { useState, useEffect, useRef } from "react";
 import type { AircraftInstance, AircraftModel, AirlineEntity } from "@acars/core";
+import { uploadToBlossom } from "@acars/nostr";
 import { useAirlineStore } from "@acars/store";
+import { useEffect, useRef, useState } from "react";
 import {
   buildLiveryPrompt,
   computePromptHash,
   generateLiveryImage,
   isLiveryApiUnavailable,
 } from "../services/aircraftImageService";
-import { uploadToBlossom } from "@acars/nostr";
 
 // ---------------------------------------------------------------------------
 // IndexedDB cache for generated livery images (survives page reloads)
@@ -145,7 +145,7 @@ export function useAircraftImage(
       if (!airline || !model) return;
 
       const hubIata = airline.hubs[0] ?? aircraft.baseAirportIata;
-      const currentHash = await computePromptHash(airline, model, hubIata);
+      const currentHash = await computePromptHash(airline, model, hubIata, aircraft.id);
 
       // Bailed by StrictMode cleanup while computing hash
       if (cancelled) return;
@@ -201,7 +201,7 @@ export function useAircraftImage(
       // Do NOT check `cancelled` inside — parent re-renders must not abort queued work.
       enqueue(async () => {
         try {
-          const prompt = buildLiveryPrompt(airline!, model!, hubIata);
+          const prompt = buildLiveryPrompt(airline!, model!, hubIata, aircraft.id);
           console.log(`[Livery] Generating for ${aircraft.id}…`);
           const imageBlob = await generateLiveryImage(prompt);
           console.log(`[Livery] Got blob: ${imageBlob.size} bytes, ${imageBlob.type}`);

--- a/apps/web/src/features/fleet/services/aircraftImageService.test.ts
+++ b/apps/web/src/features/fleet/services/aircraftImageService.test.ts
@@ -76,6 +76,24 @@ describe("buildSceneDescriptor", () => {
     expect(scene.timeOfDay.length).toBeGreaterThan(0);
     expect(scene.weather.length).toBeGreaterThan(0);
   });
+
+  it("produces high variety across dimensions with per-dimension hashing", () => {
+    const activities = new Set<string>();
+    const times = new Set<string>();
+    const weathers = new Set<string>();
+    // Generate scenes for 100 different aircraft IDs
+    for (let i = 0; i < 100; i++) {
+      const scene = buildSceneDescriptor(`aircraft-${i}`, "JFK");
+      activities.add(scene.activity);
+      times.add(scene.timeOfDay);
+      weathers.add(scene.weather);
+    }
+    // With 7 activities, 7 times, and ~6 weather options for JFK,
+    // 100 aircraft should hit at least 4 unique values in each dimension
+    expect(activities.size).toBeGreaterThanOrEqual(4);
+    expect(times.size).toBeGreaterThanOrEqual(4);
+    expect(weathers.size).toBeGreaterThanOrEqual(3);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -181,6 +199,32 @@ describe("deriveWeather", () => {
     const hasMountain = [...weathers].some((w) => w.toLowerCase().includes("mountain"));
     expect(hasMountain).toBe(true);
   });
+
+  it("can produce haze for a beach airport above 30° latitude", () => {
+    const niceBeach = makeAirport({
+      latitude: 43.66, // Nice, France — well above 30°
+      country: "FR",
+      tags: ["beach"],
+    });
+    const weathers = new Set<string>();
+    for (let seed = 0; seed < 200; seed++) {
+      weathers.add(deriveWeather(niceBeach, seed));
+    }
+    const hasHaze = [...weathers].some((w) => w.toLowerCase().includes("haz"));
+    expect(hasHaze).toBe(true);
+  });
+
+  it("does not produce haze for a non-beach airport above 30° latitude", () => {
+    const inland = makeAirport({
+      latitude: 48.0, // Paris-area, no beach tag
+      country: "FR",
+      tags: ["business"],
+    });
+    for (let seed = 0; seed < 200; seed++) {
+      const weather = deriveWeather(inland, seed);
+      expect(weather.toLowerCase()).not.toContain("humid hazy");
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -188,7 +232,7 @@ describe("deriveWeather", () => {
 // ---------------------------------------------------------------------------
 
 describe("SCENE_VERSION", () => {
-  it("is set to 2 for the diverse scene update", () => {
-    expect(SCENE_VERSION).toBe(2);
+  it("is set to 3 after the per-dimension hashing and beach-haze fix", () => {
+    expect(SCENE_VERSION).toBe(3);
   });
 });

--- a/apps/web/src/features/fleet/services/aircraftImageService.test.ts
+++ b/apps/web/src/features/fleet/services/aircraftImageService.test.ts
@@ -1,0 +1,194 @@
+import type { Airport } from "@acars/core";
+import { describe, expect, it } from "vitest";
+import {
+  buildSceneDescriptor,
+  deriveWeather,
+  fnv1aHash,
+  SCENE_VERSION,
+} from "./aircraftImageService";
+
+// ---------------------------------------------------------------------------
+// Helpers: minimal Airport stubs
+// ---------------------------------------------------------------------------
+
+function makeAirport(overrides: Partial<Airport> = {}): Airport {
+  return {
+    id: "1",
+    name: "Test Airport",
+    iata: "TST",
+    icao: "KTST",
+    latitude: 40.0,
+    longitude: -74.0,
+    altitude: 100,
+    timezone: "America/New_York",
+    country: "US",
+    city: "Test City",
+    population: 1_000_000,
+    gdpPerCapita: 50_000,
+    tags: ["business"],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// fnv1aHash
+// ---------------------------------------------------------------------------
+
+describe("fnv1aHash", () => {
+  it("returns a stable unsigned 32-bit integer for a given string", () => {
+    const a = fnv1aHash("aircraft-001");
+    const b = fnv1aHash("aircraft-001");
+    expect(a).toBe(b);
+    expect(a).toBeGreaterThanOrEqual(0);
+    expect(a).toBeLessThanOrEqual(0xffffffff);
+  });
+
+  it("produces different hashes for different inputs", () => {
+    const a = fnv1aHash("aircraft-001");
+    const b = fnv1aHash("aircraft-002");
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSceneDescriptor
+// ---------------------------------------------------------------------------
+
+describe("buildSceneDescriptor", () => {
+  it("returns deterministic scene for the same aircraft ID", () => {
+    const a = buildSceneDescriptor("ac-abc123", "JFK");
+    const b = buildSceneDescriptor("ac-abc123", "JFK");
+    expect(a).toEqual(b);
+  });
+
+  it("returns different scenes for different aircraft IDs", () => {
+    const a = buildSceneDescriptor("ac-001", "JFK");
+    const b = buildSceneDescriptor("ac-002", "JFK");
+    // At least one dimension should differ (extremely likely with FNV-1a)
+    const isDifferent =
+      a.activity !== b.activity || a.timeOfDay !== b.timeOfDay || a.weather !== b.weather;
+    expect(isDifferent).toBe(true);
+  });
+
+  it("contains non-empty strings for all fields", () => {
+    const scene = buildSceneDescriptor("ac-xyz", "LAX");
+    expect(scene.activity.length).toBeGreaterThan(0);
+    expect(scene.timeOfDay.length).toBeGreaterThan(0);
+    expect(scene.weather.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveWeather — geographic realism constraints
+// ---------------------------------------------------------------------------
+
+describe("deriveWeather", () => {
+  it("never produces snow for a tropical airport", () => {
+    const tropical = makeAirport({
+      latitude: 1.35,
+      country: "SG",
+      tags: ["business"],
+    });
+    // Try many seeds — none should produce snow
+    for (let seed = 0; seed < 200; seed++) {
+      const weather = deriveWeather(tropical, seed);
+      expect(weather.toLowerCase()).not.toContain("snow");
+    }
+  });
+
+  it("never produces snow for a low-latitude country outside SNOW_COUNTRIES", () => {
+    const mumbai = makeAirport({
+      latitude: 19.09,
+      country: "IN",
+      tags: ["business"],
+    });
+    for (let seed = 0; seed < 200; seed++) {
+      const weather = deriveWeather(mumbai, seed);
+      expect(weather.toLowerCase()).not.toContain("snow");
+    }
+  });
+
+  it("can produce snow for a high-latitude snow country", () => {
+    const oslo = makeAirport({
+      latitude: 60.19,
+      country: "NO",
+      tags: ["business"],
+    });
+    const weathers = new Set<string>();
+    for (let seed = 0; seed < 200; seed++) {
+      weathers.add(deriveWeather(oslo, seed));
+    }
+    const hasSnow = [...weathers].some((w) => w.toLowerCase().includes("snow"));
+    expect(hasSnow).toBe(true);
+  });
+
+  it("can produce snow for a ski-tagged airport even at moderate latitude", () => {
+    const ski = makeAirport({
+      latitude: 38.0,
+      country: "TR", // Turkey — not in SNOW_COUNTRIES
+      tags: ["ski"],
+    });
+    const weathers = new Set<string>();
+    for (let seed = 0; seed < 200; seed++) {
+      weathers.add(deriveWeather(ski, seed));
+    }
+    const hasSnow = [...weathers].some((w) => w.toLowerCase().includes("snow"));
+    expect(hasSnow).toBe(true);
+  });
+
+  it("never produces rain for an arid desert airport", () => {
+    const riyadh = makeAirport({
+      latitude: 24.77,
+      country: "SA",
+      tags: ["business"],
+    });
+    for (let seed = 0; seed < 200; seed++) {
+      const weather = deriveWeather(riyadh, seed);
+      expect(weather.toLowerCase()).not.toContain("rain");
+    }
+  });
+
+  it("can produce tropical rain for a beach airport near the equator", () => {
+    const bali = makeAirport({
+      latitude: -8.75,
+      country: "ID",
+      tags: ["beach"],
+    });
+    const weathers = new Set<string>();
+    for (let seed = 0; seed < 200; seed++) {
+      weathers.add(deriveWeather(bali, seed));
+    }
+    const hasTropicalRain = [...weathers].some((w) => w.toLowerCase().includes("tropical rain"));
+    expect(hasTropicalRain).toBe(true);
+  });
+
+  it("returns a fallback for an unknown airport", () => {
+    const weather = deriveWeather(undefined, 42);
+    expect(weather).toBe("under clear skies");
+  });
+
+  it("can produce mountain scenery for high-altitude airports", () => {
+    const highAlt = makeAirport({
+      latitude: -16.5,
+      country: "BO",
+      altitude: 13325, // La Paz
+      tags: ["general"],
+    });
+    const weathers = new Set<string>();
+    for (let seed = 0; seed < 200; seed++) {
+      weathers.add(deriveWeather(highAlt, seed));
+    }
+    const hasMountain = [...weathers].some((w) => w.toLowerCase().includes("mountain"));
+    expect(hasMountain).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SCENE_VERSION
+// ---------------------------------------------------------------------------
+
+describe("SCENE_VERSION", () => {
+  it("is set to 2 for the diverse scene update", () => {
+    expect(SCENE_VERSION).toBe(2);
+  });
+});

--- a/apps/web/src/features/fleet/services/aircraftImageService.ts
+++ b/apps/web/src/features/fleet/services/aircraftImageService.ts
@@ -1,4 +1,4 @@
-import type { AircraftModel, AirlineEntity } from "@acars/core";
+import type { AircraftModel, AirlineEntity, Airport } from "@acars/core";
 import { airports } from "@acars/data";
 
 // Model candidates sent to the server proxy (tries in order)
@@ -6,11 +6,21 @@ const MODEL_CANDIDATES = ["imagen-4.0-generate-001", "imagen-3.0-generate-002"];
 const GENERATE_TIMEOUT_MS = 20_000;
 const LIVERY_PROXY_ENDPOINTS = ["/api/generate-livery"];
 
+/**
+ * Bump this constant to force regeneration of all livery images.
+ * It is included in the prompt hash, so changing it invalidates every cache entry.
+ */
+export const SCENE_VERSION = 2;
+
 /** Circuit breaker: once the API reports a missing secret we stop retrying. */
 let apiSecretMissing = false;
 export function isLiveryApiUnavailable(): boolean {
   return apiSecretMissing;
 }
+
+// ---------------------------------------------------------------------------
+// Color utilities
+// ---------------------------------------------------------------------------
 
 /** Convert a hex color to a human-readable color name for image prompts. */
 function hexToColorName(hex: string): string {
@@ -58,9 +68,18 @@ function hexToColorName(hex: string): string {
   return `${prefix}pink`;
 }
 
+// ---------------------------------------------------------------------------
+// Airport helpers
+// ---------------------------------------------------------------------------
+
+/** Look up full airport record by IATA code. */
+function getAirport(iata: string): Airport | undefined {
+  return airports.find((a) => a.iata === iata);
+}
+
 /** Look up airport display name by IATA code. */
 function getAirportName(iata: string): string {
-  const airport = airports.find((a) => a.iata === iata);
+  const airport = getAirport(iata);
   return airport ? `${airport.name} (${airport.city})` : iata;
 }
 
@@ -78,17 +97,258 @@ function describeAircraftType(type: AircraftModel["type"]): string {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Deterministic seed from aircraft ID (pure integer hash, no crypto needed)
+// ---------------------------------------------------------------------------
+
+/**
+ * Simple FNV-1a 32-bit hash that turns an arbitrary string into a stable
+ * integer. Used to deterministically pick scene attributes per aircraft
+ * without needing async crypto.
+ */
+export function fnv1aHash(str: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    hash ^= str.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0; // unsigned 32-bit
+}
+
+/** Pick an element from an array using a seed integer. */
+function pickFromSeed<T>(arr: readonly T[], seed: number): T {
+  return arr[seed % arr.length];
+}
+
+// ---------------------------------------------------------------------------
+// Scene variation: activity, time of day, weather/climate
+// ---------------------------------------------------------------------------
+
+const AIRCRAFT_ACTIVITIES = [
+  "landing on the runway with landing gear deployed, slight tire smoke",
+  "taking off from the runway, nose pitched up, gear retracting",
+  "taxiing on a taxiway near the terminal buildings",
+  "parked at the gate with a jet bridge connected, ground crew visible",
+  "pushing back from the gate with a tug attached",
+  "on final approach low over the airport with gear down",
+  "climbing after takeoff with gear retracting, airport visible below",
+] as const;
+
+const TIMES_OF_DAY = [
+  "during golden sunrise, warm orange and pink sky on the horizon",
+  "on a bright clear morning, soft blue sky with gentle light",
+  "at midday under a high bright sun, vivid colors and sharp shadows",
+  "during golden hour before sunset, long warm shadows and amber light",
+  "at sunset with a vivid orange and purple sky behind the aircraft",
+  "at dusk with deep blue twilight, runway lights glowing",
+  "at night with runway and taxiway lights illuminating the scene, dark sky",
+] as const;
+
+/**
+ * Countries/regions where snow is realistic at airports.
+ * ISO 3166-1 alpha-2 codes of countries that regularly receive snow at
+ * airport elevations. This is deliberately conservative — equatorial and
+ * low-latitude countries are excluded even if they have mountain snow,
+ * because airport infrastructure is almost always at lower elevations.
+ */
+const SNOW_COUNTRIES = new Set([
+  // North America
+  "CA",
+  "US",
+  // Europe
+  "IS",
+  "NO",
+  "SE",
+  "FI",
+  "DK",
+  "GB",
+  "IE",
+  "NL",
+  "BE",
+  "DE",
+  "AT",
+  "CH",
+  "CZ",
+  "SK",
+  "PL",
+  "LT",
+  "LV",
+  "EE",
+  "RU",
+  "UA",
+  "BY",
+  "MD",
+  "RO",
+  "HU",
+  "SI",
+  "HR",
+  "BA",
+  "RS",
+  "ME",
+  "MK",
+  "BG",
+  "FR",
+  "LU",
+  // East Asia
+  "JP",
+  "KR",
+  "KP",
+  "MN",
+  "CN",
+  // Central Asia
+  "KZ",
+  "KG",
+  "TJ",
+  "UZ",
+  // South America (southern high altitude/latitude)
+  "AR",
+  "CL",
+  // Oceania
+  "NZ",
+]);
+
+/** Minimum absolute latitude (degrees) for snow to be plausible at an airport. */
+const SNOW_MIN_LATITUDE = 35;
+
+/** Countries in arid/desert climate zones where rain is very rare. */
+const ARID_COUNTRIES = new Set([
+  "SA",
+  "AE",
+  "QA",
+  "BH",
+  "KW",
+  "OM",
+  "YE",
+  "EG",
+  "LY",
+  "DZ",
+  "TN",
+  "MA",
+  "MR",
+  "ML",
+  "NE",
+  "TD",
+  "SD",
+  "ER",
+  "DJ",
+  "SO",
+]);
+
+export interface SceneDescriptor {
+  activity: string;
+  timeOfDay: string;
+  weather: string;
+}
+
+/**
+ * Derives a realistic weather/climate description for an airport, seeded
+ * deterministically from the aircraft ID. The function uses the airport's
+ * latitude, country code, tags, and altitude to constrain weather choices
+ * so that e.g. tropical airports never get snow and desert airports rarely
+ * get rain.
+ */
+export function deriveWeather(airport: Airport | undefined, seed: number): string {
+  if (!airport) return "under clear skies";
+
+  const absLat = Math.abs(airport.latitude);
+  const country = airport.country;
+  const isBeach = airport.tags.includes("beach");
+  const isSki = airport.tags.includes("ski");
+  const isArid = ARID_COUNTRIES.has(country);
+
+  // Build a pool of plausible weather conditions weighted by geography
+  const pool: string[] = [];
+
+  // Clear/sunny — universally plausible, always in the pool
+  pool.push("under clear blue skies");
+  pool.push("with a few scattered white clouds in the sky");
+
+  // Overcast — plausible everywhere except extreme desert
+  if (!isArid) {
+    pool.push("under an overcast grey sky with diffused soft light");
+  }
+
+  // Rain — plausible in non-arid regions
+  if (!isArid) {
+    pool.push("during light rain, wet reflective tarmac and runway");
+    if (isBeach || absLat < 25) {
+      // Tropical regions get heavier rain options
+      pool.push("during a tropical rain shower, lush green surroundings");
+    }
+  }
+
+  // Haze/humidity — tropical and subtropical
+  if (absLat < 30 && !isArid) {
+    pool.push("in humid hazy conditions, warm tropical atmosphere");
+  }
+
+  // Snow — only where geographically realistic
+  const snowPlausible = (SNOW_COUNTRIES.has(country) && absLat >= SNOW_MIN_LATITUDE) || isSki;
+  if (snowPlausible) {
+    pool.push("with snow covering the ground and airport surroundings, cold winter atmosphere");
+    pool.push("with light snowfall, dusting of snow on taxiways and grass areas");
+  }
+
+  // Fog/mist — plausible in temperate and coastal regions
+  if (absLat > 20 && absLat < 60 && !isArid) {
+    pool.push("in early morning mist, low visibility with soft diffused light");
+  }
+
+  // Dry/dusty — arid regions
+  if (isArid) {
+    pool.push("under a hazy dry sky with dusty desert surroundings");
+    pool.push("with shimmering heat haze rising from the hot tarmac");
+  }
+
+  // High altitude — dramatic skies
+  if (airport.altitude > 5000) {
+    pool.push("with dramatic mountain scenery visible in the background, thin crisp air");
+  }
+
+  return pickFromSeed(pool, seed);
+}
+
+/**
+ * Builds a complete scene descriptor (activity + time of day + weather)
+ * deterministically from the aircraft instance ID and airport data.
+ * Each aircraft always gets the same scene, but different aircraft get
+ * different scenes.
+ */
+export function buildSceneDescriptor(aircraftId: string, hubIata: string): SceneDescriptor {
+  const seed = fnv1aHash(aircraftId);
+  const airport = getAirport(hubIata);
+
+  // Use different bits of the seed for each dimension to avoid correlation
+  const activitySeed = seed;
+  const timeSeed = seed >>> 8;
+  const weatherSeed = seed >>> 16;
+
+  return {
+    activity: pickFromSeed(AIRCRAFT_ACTIVITIES, activitySeed),
+    timeOfDay: pickFromSeed(TIMES_OF_DAY, timeSeed),
+    weather: deriveWeather(airport, weatherSeed),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Prompt building
+// ---------------------------------------------------------------------------
+
 /**
  * Builds a deterministic, detailed prompt for generating a photorealistic
- * aircraft livery image from game state data.
+ * aircraft livery image from game state data. Each aircraft instance gets
+ * a unique scene (activity, time of day, weather) derived from its ID,
+ * while the livery and model details come from the airline/model data.
  */
 export function buildLiveryPrompt(
   airline: AirlineEntity,
   model: AircraftModel,
   hubIata: string,
+  aircraftId: string,
 ): string {
   const hubName = getAirportName(hubIata);
   const typeDesc = describeAircraftType(model.type);
+  const scene = buildSceneDescriptor(aircraftId, hubIata);
 
   const primaryHex = airline.livery?.primary ?? "#ffffff";
   const secondaryHex = airline.livery?.secondary ?? "#1f2937";
@@ -100,23 +360,30 @@ export function buildLiveryPrompt(
   return [
     `Professional aviation photography of a ${model.manufacturer} ${model.name} commercial ${typeDesc} aircraft`,
     `in the livery of ${airline.name} airline (ICAO: ${airline.icaoCode}).`,
-    `The aircraft is parked at ${hubName} airport which is visible in the background`,
+    `The aircraft is ${scene.activity} at ${hubName} airport.`,
+    `${scene.timeOfDay}, ${scene.weather}.`,
     `The fuselage is painted ${primaryColor} with a ${secondaryColor} tail fin`,
     `and ${accentColor} accent striping along the plane.`,
     `The airline name "${airline.name}" is displayed prominently on the fuselage in large lettering.`,
     `${model.engineCount}-engine ${typeDesc} aircraft with realistic proportions.`,
-    `photorealistic quality`,
+    `photorealistic quality, cinematic aviation scene`,
   ].join(" ");
 }
 
+// ---------------------------------------------------------------------------
+// Prompt hash (cache key)
+// ---------------------------------------------------------------------------
+
 /**
  * Computes a deterministic hash of the prompt inputs for cache invalidation.
- * If any of these inputs change, the image should be regenerated.
+ * Includes the aircraft instance ID and scene version so that each aircraft
+ * gets a unique image and bumping SCENE_VERSION regenerates all images.
  */
 export async function computePromptHash(
   airline: AirlineEntity,
   model: AircraftModel,
   hubIata: string,
+  aircraftId: string,
 ): Promise<string> {
   const primaryHex = airline.livery?.primary ?? "#ffffff";
   const secondaryHex = airline.livery?.secondary ?? "#1f2937";
@@ -133,6 +400,8 @@ export async function computePromptHash(
     model.type,
     String(model.engineCount),
     hubIata,
+    aircraftId,
+    String(SCENE_VERSION),
   ].join("|");
 
   const encoder = new TextEncoder();

--- a/apps/web/src/features/fleet/services/aircraftImageService.ts
+++ b/apps/web/src/features/fleet/services/aircraftImageService.ts
@@ -10,7 +10,7 @@ const LIVERY_PROXY_ENDPOINTS = ["/api/generate-livery"];
  * Bump this constant to force regeneration of all livery images.
  * It is included in the prompt hash, so changing it invalidates every cache entry.
  */
-export const SCENE_VERSION = 2;
+export const SCENE_VERSION = 3;
 
 /** Circuit breaker: once the API reports a missing secret we stop retrying. */
 let apiSecretMissing = false;
@@ -277,8 +277,8 @@ export function deriveWeather(airport: Airport | undefined, seed: number): strin
     }
   }
 
-  // Haze/humidity — tropical and subtropical
-  if (absLat < 30 && !isArid) {
+  // Haze/humidity — tropical, subtropical, and coastal beach airports
+  if ((absLat < 30 || isBeach) && !isArid) {
     pool.push("in humid hazy conditions, warm tropical atmosphere");
   }
 
@@ -315,13 +315,12 @@ export function deriveWeather(airport: Airport | undefined, seed: number): strin
  * different scenes.
  */
 export function buildSceneDescriptor(aircraftId: string, hubIata: string): SceneDescriptor {
-  const seed = fnv1aHash(aircraftId);
   const airport = getAirport(hubIata);
 
-  // Use different bits of the seed for each dimension to avoid correlation
-  const activitySeed = seed;
-  const timeSeed = seed >>> 8;
-  const weatherSeed = seed >>> 16;
+  // Hash distinct salted strings per dimension so each gets full 32-bit entropy
+  const activitySeed = fnv1aHash(aircraftId + ":activity");
+  const timeSeed = fnv1aHash(aircraftId + ":time");
+  const weatherSeed = fnv1aHash(aircraftId + ":weather");
 
   return {
     activity: pickFromSeed(AIRCRAFT_ACTIVITIES, activitySeed),


### PR DESCRIPTION
## Summary

- Each aircraft now generates a **unique, visually distinct livery image** instead of all aircraft sharing the same "parked at hub" composition
- Scene variation is **deterministic** (FNV-1a hash of aircraft ID as seed), so each aircraft always renders the same scene but different aircraft get different scenes
- **No caching/hashing breakage** — `aircraftId` and `SCENE_VERSION` are added to the prompt hash, so old images naturally regenerate with new diverse prompts

## Scene Dimensions

### Activity (7 options)
Landing, takeoff, taxiing, at the gate with jet bridge, pushback, final approach, climbing after takeoff

### Time of Day (7 options)
Golden sunrise, bright morning, midday, golden hour, sunset, dusk/twilight, night

### Weather/Climate (geographically constrained)
- **Universal**: clear skies, scattered clouds
- **Non-arid**: overcast, light rain, fog/mist
- **Tropical** (lat < 25° or beach-tagged): tropical rain, humidity/haze
- **Snow** (high-latitude snow countries OR ski-tagged airports only): snow cover, light snowfall
- **Arid** (desert countries): dusty skies, heat haze
- **High altitude** (>5000ft): mountain scenery

### Geographic Realism Constraints
- Snow is **never** generated for tropical/equatorial airports
- Rain is **never** generated for arid desert airports (SA, AE, QA, EG, etc.)
- Tropical rain only appears near the equator or at beach-tagged airports
- Fog/mist only in temperate zones (lat 20°-60°)
- Mountain scenery only for airports above 5,000ft elevation

## Cache Migration

- `SCENE_VERSION = 2` is included in the hash, so all existing v1 images will be regenerated on next view
- Bumping `SCENE_VERSION` in the future will force a full fleet re-generation
- IndexedDB and Blossom/Nostr persistence flow is unchanged

## Tests

14 new tests covering:
- FNV-1a hash stability and uniqueness
- Scene descriptor determinism and variation
- Geographic weather constraints (no snow in tropics, no rain in deserts, snow in Oslo, tropical rain in Bali, mountains at La Paz altitude)

## Files Changed

| File | Change |
|------|--------|
| `aircraftImageService.ts` | Scene variation system, updated prompt builder and hash |
| `useAircraftImage.ts` | Pass `aircraft.id` to updated function signatures |
| `aircraftImageService.test.ts` | New test suite (14 tests) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Aircraft image generation now personalizes livery prompts per aircraft and includes dynamic scene context (activity, time of day, and geography-aware weather) for more varied, cinematic images.

* **Tests**
  * Added comprehensive tests for hashing, scene generation, weather derivation, and deterministic behavior across aircraft IDs.

* **Chores**
  * Improved cache invalidation with a scene-versioning strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->