### PR TITLE
fix(store): remove actionReducer backfill loop and localLoader balance override

### DIFF
--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -702,8 +702,6 @@ function capLandingsForGrounding(
  *
  * Used by:
  * - `reconcileFleetToTick` for balance-delta estimation during fast-forward
- * - The recovery sweep in `engineSlice.processTick` to produce full-detail
- *   timeline events when a landing was missed during tick-by-tick catch-up
  *
  * Returns the full revenue/cost breakdown so callers can either just grab
  * `.profit` or build a complete `TimelineEvent.details` object.

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -22,7 +22,7 @@ import {
   TICKS_PER_HOUR,
 } from "@acars/core";
 import { getAircraftById } from "@acars/data";
-import { processFlightEngine, reconcileFleetToTick } from "./FlightEngine";
+import { reconcileFleetToTick } from "./FlightEngine";
 
 export interface ActionRecord {
   action: import("@acars/core").GameActionEnvelope;
@@ -42,7 +42,6 @@ export interface ActionReplayResult {
 }
 
 const MAX_TIMELINE_EVENTS = 1000;
-const BACKFILL_TICK_WINDOW = TICKS_PER_HOUR * 6;
 
 const DEFAULT_LIVERY = {
   primary: "#1f2937",
@@ -345,12 +344,6 @@ export async function replayActionLog(params: {
     if (aTime !== bTime) return aTime - bTime;
     return a.eventId.localeCompare(b.eventId);
   });
-  const actionTicks = sortedActions
-    .map((record) => clampInt(record.action.payload.tick, 0, Number.MAX_SAFE_INTEGER))
-    .filter((tick): tick is number => typeof tick === "number" && Number.isFinite(tick));
-  const latestActionTick = actionTicks.length ? Math.max(...actionTicks) : 0;
-  const backfillStartTick = Math.max(0, latestActionTick - BACKFILL_TICK_WINDOW);
-  const backfillTickSet = new Set<number>();
   let bootstrapTick: number | null = null;
 
   // Bootstrap: If no checkpoint and no AIRLINE_CREATE in the action log,
@@ -458,7 +451,6 @@ export async function replayActionLog(params: {
       routeIdAliases.clear();
       timeline.splice(0, timeline.length);
       timelineEventIds.clear();
-      backfillTickSet.clear();
       allowActionTimeline = true;
 
       const name = clampString(payload.name, MAX_NAME_LENGTH) ?? "New Airline";
@@ -514,7 +506,6 @@ export async function replayActionLog(params: {
       routeIdAliases.clear();
       timeline.splice(0, timeline.length);
       timelineEventIds.clear();
-      backfillTickSet.clear();
       allowActionTimeline = true;
       continue;
     }
@@ -578,9 +569,6 @@ export async function replayActionLog(params: {
           }
 
           updateLastTick(actionTick);
-          if (actionTick >= backfillStartTick) {
-            backfillTickSet.add(actionTick);
-          }
           mergeTickTimelineEvents(payload.timeline);
           break;
         }
@@ -631,9 +619,6 @@ export async function replayActionLog(params: {
         }
 
         updateLastTick(actionTick);
-        if (actionTick >= backfillStartTick) {
-          backfillTickSet.add(actionTick);
-        }
         mergeTickTimelineEvents(payload.timeline);
         break;
       }
@@ -1271,48 +1256,8 @@ export async function replayActionLog(params: {
   const routes = Array.from(routesById.values());
 
   const orderedTimeline = sortedTimeline();
-  const backfillTimeline = new Map<string, TimelineEvent>();
-  for (const event of orderedTimeline) backfillTimeline.set(event.id, event);
-  const orderedBackfillTicks = Array.from(backfillTickSet.values()).sort((a, b) => a - b);
-  if (airline && orderedBackfillTicks.length > 0) {
-    let simulatedFleet = fleet.map((ac) => ({ ...ac }));
-    let simulatedBalance = airline.corporateBalance;
-    let lastTick = backfillStartTick - 1;
-    for (const tick of orderedBackfillTicks) {
-      const { updatedFleet, corporateBalance, events } = processFlightEngine(
-        tick,
-        simulatedFleet,
-        routes,
-        simulatedBalance,
-        lastTick,
-        new Map(),
-        pubkey,
-        0.5,
-      );
-      simulatedFleet = updatedFleet;
-      simulatedBalance = corporateBalance;
-      lastTick = tick;
-      for (const event of events) {
-        if (!backfillTimeline.has(event.id)) {
-          backfillTimeline.set(event.id, event);
-        }
-      }
-    }
-    airline = { ...airline, corporateBalance: simulatedBalance };
-    fleetById.clear();
-    for (const aircraft of simulatedFleet) {
-      fleetById.set(aircraft.id, aircraft);
-    }
-    timeline.length = 0;
-    timeline.push(
-      ...Array.from(backfillTimeline.values())
-        .sort((a, b) => (a.tick !== b.tick ? b.tick - a.tick : b.timestamp - a.timestamp))
-        .slice(0, MAX_TIMELINE_EVENTS),
-    );
-  } else {
-    timeline.length = 0;
-    timeline.push(...orderedTimeline.slice(0, MAX_TIMELINE_EVENTS));
-  }
+  timeline.length = 0;
+  timeline.push(...orderedTimeline.slice(0, MAX_TIMELINE_EVENTS));
 
   fleet = Array.from(fleetById.values());
   if (airline) {

--- a/packages/store/src/localLoader.ts
+++ b/packages/store/src/localLoader.ts
@@ -1,8 +1,8 @@
-import { type Checkpoint, decompressSnapshotString, fpAdd } from "@acars/core";
+import { type Checkpoint, decompressSnapshotString } from "@acars/core";
 import { loadSnapshot } from "@acars/nostr";
 import { db } from "./db.js";
-import { reconcileFleetToTick } from "./FlightEngine.js";
 import { useEngineStore } from "./engine.js";
+import { reconcileFleetToTick } from "./FlightEngine.js";
 import type { AirlineState } from "./types.js";
 
 const MAX_PLAYER_CATCHUP = 50000;
@@ -95,9 +95,8 @@ export async function hydrateIdentityFromStorage(
 
   // Reconcile to the current engine tick, not the snapshot's lastTick
   if (airline.lastTick != null && fleet.length > 0 && engineTick > airline.lastTick) {
-    const { fleet: reconciled, balanceDelta } = reconcileFleetToTick(fleet, routes, engineTick);
+    const { fleet: reconciled } = reconcileFleetToTick(fleet, routes, engineTick);
     fleet = reconciled;
-    airline.corporateBalance = fpAdd(airline.corporateBalance, balanceDelta);
     airline.lastTick = engineTick;
   }
 


### PR DESCRIPTION
## Summary

Removes the second source of duplicate landing events: the backfill loop in `replayActionLog()` that re-ran `processFlightEngine` on sparse TICK_UPDATE ticks, producing landing events with different IDs that bypassed dedup and overwrote the authoritative `corporateBalance` with a simplified estimate.

## Root Cause

After the first fix (removing engineSlice backfill/recovery sweep), duplicates still occurred because `actionReducer.ts` had a secondary backfill loop that:

1. **Produced duplicate landing events**: Iterated sparse ticks (only TICK_UPDATE heartbeat ticks), so aircraft landed at different tick numbers than the original. Event IDs include the tick number (`evt-landing-${ac.id}-${tick}`), so re-simulated landings got different IDs and bypassed dedup.

2. **Overwrote authoritative balance**: Replaced `airline.corporateBalance` with a re-simulated balance computed using `new Map()` (empty competitors) and `0.5` brand score — less accurate than the authoritative balance from the TICK_UPDATE payload.

## Changes

- **actionReducer.ts**: Remove `BACKFILL_TICK_WINDOW`, `backfillStartTick`, `backfillTickSet`, and the entire backfill simulation block (~40 lines). Timeline now uses only authoritative events from TICK_UPDATE payloads. Remove `processFlightEngine` import.
- **localLoader.ts**: Stop applying `balanceDelta` from `reconcileFleetToTick` during hydration — the tick loop in `engineSlice.processTick` computes the authoritative balance immediately after. Remove unused `fpAdd` import.
- **FlightEngine.ts**: Update `estimateLandingFinancials` JSDoc to remove reference to the deleted recovery sweep.

## Test Plan

- [x] TypeScript: zero errors (`tsc --noEmit -p packages/store/tsconfig.json`)
- [x] Store tests: 134/134 passed
- [x] Core tests: 134/134 passed
- [x] Pre-commit hooks (biome + eslint): passed