### PR TITLE
fix(store): generate synthetic timeline events during offline catch-up

### DIFF
--- a/packages/core/src/cycle.test.ts
+++ b/packages/core/src/cycle.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from "vitest";
+import { countLandingsBetween, enumerateFlightEvents } from "./cycle.js";
+import type { Route } from "./types.js";
+
+const makeRoute = (overrides: Partial<Route> = {}): Route =>
+  ({
+    id: overrides.id ?? "route-test",
+    originIata: overrides.originIata ?? "JFK",
+    destinationIata: overrides.destinationIata ?? "LAX",
+    airlinePubkey: "test-pubkey",
+    distanceKm: 3000,
+    frequencyPerWeek: 7,
+    assignedAircraftIds: [],
+    status: "active",
+    ...overrides,
+  }) as Route;
+
+describe("enumerateFlightEvents", () => {
+  const route = makeRoute();
+  const durationTicks = 4000;
+  const turnaroundTicks = 600;
+  const roundTrip = durationTicks * 2 + turnaroundTicks * 2; // 9200
+
+  it("returns empty when toTick <= fromTick", () => {
+    expect(enumerateFlightEvents(0, 100, 100, durationTicks, turnaroundTicks, route)).toEqual([]);
+    expect(enumerateFlightEvents(0, 200, 100, durationTicks, turnaroundTicks, route)).toEqual([]);
+  });
+
+  it("returns empty when durationTicks <= 0", () => {
+    expect(enumerateFlightEvents(0, 0, 10000, 0, turnaroundTicks, route)).toEqual([]);
+    expect(enumerateFlightEvents(0, 0, 10000, -1, turnaroundTicks, route)).toEqual([]);
+  });
+
+  it("returns empty when turnaroundTicks < 0", () => {
+    expect(enumerateFlightEvents(0, 0, 10000, durationTicks, -1, route)).toEqual([]);
+  });
+
+  it("enumerates a single full round-trip cycle", () => {
+    // Cycle starts at tick 0.
+    // Transitions:
+    //   tick 0    → takeoff outbound  (JFK → LAX)
+    //   tick 4000 → landing outbound  (JFK → LAX, arrived LAX)
+    //   tick 4600 → takeoff inbound   (LAX → JFK)
+    //   tick 8600 → landing inbound   (LAX → JFK, arrived JFK)
+    //
+    // Query interval: (0, 9200] — one full round trip, excluding the
+    // starting takeoff at tick 0 (half-open, exclusive start).
+    const events = enumerateFlightEvents(0, 0, roundTrip, durationTicks, turnaroundTicks, route);
+
+    // We should see: landing@4000, takeoff@4600, landing@8600, takeoff@9200
+    // (the next cycle's outbound takeoff at tick 9200 is within (0, 9200])
+    // Actually tick 9200 is the start of the NEXT cycle, which is offset 0.
+    // 0 + 1 * 9200 = 9200. Since 9200 <= 9200 (toTick), it is included.
+    expect(events.length).toBe(4);
+
+    // Sorted ascending by tick
+    expect(events[0]).toEqual({
+      tick: 4000,
+      type: "landing",
+      direction: "outbound",
+      originIata: "JFK",
+      destinationIata: "LAX",
+    });
+    expect(events[1]).toEqual({
+      tick: 4600,
+      type: "takeoff",
+      direction: "inbound",
+      originIata: "LAX",
+      destinationIata: "JFK",
+    });
+    expect(events[2]).toEqual({
+      tick: 8600,
+      type: "landing",
+      direction: "inbound",
+      originIata: "LAX",
+      destinationIata: "JFK",
+    });
+    expect(events[3]).toEqual({
+      tick: 9200,
+      type: "takeoff",
+      direction: "outbound",
+      originIata: "JFK",
+      destinationIata: "LAX",
+    });
+  });
+
+  it("respects half-open interval — excludes events at fromTick", () => {
+    // Query exactly at the outbound takeoff tick (0) — should NOT include it
+    const events = enumerateFlightEvents(0, 0, 1, durationTicks, turnaroundTicks, route);
+    expect(events.length).toBe(0);
+  });
+
+  it("includes events exactly at toTick", () => {
+    // Query (0, 4000] — should include the landing at 4000
+    const events = enumerateFlightEvents(0, 0, 4000, durationTicks, turnaroundTicks, route);
+    expect(events.length).toBe(1);
+    expect(events[0].tick).toBe(4000);
+    expect(events[0].type).toBe("landing");
+  });
+
+  it("landing count matches countLandingsBetween", () => {
+    const cycleStart = 0;
+    const fromTick = 0;
+    const toTick = roundTrip * 5; // 5 full cycles
+
+    const events = enumerateFlightEvents(
+      cycleStart,
+      fromTick,
+      toTick,
+      durationTicks,
+      turnaroundTicks,
+      route,
+    );
+    const landingEvents = events.filter((e) => e.type === "landing");
+    const countFromHelper = countLandingsBetween(
+      cycleStart,
+      fromTick,
+      toTick,
+      durationTicks,
+      turnaroundTicks,
+    );
+
+    expect(landingEvents.length).toBe(countFromHelper);
+  });
+
+  it("events are sorted by tick ascending", () => {
+    const events = enumerateFlightEvents(
+      0,
+      0,
+      roundTrip * 3,
+      durationTicks,
+      turnaroundTicks,
+      route,
+    );
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].tick).toBeGreaterThanOrEqual(events[i - 1].tick);
+    }
+  });
+
+  it("respects maxEvents safety cap", () => {
+    // 100 cycles = 400 events. Cap at 10.
+    const events = enumerateFlightEvents(
+      0,
+      0,
+      roundTrip * 100,
+      durationTicks,
+      turnaroundTicks,
+      route,
+      10,
+    );
+    expect(events.length).toBeLessThanOrEqual(10);
+  });
+
+  it("handles cycle start in the past (negative elapsed)", () => {
+    // cycleStart is at 10000, query from 0 to 5000 — both before cycleStart+offset for most events
+    const events = enumerateFlightEvents(10000, 0, 5000, durationTicks, turnaroundTicks, route);
+    // No transitions occur before tick 10000 (earliest is takeoff at 10000)
+    expect(events.length).toBe(0);
+  });
+
+  it("handles non-zero cycleStartTick correctly", () => {
+    const cycleStart = 5000;
+    // Transitions at: 5000 (takeoff-out), 9000 (land-out), 9600 (takeoff-in), 13600 (land-in)
+    const events = enumerateFlightEvents(
+      cycleStart,
+      cycleStart,
+      cycleStart + roundTrip,
+      durationTicks,
+      turnaroundTicks,
+      route,
+    );
+
+    // Excluding takeoff at 5000 (half-open), we get:
+    // land@9000, takeoff@9600, land@13600, takeoff@14200 (next cycle start)
+    expect(events.length).toBe(4);
+    expect(events[0].tick).toBe(cycleStart + durationTicks);
+    expect(events[0].type).toBe("landing");
+  });
+
+  it("correctly assigns direction and airports", () => {
+    const events = enumerateFlightEvents(0, 0, roundTrip, durationTicks, turnaroundTicks, route);
+
+    const outboundEvents = events.filter((e) => e.direction === "outbound");
+    const inboundEvents = events.filter((e) => e.direction === "inbound");
+
+    // Outbound events go JFK → LAX
+    for (const e of outboundEvents) {
+      expect(e.originIata).toBe("JFK");
+      expect(e.destinationIata).toBe("LAX");
+    }
+
+    // Inbound events go LAX → JFK
+    for (const e of inboundEvents) {
+      expect(e.originIata).toBe("LAX");
+      expect(e.destinationIata).toBe("JFK");
+    }
+  });
+
+  it("produces exactly 4 events per full cycle when queried cycle-by-cycle", () => {
+    // Each full cycle has: landing-out, takeoff-in, landing-in, takeoff-out(next)
+    // When querying from end of one cycle to end of next
+    for (let c = 0; c < 3; c++) {
+      const from = c * roundTrip;
+      const to = (c + 1) * roundTrip;
+      const events = enumerateFlightEvents(0, from, to, durationTicks, turnaroundTicks, route);
+      expect(events.length).toBe(4);
+    }
+  });
+
+  it("handles narrow query window with no events", () => {
+    // Query (1, 2] — well within the first outbound flight, no transitions
+    const events = enumerateFlightEvents(0, 1, 2, durationTicks, turnaroundTicks, route);
+    expect(events.length).toBe(0);
+  });
+
+  it("handles zero turnaround correctly", () => {
+    // 0 turnaround is not valid (turnaroundTicks must be >= 0, but roundTrip = 2*d+2*0 = 2*d)
+    // Actually turnaroundTicks = 0 is allowed. Round trip = 2*4000 = 8000
+    const events = enumerateFlightEvents(0, 0, 8000, durationTicks, 0, route);
+    // Transitions: takeoff-out@0(excluded), land-out@4000, takeoff-in@4000, land-in@8000, takeoff-out@8000
+    // land-out and takeoff-in at same tick 4000 — both should appear
+    expect(events.length).toBe(4);
+    const at4000 = events.filter((e) => e.tick === 4000);
+    expect(at4000.length).toBe(2);
+    expect(at4000.map((e) => e.type).sort()).toEqual(["landing", "takeoff"]);
+  });
+
+  it("phase offset (effectiveCycleStart adjustment) produces correct events", () => {
+    // Simulate an aircraft that starts at destination (LAX).
+    // The caller adjusts cycleStartTick by subtracting phaseOffset.
+    const phaseOffset = durationTicks + turnaroundTicks; // 4600
+    const assignedTick = 1000;
+    const effectiveCycleStart = assignedTick - phaseOffset; // -3600
+
+    // Query from assignment to one round trip after
+    const events = enumerateFlightEvents(
+      effectiveCycleStart,
+      assignedTick,
+      assignedTick + roundTrip,
+      durationTicks,
+      turnaroundTicks,
+      route,
+    );
+
+    // The first event after tick 1000 should be near the inbound takeoff or landing
+    // since the aircraft conceptually starts at the inbound position
+    expect(events.length).toBeGreaterThan(0);
+
+    // All events should be within (assignedTick, assignedTick + roundTrip]
+    for (const e of events) {
+      expect(e.tick).toBeGreaterThan(assignedTick);
+      expect(e.tick).toBeLessThanOrEqual(assignedTick + roundTrip);
+    }
+  });
+
+  it("landing event count across multiple cycles matches countLandingsBetween exactly", () => {
+    // Test with various offsets and ranges
+    const testCases = [
+      { cycleStart: 0, from: 0, to: roundTrip * 10 },
+      { cycleStart: 500, from: 500, to: 500 + roundTrip * 7 },
+      { cycleStart: 0, from: roundTrip * 2, to: roundTrip * 5 },
+      { cycleStart: 100, from: 3000, to: 50000 },
+    ];
+
+    for (const { cycleStart, from, to } of testCases) {
+      const events = enumerateFlightEvents(
+        cycleStart,
+        from,
+        to,
+        durationTicks,
+        turnaroundTicks,
+        route,
+        500, // high cap for this test
+      );
+      const landingCount = events.filter((e) => e.type === "landing").length;
+      const expected = countLandingsBetween(cycleStart, from, to, durationTicks, turnaroundTicks);
+      expect(landingCount).toBe(expected);
+    }
+  });
+});

--- a/packages/core/src/cycle.ts
+++ b/packages/core/src/cycle.ts
@@ -118,3 +118,121 @@ export function countLandingsBetween(
 
   return Math.max(0, count);
 }
+
+// --- Flight event enumeration ---
+
+export interface CycleFlightEvent {
+  tick: number;
+  type: "takeoff" | "landing";
+  direction: "outbound" | "inbound";
+  originIata: string;
+  destinationIata: string;
+}
+
+const DEFAULT_MAX_EVENTS = 200;
+
+/**
+ * Enumerate every individual takeoff and landing tick in the half-open
+ * interval (fromTick, toTick].  Uses cycle algebra (no tick-by-tick loop).
+ *
+ * Within each round-trip cycle the 4 transition offsets are:
+ *   0                              → takeoff outbound
+ *   durationTicks                  → landing outbound  (= arrival at dest)
+ *   durationTicks + turnaroundTicks→ takeoff inbound   (= departure from dest)
+ *   durationTicks*2 + turnaroundTicks → landing inbound (= arrival at origin)
+ *
+ * Events are returned sorted by tick ascending.  A safety cap (`maxEvents`,
+ * default 200) prevents runaway allocation for extremely long offline gaps.
+ */
+export function enumerateFlightEvents(
+  cycleStartTick: number,
+  fromTick: number,
+  toTick: number,
+  durationTicks: number,
+  turnaroundTicks: number,
+  route: Route,
+  maxEvents: number = DEFAULT_MAX_EVENTS,
+): CycleFlightEvent[] {
+  if (toTick <= fromTick) return [];
+  if (durationTicks <= 0 || turnaroundTicks < 0) return [];
+
+  const roundTripTicks = durationTicks * 2 + turnaroundTicks * 2;
+
+  // The 4 transition points within each cycle, described by their offset from
+  // cycle start, event type, direction, and origin/destination airports.
+  const transitions: Array<{
+    offset: number;
+    type: "takeoff" | "landing";
+    direction: "outbound" | "inbound";
+    originIata: string;
+    destinationIata: string;
+  }> = [
+    {
+      offset: 0,
+      type: "takeoff",
+      direction: "outbound",
+      originIata: route.originIata,
+      destinationIata: route.destinationIata,
+    },
+    {
+      offset: durationTicks,
+      type: "landing",
+      direction: "outbound",
+      originIata: route.originIata,
+      destinationIata: route.destinationIata,
+    },
+    {
+      offset: durationTicks + turnaroundTicks,
+      type: "takeoff",
+      direction: "inbound",
+      originIata: route.destinationIata,
+      destinationIata: route.originIata,
+    },
+    {
+      offset: durationTicks * 2 + turnaroundTicks,
+      type: "landing",
+      direction: "inbound",
+      originIata: route.destinationIata,
+      destinationIata: route.originIata,
+    },
+  ];
+
+  const events: CycleFlightEvent[] = [];
+
+  for (const t of transitions) {
+    // First occurrence of this transition type at or after cycleStartTick
+    const firstTick = cycleStartTick + t.offset;
+
+    // Find the first occurrence in (fromTick, toTick]
+    // i.e. the smallest k >= 0 such that firstTick + k * roundTripTicks > fromTick
+    if (firstTick > toTick) continue;
+
+    let startK: number;
+    if (firstTick > fromTick) {
+      startK = 0;
+    } else {
+      // firstTick + k * roundTripTicks > fromTick
+      // k > (fromTick - firstTick) / roundTripTicks
+      startK = Math.floor((fromTick - firstTick) / roundTripTicks) + 1;
+    }
+
+    for (let k = startK; ; k++) {
+      const eventTick = firstTick + k * roundTripTicks;
+      if (eventTick > toTick) break;
+      events.push({
+        tick: eventTick,
+        type: t.type,
+        direction: t.direction,
+        originIata: t.originIata,
+        destinationIata: t.destinationIata,
+      });
+      if (events.length >= maxEvents) break;
+    }
+    if (events.length >= maxEvents) break;
+  }
+
+  // Sort by tick ascending (transitions are interleaved across types)
+  events.sort((a, b) => a.tick - b.tick);
+
+  return events;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,8 +10,13 @@ export {
   verifyCheckpoint,
 } from "./checkpoint.js";
 export * from "./compression.js";
+export type { CycleFlightEvent } from "./cycle.js";
 // Cycle
-export { countLandingsBetween, getCyclePhase } from "./cycle.js";
+export {
+  countLandingsBetween,
+  enumerateFlightEvents,
+  getCyclePhase,
+} from "./cycle.js";
 // Demand
 export {
   calculateBidirectionalDemand,
@@ -70,7 +75,10 @@ export { createPRNG, createTickPRNG } from "./prng.js";
 export { allocatePassengers, calculateShares } from "./qsi.js";
 // Season
 export { getSeason, getSeasonalMultiplier } from "./season.js";
-export type { NightOverlayFeatureCollection, TerminatorLineCollection } from "./solar.js";
+export type {
+  NightOverlayFeatureCollection,
+  TerminatorLineCollection,
+} from "./solar.js";
 // Solar
 export {
   computeNightOverlay,

--- a/packages/store/src/FlightEngine.test.ts
+++ b/packages/store/src/FlightEngine.test.ts
@@ -1,5 +1,12 @@
 import type { AircraftInstance, FixedPoint, FlightOffer, Route, TimelineEvent } from "@acars/core";
-import { calculateDemand, fp, fpToNumber, getSuggestedFares, TICKS_PER_HOUR } from "@acars/core";
+import {
+  calculateDemand,
+  countLandingsBetween,
+  fp,
+  fpToNumber,
+  getSuggestedFares,
+  TICKS_PER_HOUR,
+} from "@acars/core";
 import { airports, getAircraftById } from "@acars/data";
 import { describe, expect, it } from "vitest";
 import { processFlightEngine, reconcileFleetToTick } from "./FlightEngine.js";
@@ -330,7 +337,9 @@ describe("FlightEngine — Multiplayer scenarios", () => {
     };
     const registry = new Map<string, FlightOffer[]>([["JFK-LAX", [competitorOffer]]]);
 
-    const competition = simulateSingleLanding(aircraft, route, { globalRouteRegistry: registry });
+    const competition = simulateSingleLanding(aircraft, route, {
+      globalRouteRegistry: registry,
+    });
 
     const monoPax = monopoly.landing.details?.passengers?.total ?? 0;
     const compPax = competition.landing.details?.passengers?.total ?? 0;
@@ -368,7 +377,9 @@ describe("FlightEngine — Multiplayer scenarios", () => {
     };
     const registry = new Map<string, FlightOffer[]>([["JFK-LAX", [competitorOffer]]]);
 
-    const { state } = simulateSingleLanding(aircraft, route, { globalRouteRegistry: registry });
+    const { state } = simulateSingleLanding(aircraft, route, {
+      globalRouteRegistry: registry,
+    });
     const priceWarEvent = state.events.find((e) => e.type === "price_war");
     expect(priceWarEvent).toBeTruthy();
   });
@@ -408,7 +419,9 @@ describe("FlightEngine — Multiplayer scenarios", () => {
     ]);
 
     const baseline = simulateSingleLanding(aircraft, route);
-    const otherRoutes = simulateSingleLanding(aircraft, route, { globalRouteRegistry: registry });
+    const otherRoutes = simulateSingleLanding(aircraft, route, {
+      globalRouteRegistry: registry,
+    });
     const basePax = baseline.landing.details?.passengers?.total ?? 0;
     const otherPax = otherRoutes.landing.details?.passengers?.total ?? 0;
     expect(otherPax).toBe(basePax);
@@ -1531,5 +1544,280 @@ describe("reconcileFleetToTick — destination-aware stagger", () => {
     const aFlight = result[0].flight!;
     const bFlight = result[1].flight!;
     expect(aFlight.direction).not.toBe(bFlight.direction);
+  });
+});
+
+describe("reconcileFleetToTick — synthetic timeline events", () => {
+  it("returns takeoff and landing events for an idle aircraft with assigned route", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-evt1",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt1"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    const aircraft = makeAircraft({
+      id: "ac-evt1",
+      assignedRouteId: "route-evt1",
+      status: "idle",
+      flight: null,
+      routeAssignedAtTick: 1000,
+    });
+
+    // Fast-forward through 3 complete cycles
+    const targetTick = 1000 + roundTrip * 3 + 1;
+    const { events } = reconcileFleetToTick([aircraft], [route], targetTick);
+
+    // Should have takeoff and landing events
+    const takeoffs = events.filter((e) => e.type === "takeoff");
+    const landings = events.filter((e) => e.type === "landing");
+
+    expect(takeoffs.length).toBeGreaterThan(0);
+    expect(landings.length).toBeGreaterThan(0);
+
+    // Events should be sorted by tick descending (newest first)
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].tick).toBeLessThanOrEqual(events[i - 1].tick);
+    }
+  });
+
+  it("events have correct ID format matching processFlightEngine", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-evt2",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt2"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    const aircraft = makeAircraft({
+      id: "ac-evt2",
+      assignedRouteId: "route-evt2",
+      status: "idle",
+      flight: null,
+      routeAssignedAtTick: 0,
+    });
+
+    const targetTick = roundTrip * 2 + 1;
+    const { events } = reconcileFleetToTick([aircraft], [route], targetTick);
+
+    for (const evt of events) {
+      if (evt.type === "takeoff") {
+        // Outbound: evt-takeoff-{acId}-{tick}, Inbound: evt-takeoff-rtn-{acId}-{tick}
+        expect(evt.id).toMatch(/^evt-takeoff(-rtn)?-ac-evt2-\d+$/);
+      } else if (evt.type === "landing") {
+        expect(evt.id).toMatch(/^evt-landing-ac-evt2-\d+$/);
+      }
+    }
+  });
+
+  it("landing events include financial details", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-evt3",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt3"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    const aircraft = makeAircraft({
+      id: "ac-evt3",
+      assignedRouteId: "route-evt3",
+      status: "idle",
+      flight: null,
+      routeAssignedAtTick: 0,
+    });
+
+    const targetTick = roundTrip + 1;
+    const { events } = reconcileFleetToTick([aircraft], [route], targetTick);
+    const landing = events.find((e) => e.type === "landing");
+
+    expect(landing).toBeDefined();
+    expect(landing!.revenue).toBeDefined();
+    expect(landing!.cost).toBeDefined();
+    expect(landing!.profit).toBeDefined();
+    expect(landing!.details).toBeDefined();
+    expect(landing!.details!.passengers).toBeDefined();
+    expect(landing!.details!.loadFactor).toBeGreaterThan(0);
+  });
+
+  it("returns no events for aircraft without assigned route", () => {
+    const aircraft = makeAircraft({
+      id: "ac-evt4",
+      assignedRouteId: null,
+      status: "idle",
+      flight: null,
+    });
+
+    const { events } = reconcileFleetToTick([aircraft], [], 50000);
+    expect(events.length).toBe(0);
+  });
+
+  it("returns no events when targetTick equals cycleStartTick", () => {
+    const route = makeRoute({
+      id: "route-evt5",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt5"],
+    });
+
+    const aircraft = makeAircraft({
+      id: "ac-evt5",
+      assignedRouteId: "route-evt5",
+      status: "idle",
+      flight: null,
+      routeAssignedAtTick: 5000,
+    });
+
+    const { events } = reconcileFleetToTick([aircraft], [route], 5000);
+    expect(events.length).toBe(0);
+  });
+
+  it("landing event count matches countLandingsBetween for the same parameters", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-evt6",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt6"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    const cycleStartTick = 1000;
+    const aircraft = makeAircraft({
+      id: "ac-evt6",
+      assignedRouteId: "route-evt6",
+      status: "idle",
+      flight: null,
+      routeAssignedAtTick: cycleStartTick,
+    });
+
+    const targetTick = cycleStartTick + roundTrip * 5 + 1;
+    const { events } = reconcileFleetToTick([aircraft], [route], targetTick);
+    const landingCount = events.filter((e) => e.type === "landing").length;
+    const expectedLandings = countLandingsBetween(
+      cycleStartTick,
+      cycleStartTick,
+      targetTick,
+      durationTicks,
+      turnaroundTicks,
+    );
+
+    expect(landingCount).toBe(expectedLandings);
+  });
+
+  it("enroute aircraft past arrival generates events for missed period", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-evt7",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt7"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    const aircraft = makeAircraft({
+      id: "ac-evt7",
+      assignedRouteId: "route-evt7",
+      status: "enroute",
+      flight: {
+        originIata: "JFK",
+        destinationIata: "LAX",
+        departureTick: 100,
+        arrivalTick: 100 + durationTicks,
+        direction: "outbound",
+      },
+    });
+
+    // Target is 5 cycles later — long offline gap
+    const targetTick = 100 + roundTrip * 5 + Math.floor(durationTicks / 2);
+    const { events } = reconcileFleetToTick([aircraft], [route], targetTick);
+
+    expect(events.length).toBeGreaterThan(0);
+    const takeoffs = events.filter((e) => e.type === "takeoff");
+    const landings = events.filter((e) => e.type === "landing");
+    expect(takeoffs.length).toBeGreaterThan(0);
+    expect(landings.length).toBeGreaterThan(0);
+  });
+
+  it("destination-start aircraft generates correctly shifted events", () => {
+    const model = getAircraftById("a320neo")!;
+    const route = makeRoute({
+      id: "route-evt8",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt8"],
+    });
+    const durationTicks = Math.ceil((3000 / model.speedKmh) * TICKS_PER_HOUR);
+    const turnaroundTicks = Math.ceil((model.turnaroundTimeMinutes / 60) * TICKS_PER_HOUR);
+    const roundTrip = durationTicks * 2 + turnaroundTicks * 2;
+
+    // Aircraft starts at destination (LAX)
+    const aircraft = makeAircraft({
+      id: "ac-evt8",
+      assignedRouteId: "route-evt8",
+      status: "idle",
+      baseAirportIata: "LAX",
+      flight: null,
+      routeAssignedAtTick: 1000,
+      routeAssignedAtIata: "LAX",
+    });
+
+    const targetTick = 1000 + roundTrip * 2 + 1;
+    const { events } = reconcileFleetToTick([aircraft], [route], targetTick);
+
+    expect(events.length).toBeGreaterThan(0);
+
+    // All event ticks should be within (1000, targetTick]
+    for (const evt of events) {
+      expect(evt.tick).toBeGreaterThan(1000);
+      expect(evt.tick).toBeLessThanOrEqual(targetTick);
+    }
+  });
+
+  it("grounded aircraft produces no events (cappedLandings = 0)", () => {
+    const route = makeRoute({
+      id: "route-evt9",
+      originIata: "JFK",
+      destinationIata: "LAX",
+      distanceKm: 3000,
+      assignedAircraftIds: ["ac-evt9"],
+    });
+
+    // Aircraft is near grounding (flightHoursSinceCheck at 599, condition barely above 0.2)
+    const aircraft = makeAircraft({
+      id: "ac-evt9",
+      assignedRouteId: "route-evt9",
+      status: "idle",
+      flight: null,
+      routeAssignedAtTick: 0,
+      flightHoursSinceCheck: 599,
+      condition: 1.0,
+    });
+
+    // From the existing test, this should cap landings to 0
+    const { events } = reconcileFleetToTick([aircraft], [route], 50000);
+    expect(events.length).toBe(0);
   });
 });

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -10,6 +10,7 @@ import {
   computeRouteFrequency,
   countLandingsBetween,
   detectPriceWar,
+  enumerateFlightEvents,
   fp,
   fpAdd,
   fpScale,
@@ -864,13 +865,36 @@ export function estimateLandingFinancials(
  * Only touches aircraft that are actively flying a route (enroute/turnaround
  * with an assignedRouteId).  Revenue/cost is NOT calculated — this is purely
  * positional reconciliation.
+ *
+ * Returns synthetic timeline events (takeoff/landing) for the reconciled
+ * period so the activity log is populated even when the tick-by-tick engine
+ * loop is skipped (e.g. after an overnight absence).
  */
 export function reconcileFleetToTick(
   fleet: AircraftInstance[],
   routes: Route[],
   targetTick: number,
-): { fleet: AircraftInstance[]; balanceDelta: FixedPoint } {
+): {
+  fleet: AircraftInstance[];
+  balanceDelta: FixedPoint;
+  events: TimelineEvent[];
+} {
   let balanceDelta = fp(0);
+
+  // Collect per-aircraft cycle parameters so we can generate synthetic
+  // timeline events after the positional reconciliation is complete.
+  interface EventGenParams {
+    ac: AircraftInstance;
+    route: Route;
+    cycleStartTick: number;
+    fromTick: number;
+    durationTicks: number;
+    turnaroundTicks: number;
+    phaseOffset: number;
+    cappedLandings: number;
+  }
+  const eventGenQueue: EventGenParams[] = [];
+
   const updatedFleet: AircraftInstance[] = fleet.map((ac): AircraftInstance => {
     // Handle delivery aircraft that have been delivered but have no route —
     // they just need to transition to idle.  This must happen before the
@@ -949,6 +973,16 @@ export function reconcileFleetToTick(
           balanceDelta,
           accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
         );
+        eventGenQueue.push({
+          ac: updated,
+          route,
+          cycleStartTick,
+          fromTick: referenceTick,
+          durationTicks,
+          turnaroundTicks,
+          phaseOffset: stalePhaseOffset,
+          cappedLandings: landings,
+        });
         return updated;
       }
       // Aircraft was mid-flight. Its cycle started at departureTick.
@@ -997,6 +1031,16 @@ export function reconcileFleetToTick(
           balanceDelta,
           accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
         );
+        eventGenQueue.push({
+          ac: updated,
+          route,
+          cycleStartTick,
+          fromTick: referenceTick,
+          durationTicks,
+          turnaroundTicks,
+          phaseOffset: stalePhaseOffset,
+          cappedLandings: landings,
+        });
         return updated;
       }
       // Aircraft was in turnaround. Turnaround started at arrivalTick.
@@ -1049,6 +1093,16 @@ export function reconcileFleetToTick(
         balanceDelta,
         accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
       );
+      eventGenQueue.push({
+        ac: updated,
+        route,
+        cycleStartTick,
+        fromTick: referenceTick,
+        durationTicks,
+        turnaroundTicks,
+        phaseOffset,
+        cappedLandings: landings,
+      });
       return updated;
     } else if (ac.status === "delivery") {
       // Delivery aircraft whose deliveryAtTick is in the past should be
@@ -1097,6 +1151,16 @@ export function reconcileFleetToTick(
           balanceDelta,
           accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
         );
+        eventGenQueue.push({
+          ac: updated,
+          route,
+          cycleStartTick,
+          fromTick: referenceTick,
+          durationTicks,
+          turnaroundTicks,
+          phaseOffset: delPhaseOffset,
+          cappedLandings: landings,
+        });
         return updated;
       }
       // Still in delivery period — skip
@@ -1140,9 +1204,94 @@ export function reconcileFleetToTick(
       balanceDelta,
       accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
     );
+    eventGenQueue.push({
+      ac: updated,
+      route,
+      cycleStartTick,
+      fromTick: referenceTick,
+      durationTicks,
+      turnaroundTicks,
+      phaseOffset: 0,
+      cappedLandings: landings,
+    });
 
     return updated;
   });
 
-  return { fleet: updatedFleet, balanceDelta };
+  // --- Generate synthetic timeline events for the reconciled period ---
+  const events: TimelineEvent[] = [];
+  for (const params of eventGenQueue) {
+    if (params.cappedLandings <= 0) continue;
+
+    // For phase-offset routes (aircraft starting at destination), we need to
+    // adjust the effective cycle start so that enumerateFlightEvents (which
+    // always assumes the cycle starts at outbound takeoff) produces correctly
+    // shifted ticks.
+    const effectiveCycleStart = params.cycleStartTick - params.phaseOffset;
+
+    const rawEvents = enumerateFlightEvents(
+      effectiveCycleStart,
+      params.fromTick,
+      targetTick,
+      params.durationTicks,
+      params.turnaroundTicks,
+      params.route,
+    );
+
+    for (const evt of rawEvents) {
+      const simulatedTimestamp = GENESIS_TIME + evt.tick * TICK_DURATION;
+      const idSuffix = evt.direction === "outbound" ? "" : "-rtn";
+
+      if (evt.type === "takeoff") {
+        events.push({
+          id: `evt-takeoff${idSuffix}-${params.ac.id}-${evt.tick}`,
+          tick: evt.tick,
+          timestamp: simulatedTimestamp,
+          type: "takeoff",
+          aircraftId: params.ac.id,
+          aircraftName: params.ac.name,
+          routeId: params.route.id,
+          originIata: evt.originIata,
+          destinationIata: evt.destinationIata,
+          description:
+            evt.direction === "outbound"
+              ? `${params.ac.name} taking off: ${evt.originIata} → ${evt.destinationIata}`
+              : `${params.ac.name} returning: ${evt.originIata} → ${evt.destinationIata}`,
+        });
+      } else {
+        // Landing — include estimated financial details
+        const model = getAircraftById(params.ac.modelId);
+        const hoursPerLeg = Math.min(24, params.durationTicks / TICKS_PER_HOUR);
+        const financials = estimateLandingFinancials(
+          params.ac,
+          params.route,
+          model,
+          hoursPerLeg,
+          params.ac.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
+        );
+
+        events.push({
+          id: `evt-landing-${params.ac.id}-${evt.tick}`,
+          tick: evt.tick,
+          timestamp: simulatedTimestamp,
+          type: "landing",
+          aircraftId: params.ac.id,
+          aircraftName: params.ac.name,
+          routeId: params.route.id,
+          originIata: evt.originIata,
+          destinationIata: evt.destinationIata,
+          description: `${params.ac.name} landed at ${evt.destinationIata}`,
+          revenue: financials.revenue.revenueTotal,
+          cost: financials.cost.costTotal,
+          profit: financials.profit,
+          details: financials.details,
+        });
+      }
+    }
+  }
+
+  // Sort events by tick descending (newest first) to match timeline convention
+  events.sort((a, b) => b.tick - a.tick);
+
+  return { fleet: updatedFleet, balanceDelta, events };
 }

--- a/packages/store/src/localLoader.ts
+++ b/packages/store/src/localLoader.ts
@@ -94,10 +94,21 @@ export async function hydrateIdentityFromStorage(
   }
 
   // Reconcile to the current engine tick, not the snapshot's lastTick
+  let reconciledTimeline = airline.timeline || [];
   if (airline.lastTick != null && fleet.length > 0 && engineTick > airline.lastTick) {
-    const { fleet: reconciled } = reconcileFleetToTick(fleet, routes, engineTick);
+    const { fleet: reconciled, events } = reconcileFleetToTick(fleet, routes, engineTick);
     fleet = reconciled;
     airline.lastTick = engineTick;
+
+    // Merge synthetic takeoff/landing events into the timeline so the
+    // activity log reflects what happened while the client was offline.
+    if (events.length > 0) {
+      const existingIds = new Set(reconciledTimeline.map((e) => e.id));
+      const newEvents = events.filter((e) => !existingIds.has(e.id));
+      if (newEvents.length > 0) {
+        reconciledTimeline = [...newEvents, ...reconciledTimeline].slice(0, 1000);
+      }
+    }
   }
 
   set({
@@ -105,7 +116,7 @@ export async function hydrateIdentityFromStorage(
     airline,
     fleet,
     routes,
-    timeline: airline.timeline || [],
+    timeline: reconciledTimeline,
     actionChainHash: currentActionChainHash,
     actionSeq: currentActionSeq,
     fleetDeletedDuringCatchup: [],

--- a/packages/store/src/slices/engineSlice.test.ts
+++ b/packages/store/src/slices/engineSlice.test.ts
@@ -28,6 +28,7 @@ vi.mock("../FlightEngine", () => ({
   reconcileFleetToTick: vi.fn((fleet: AircraftInstance[]) => ({
     fleet,
     balanceDelta: 0,
+    events: [],
   })),
 }));
 
@@ -307,6 +308,7 @@ describe("immediate visual reconciliation during catch-up", () => {
     vi.mocked(reconcileFleetToTick).mockReturnValue({
       fleet: [projectedAircraft],
       balanceDelta: 0 as FixedPoint,
+      events: [],
     });
 
     vi.mocked(processFlightEngine).mockReturnValue({

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -310,8 +310,23 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
       // the tick-by-tick financial simulation catches up. Without this, the
       // fleet appears stuck at stale arrivalTick positions during catch-up.
       if (targetTick - lastTick > 1) {
-        const { fleet: projectedFleet } = reconcileFleetToTick(fleet, routes, targetTick);
+        const { fleet: projectedFleet, events: reconciledEvents } = reconcileFleetToTick(
+          fleet,
+          routes,
+          targetTick,
+        );
         set({ fleet: projectedFleet });
+
+        // Merge synthetic timeline events from reconciliation so the activity
+        // log is immediately populated even before the tick-by-tick loop runs.
+        if (reconciledEvents.length > 0) {
+          const newEvents = reconciledEvents.filter((e) => !timelineEventIds.has(e.id));
+          if (newEvents.length > 0) {
+            currentTimeline = [...newEvents, ...currentTimeline].slice(0, 1000);
+            timelineEventIds.clear();
+            for (const event of currentTimeline) timelineEventIds.add(event.id);
+          }
+        }
       }
 
       let processingError = false;

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -29,7 +29,11 @@ vi.mock("../engine", () => ({
 }));
 
 vi.mock("../FlightEngine", () => ({
-  reconcileFleetToTick: vi.fn((fleet) => ({ fleet, balanceDelta: 0 })),
+  reconcileFleetToTick: vi.fn((fleet) => ({
+    fleet,
+    balanceDelta: 0,
+    events: [],
+  })),
 }));
 
 const createSliceState = (overrides: Partial<AirlineState> = {}) => {
@@ -177,7 +181,10 @@ describe("projectCompetitorFleet", () => {
   it("does not project bankrupt competitors", () => {
     const tick = 200;
     const pubkey = "comp-bankrupt";
-    const airline = { ...makeAirline(pubkey, tick - 50), status: "chapter11" as const };
+    const airline = {
+      ...makeAirline(pubkey, tick - 50),
+      status: "chapter11" as const,
+    };
     const aircraft: AircraftInstance = {
       ...makeAircraft("ac-bankrupt", pubkey),
       status: "enroute",
@@ -241,7 +248,10 @@ describe("syncWorld", () => {
 
   it("ignores bankrupt states", async () => {
     const pubkey = "comp-bankrupt";
-    const bankruptAirline = { ...makeAirline(pubkey, 100), status: "chapter11" };
+    const bankruptAirline = {
+      ...makeAirline(pubkey, 100),
+      status: "chapter11",
+    };
     const mockSnapshot = {
       schemaVersion: 1,
       tick: 120,


### PR DESCRIPTION
## Summary

When a player closes the browser and reopens hours later, `reconcileFleetToTick()` correctly repositions aircraft and accumulates revenue using O(1) cycle algebra — but the activity timeline stayed empty because no `TimelineEvent` entries were generated for the flights that occurred while offline.

## Root Cause

1. `localLoader.ts` set `airline.lastTick = engineTick` after reconciliation, causing the tick-by-tick catch-up loop in `engineSlice.ts` to be skipped entirely
2. `reconcileFleetToTick()` itself was purely positional/financial — it never created timeline events

## Solution

Added a new `enumerateFlightEvents()` function in `@acars/core` that uses cycle algebra to enumerate every takeoff/landing tick in a half-open interval `(fromTick, toTick]` — no tick-by-tick simulation needed. `reconcileFleetToTick()` now collects cycle parameters alongside its existing financial calculations, then generates synthetic `TimelineEvent` objects in a second pass. Events use the same ID format as the live engine for natural deduplication.

## Changes

- **`packages/core/src/cycle.ts`** — New `enumerateFlightEvents()` + `CycleFlightEvent` interface using modular arithmetic over 4 transition offsets per round-trip cycle. Safety cap of 200 events.
- **`packages/core/src/cycle.test.ts`** — 17 unit tests covering interval semantics, landing count consistency, direction/airport correctness, maxEvents cap, phase offsets, and multi-cycle ranges.
- **`packages/store/src/FlightEngine.ts`** — `reconcileFleetToTick()` now returns `events: TimelineEvent[]` alongside fleet and balanceDelta. All 5 branches that call `countLandingsBetween()` push corresponding event-gen params.
- **`packages/store/src/localLoader.ts`** — Merges reconciled events into timeline with deduplication by event ID.
- **`packages/store/src/slices/engineSlice.ts`** — Merges reconciled events during immediate visual reconciliation with deduplication.
- **`packages/store/src/FlightEngine.test.ts`** — 9 integration tests for synthetic event generation.
- **Test mocks updated** in `engineSlice.test.ts` and `worldSlice.test.ts`.

## Verification

- `@acars/core`: 151 tests pass (was 134, +17 new)
- `@acars/store`: 143 tests pass (was 134, +9 new)
- `pnpm -r build`: All 6 packages build clean
- `pnpm -r typecheck`: Zero errors
- `pnpm -r lint`: Clean