### PR TITLE
fix: unify route competition keys and inbound demand

### DIFF
--- a/apps/web/src/features/competition/leaderboardMetrics.test.ts
+++ b/apps/web/src/features/competition/leaderboardMetrics.test.ts
@@ -22,6 +22,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => (
   livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
   brandScore: 0.7,
   tier: 1,
+  cumulativeRevenue: fp(0),
   corporateBalance: fp(1000000),
   stockPrice: fp(0),
   fleetIds: [],

--- a/apps/web/src/features/fleet/components/AircraftDealer.tsx
+++ b/apps/web/src/features/fleet/components/AircraftDealer.tsx
@@ -22,6 +22,9 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useConfirm } from "@/shared/lib/useConfirm";
 
+/**
+ * Renders the aircraft dealer with factory and marketplace listings.
+ */
 export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () => void }) {
   const logger = useMemo(() => createLogger("AircraftDealer"), []);
   const [mode, setMode] = useState<"factory" | "marketplace">("factory");
@@ -342,6 +345,9 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
   );
 }
 
+/**
+ * Shows a factory aircraft card with tier gating.
+ */
 function AircraftCard({
   aircraft,
   airlineTier,
@@ -468,6 +474,9 @@ type UsedListingCardProps = {
   onBuy: () => void;
 };
 
+/**
+ * Shows a used aircraft listing with tier gating.
+ */
 function UsedAircraftCard({ listing, airlineTier, onBuy }: UsedListingCardProps) {
   const model = getAircraftById(listing.modelId);
   if (!model) return null;
@@ -560,6 +569,9 @@ function UsedAircraftCard({ listing, airlineTier, onBuy }: UsedListingCardProps)
   );
 }
 
+/**
+ * Captures configuration and confirms aircraft purchase.
+ */
 function PurchaseModal({
   aircraft,
   onClose,

--- a/apps/web/src/features/fleet/components/AircraftDealer.tsx
+++ b/apps/web/src/features/fleet/components/AircraftDealer.tsx
@@ -31,7 +31,12 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
   const [isLoadingUsed, setIsLoadingUsed] = useState(false);
   const purchaseUsed = useAirlineStore((state) => state.purchaseUsedAircraft);
   const fleet = useAirlineStore((state) => state.fleet);
+  const airlineTier = useAirlineStore((state) => state.airline?.tier ?? 1);
   const confirm = useConfirm();
+  const skeletonKeys = useMemo(
+    () => Array.from({ length: 6 }, (_, index) => `skeleton-${index}`),
+    [],
+  );
 
   const handleBuyUsed = async (listing: MarketplaceListing) => {
     const approved = await confirm({
@@ -132,6 +137,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
       {/* Mode Switcher */}
       <div className="flex items-center gap-2 border-b border-border/40 pb-4">
         <button
+          type="button"
           onClick={() => setMode("factory")}
           className={`flex items-center gap-2 px-6 py-2 rounded-xl text-sm font-bold transition-all ${mode === "factory" ? "bg-primary text-primary-foreground shadow-lg shadow-primary/20" : "text-muted-foreground hover:bg-accent/40"}`}
         >
@@ -139,6 +145,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
           Factory New
         </button>
         <button
+          type="button"
           onClick={() => {
             setMode("marketplace");
             fetchUsed();
@@ -166,6 +173,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
           </div>
           {mode === "marketplace" && (
             <button
+              type="button"
               onClick={fetchUsed}
               disabled={isLoadingUsed}
               className="h-10 px-4 rounded-xl border border-orange-500/20 bg-orange-500/10 text-orange-400 hover:bg-orange-500/20 transition-all font-bold text-xs flex items-center gap-2 disabled:opacity-50"
@@ -179,6 +187,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
         {mode === "factory" && (
           <div className="flex items-center space-x-2 bg-background p-1 rounded-xl border border-border/50">
             <button
+              type="button"
               onClick={() => setSelectedTier("all")}
               className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-all ${
                 selectedTier === "all"
@@ -191,6 +200,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
             {[1, 2, 3, 4].map((tier) => (
               <button
                 key={tier}
+                type="button"
                 onClick={() => setSelectedTier(tier)}
                 className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-all flex items-center gap-1 ${
                   selectedTier === tier
@@ -213,6 +223,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
               <AircraftCard
                 key={aircraft.id}
                 aircraft={aircraft}
+                airlineTier={airlineTier}
                 onSelect={() => setSelectedModel(aircraft)}
               />
             ))}
@@ -220,9 +231,9 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
         ) : (
           <div className="grid grid-cols-1 xl:grid-cols-2 2xl:grid-cols-3 gap-6">
             {isLoadingUsed ? (
-              Array.from({ length: 6 }).map((_, i) => (
+              skeletonKeys.map((key) => (
                 <div
-                  key={i}
+                  key={key}
                   className="h-64 rounded-2xl bg-card animate-pulse border border-border/40"
                 />
               ))
@@ -258,7 +269,15 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
   );
 }
 
-function AircraftCard({ aircraft, onSelect }: { aircraft: AircraftModel; onSelect: () => void }) {
+function AircraftCard({
+  aircraft,
+  airlineTier,
+  onSelect,
+}: {
+  aircraft: AircraftModel;
+  airlineTier: number;
+  onSelect: () => void;
+}) {
   const gradientMap: Record<string, string> = {
     Airbus: "from-blue-500/20 via-blue-900/10 to-transparent",
     Boeing: "from-indigo-500/20 via-purple-900/10 to-transparent",
@@ -270,9 +289,14 @@ function AircraftCard({ aircraft, onSelect }: { aircraft: AircraftModel; onSelec
     gradientMap[aircraft.manufacturer] || "from-zinc-500/20 via-zinc-900/10 to-transparent";
   const totalCapacity =
     aircraft.capacity.economy + aircraft.capacity.business + aircraft.capacity.first;
+  const isLocked = aircraft.unlockTier > airlineTier;
 
   return (
-    <div className="group relative flex flex-col rounded-2xl bg-card border border-border overflow-hidden transition-all duration-300 hover:shadow-[0_8px_30px_rgb(0,0,0,0.5)] hover:border-border/80">
+    <div
+      className={`group relative flex flex-col rounded-2xl bg-card border border-border overflow-hidden transition-all duration-300 hover:shadow-[0_8px_30px_rgb(0,0,0,0.5)] hover:border-border/80 ${
+        isLocked ? "opacity-60" : ""
+      }`}
+    >
       {/* Top Image Splash */}
       <div
         className={`h-32 w-full bg-gradient-to-br ${bgGradient} relative flex items-center justify-center border-b border-border/30`}
@@ -345,10 +369,18 @@ function AircraftCard({ aircraft, onSelect }: { aircraft: AircraftModel; onSelec
           </div>
 
           <button
+            type="button"
             onClick={onSelect}
-            className="relative overflow-hidden rounded-xl bg-primary/10 px-4 py-2 text-sm font-bold text-primary transition-all duration-300 hover:bg-primary hover:text-primary-foreground hover:shadow-[0_0_20px_rgba(16,185,129,0.4)] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background"
+            disabled={isLocked}
+            className={`relative overflow-hidden rounded-xl px-4 py-2 text-sm font-bold transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-background ${
+              isLocked
+                ? "bg-muted/40 text-muted-foreground cursor-not-allowed"
+                : "bg-primary/10 text-primary hover:bg-primary hover:text-primary-foreground hover:shadow-[0_0_20px_rgba(16,185,129,0.4)] focus:ring-primary"
+            }`}
           >
-            <span className="relative flex items-center gap-2">Configure & Buy</span>
+            <span className="relative flex items-center gap-2">
+              {isLocked ? `Requires Tier ${aircraft.unlockTier}` : "Configure & Buy"}
+            </span>
           </button>
         </div>
       </div>
@@ -436,6 +468,7 @@ function UsedAircraftCard({ listing, onBuy }: UsedListingCardProps) {
           </div>
 
           <button
+            type="button"
             onClick={onBuy}
             className="rounded-lg bg-orange-500 px-4 py-2 text-xs font-bold text-white hover:bg-orange-600 transition-all hover:shadow-[0_0_15px_rgba(249,115,22,0.4)]"
           >
@@ -467,6 +500,11 @@ function PurchaseModal({
 
   const [busSeats, setBusSeats] = useState(aircraft.capacity.business);
   const [firstSeats, setFirstSeats] = useState(aircraft.capacity.first);
+  const modalKey = aircraft.id.replace(/[^a-zA-Z0-9-_]/g, "");
+  const nameInputId = `aircraft-name-${modalKey}`;
+  const hubSelectId = `aircraft-hub-${modalKey}`;
+  const firstSliderId = `aircraft-first-${modalKey}`;
+  const businessSliderId = `aircraft-business-${modalKey}`;
 
   // Calculate space dynamics based on fleet manager plan
   const baseEconSpace =
@@ -536,6 +574,7 @@ function PurchaseModal({
           <Plane className="h-24 w-24 text-foreground/10 rotate-[-15deg] absolute right-6 top-4" />
 
           <button
+            type="button"
             onClick={onClose}
             className="absolute top-4 right-4 p-2 rounded-full bg-background/20 hover:bg-background/40 backdrop-blur-md transition-colors z-20"
           >
@@ -552,10 +591,14 @@ function PurchaseModal({
             </h4>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-1.5 border border-border/50 rounded-xl p-3 bg-background/50 focus-within:border-primary/50 transition-colors">
-                <label className="text-[10px] font-semibold text-muted-foreground uppercase block">
+                <label
+                  htmlFor={nameInputId}
+                  className="text-[10px] font-semibold text-muted-foreground uppercase block"
+                >
                   Registration / Name (Optional)
                 </label>
                 <input
+                  id={nameInputId}
                   type="text"
                   value={customName}
                   onChange={(e) => setCustomName(e.target.value)}
@@ -566,10 +609,14 @@ function PurchaseModal({
 
               {hubs.length > 0 && (
                 <div className="space-y-1.5 border border-border/50 rounded-xl p-3 bg-background/50 focus-within:border-primary/50 transition-colors">
-                  <label className="text-[10px] font-semibold text-muted-foreground uppercase block flex items-center gap-1">
+                  <label
+                    htmlFor={hubSelectId}
+                    className="text-[10px] font-semibold text-muted-foreground uppercase block flex items-center gap-1"
+                  >
                     <MapPin className="h-3 w-3" /> Delivery Hub
                   </label>
                   <select
+                    id={hubSelectId}
                     value={selectedHub}
                     onChange={(e) => setSelectedHub(e.target.value)}
                     className="w-full bg-transparent text-sm font-medium outline-none cursor-pointer"
@@ -593,6 +640,7 @@ function PurchaseModal({
             </h4>
             <div className="flex p-1 bg-background/50 border border-border/50 rounded-xl w-full">
               <button
+                type="button"
                 onClick={() => setPurchaseType("buy")}
                 className={`flex-1 py-2 px-4 rounded-lg text-xs font-bold transition-all ${
                   purchaseType === "buy"
@@ -603,6 +651,7 @@ function PurchaseModal({
                 Cash Purchase
               </button>
               <button
+                type="button"
                 onClick={() => setPurchaseType("lease")}
                 className={`flex-1 py-2 px-4 rounded-lg text-xs font-bold transition-all ${
                   purchaseType === "lease"
@@ -632,11 +681,15 @@ function PurchaseModal({
 
             <div className="border border-border/50 rounded-xl p-5 bg-background/50 space-y-6">
               <div className="flex flex-col gap-2">
-                <label className="text-[10px] font-semibold text-muted-foreground uppercase flex justify-between">
+                <label
+                  htmlFor={firstSliderId}
+                  className="text-[10px] font-semibold text-muted-foreground uppercase flex justify-between"
+                >
                   <span>First Class (4x space)</span>
                   <span className={firstSeats > 0 ? "text-primary" : ""}>{firstSeats} seats</span>
                 </label>
                 <input
+                  id={firstSliderId}
                   type="range"
                   min="0"
                   max={maxFirstClass}
@@ -656,11 +709,15 @@ function PurchaseModal({
               </div>
 
               <div className="flex flex-col gap-2">
-                <label className="text-[10px] font-semibold text-muted-foreground uppercase flex justify-between">
+                <label
+                  htmlFor={businessSliderId}
+                  className="text-[10px] font-semibold text-muted-foreground uppercase flex justify-between"
+                >
                   <span>Business Class (2.5x space)</span>
                   <span className={busSeats > 0 ? "text-primary" : ""}>{busSeats} seats</span>
                 </label>
                 <input
+                  id={businessSliderId}
                   type="range"
                   min="0"
                   max={maxBusinessClass}
@@ -731,6 +788,7 @@ function PurchaseModal({
           </div>
 
           <button
+            type="button"
             onClick={handlePurchase}
             disabled={isPurchasing || !canAfford || (hubs.length > 0 && !selectedHub)}
             className={`relative overflow-hidden rounded-xl px-8 py-3 text-base font-bold transition-all duration-300 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background ${

--- a/apps/web/src/features/fleet/components/AircraftDealer.tsx
+++ b/apps/web/src/features/fleet/components/AircraftDealer.tsx
@@ -3,6 +3,7 @@ import { createLogger, FP_ZERO, fpFormat, fpScale, TICK_DURATION } from "@acars/
 import { aircraftModels, getAircraftById } from "@acars/data";
 import { loadMarketplace, type MarketplaceListing, type SellerFleetIndex } from "@acars/nostr";
 import { useAirlineStore } from "@acars/store";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   ArrowRight,
   Check,
@@ -17,7 +18,7 @@ import {
   Users,
   X,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useConfirm } from "@/shared/lib/useConfirm";
 
@@ -37,6 +38,25 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
     () => Array.from({ length: 6 }, (_, index) => `skeleton-${index}`),
     [],
   );
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [gridColumns, setGridColumns] = useState(1);
+
+  useEffect(() => {
+    const updateColumns = () => {
+      const width = scrollRef.current?.clientWidth ?? 0;
+      if (width >= 1536) {
+        setGridColumns(3);
+      } else if (width >= 1280) {
+        setGridColumns(2);
+      } else {
+        setGridColumns(1);
+      }
+    };
+
+    updateColumns();
+    window.addEventListener("resize", updateColumns);
+    return () => window.removeEventListener("resize", updateColumns);
+  }, []);
 
   const handleBuyUsed = async (listing: MarketplaceListing) => {
     const approved = await confirm({
@@ -132,6 +152,32 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
     return list;
   }, [search, usedListings, selectedTier, fleet]);
 
+  const displayMode =
+    mode === "factory"
+      ? "factory"
+      : isLoadingUsed
+        ? "used-loading"
+        : filteredUsed.length > 0
+          ? "used"
+          : "used-empty";
+
+  const listItems =
+    displayMode === "factory"
+      ? filteredFactory
+      : displayMode === "used-loading"
+        ? skeletonKeys
+        : displayMode === "used"
+          ? filteredUsed
+          : [];
+  const rowCount = Math.ceil(listItems.length / gridColumns);
+  const rowHeight = displayMode === "factory" ? 360 : displayMode === "used-loading" ? 260 : 320;
+  const virtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => rowHeight,
+    overscan: 2,
+  });
+
   return (
     <div className="flex flex-col h-full space-y-6">
       {/* Mode Switcher */}
@@ -216,43 +262,70 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
       </div>
 
       {/* Grid */}
-      <div className="flex-1 overflow-y-auto pr-2 custom-scrollbar pb-10">
-        {mode === "factory" ? (
-          <div className="grid grid-cols-1 xl:grid-cols-2 2xl:grid-cols-3 gap-6">
-            {filteredFactory.map((aircraft) => (
-              <AircraftCard
-                key={aircraft.id}
-                aircraft={aircraft}
-                airlineTier={airlineTier}
-                onSelect={() => setSelectedModel(aircraft)}
-              />
-            ))}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto pr-2 custom-scrollbar pb-10">
+        {displayMode === "used-empty" ? (
+          <div className="py-20 text-center flex flex-col items-center border border-dashed border-border/50 rounded-2xl bg-card/20">
+            <History className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />
+            <p className="text-muted-foreground">
+              No used aircraft currently listed on the Marketplace.
+            </p>
           </div>
         ) : (
-          <div className="grid grid-cols-1 xl:grid-cols-2 2xl:grid-cols-3 gap-6">
-            {isLoadingUsed ? (
-              skeletonKeys.map((key) => (
+          <div className="relative w-full" style={{ height: `${virtualizer.getTotalSize()}px` }}>
+            {virtualizer.getVirtualItems().map((row) => {
+              const startIndex = row.index * gridColumns;
+              const rowItems = listItems.slice(startIndex, startIndex + gridColumns);
+
+              return (
                 <div
-                  key={key}
-                  className="h-64 rounded-2xl bg-card animate-pulse border border-border/40"
-                />
-              ))
-            ) : filteredUsed.length > 0 ? (
-              filteredUsed.map((listing) => (
-                <UsedAircraftCard
-                  key={listing.id}
-                  listing={listing}
-                  onBuy={() => handleBuyUsed(listing)}
-                />
-              ))
-            ) : (
-              <div className="col-span-full py-20 text-center flex flex-col items-center border border-dashed border-border/50 rounded-2xl bg-card/20">
-                <History className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />
-                <p className="text-muted-foreground">
-                  No used aircraft currently listed on the Marketplace.
-                </p>
-              </div>
-            )}
+                  key={row.key}
+                  className="grid gap-6"
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: `${row.size}px`,
+                    transform: `translateY(${row.start}px)`,
+                    gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))`,
+                  }}
+                >
+                  {rowItems.map((item) => {
+                    if (displayMode === "factory") {
+                      const aircraft = item as AircraftModel;
+                      return (
+                        <AircraftCard
+                          key={aircraft.id}
+                          aircraft={aircraft}
+                          airlineTier={airlineTier}
+                          onSelect={() => setSelectedModel(aircraft)}
+                        />
+                      );
+                    }
+
+                    if (displayMode === "used-loading") {
+                      const key = item as string;
+                      return (
+                        <div
+                          key={key}
+                          className="h-64 rounded-2xl bg-card animate-pulse border border-border/40"
+                        />
+                      );
+                    }
+
+                    const listing = item as MarketplaceListing;
+                    return (
+                      <UsedAircraftCard
+                        key={listing.id}
+                        listing={listing}
+                        airlineTier={airlineTier}
+                        onBuy={() => handleBuyUsed(listing)}
+                      />
+                    );
+                  })}
+                </div>
+              );
+            })}
           </div>
         )}
       </div>
@@ -391,12 +464,14 @@ function AircraftCard({
 // ...
 type UsedListingCardProps = {
   listing: MarketplaceListing;
+  airlineTier: number;
   onBuy: () => void;
 };
 
-function UsedAircraftCard({ listing, onBuy }: UsedListingCardProps) {
+function UsedAircraftCard({ listing, airlineTier, onBuy }: UsedListingCardProps) {
   const model = getAircraftById(listing.modelId);
   if (!model) return null;
+  const isLocked = model.unlockTier > airlineTier;
 
   const bgGradient = "from-orange-500/10 via-orange-900/5 to-transparent";
 
@@ -470,9 +545,14 @@ function UsedAircraftCard({ listing, onBuy }: UsedListingCardProps) {
           <button
             type="button"
             onClick={onBuy}
-            className="rounded-lg bg-orange-500 px-4 py-2 text-xs font-bold text-white hover:bg-orange-600 transition-all hover:shadow-[0_0_15px_rgba(249,115,22,0.4)]"
+            disabled={isLocked}
+            className={`rounded-lg px-4 py-2 text-xs font-bold transition-all ${
+              isLocked
+                ? "bg-muted/40 text-muted-foreground cursor-not-allowed"
+                : "bg-orange-500 text-white hover:bg-orange-600 hover:shadow-[0_0_15px_rgba(249,115,22,0.4)]"
+            }`}
           >
-            Purchase
+            {isLocked ? `Requires Tier ${model.unlockTier}` : "Purchase"}
           </button>
         </div>
       </div>

--- a/apps/web/src/features/fleet/utils/aircraftBaseHub.test.ts
+++ b/apps/web/src/features/fleet/utils/aircraftBaseHub.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { fp } from "@acars/core";
 import type { AircraftInstance, AirlineEntity, Route } from "@acars/core";
+import { fp } from "@acars/core";
+import { describe, expect, it } from "vitest";
 import { getAircraftBaseHub } from "./aircraftBaseHub";
 
 const makeAircraft = (overrides: Partial<AircraftInstance> = {}): AircraftInstance => ({
@@ -37,6 +37,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => (
   livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
   brandScore: 0.7,
   tier: 1,
+  cumulativeRevenue: fp(0),
   corporateBalance: fp(1000000),
   stockPrice: fp(0),
   fleetIds: [],
@@ -60,7 +61,10 @@ const makeRoute = (overrides: Partial<Route> = {}): Route => ({
 
 describe("getAircraftBaseHub", () => {
   it("prefers assigned route origin over current location", () => {
-    const aircraft = makeAircraft({ assignedRouteId: "route-1", baseAirportIata: "BOG" });
+    const aircraft = makeAircraft({
+      assignedRouteId: "route-1",
+      baseAirportIata: "BOG",
+    });
     const routes = [makeRoute({ id: "route-1", originIata: "PTY" })];
     const airline = makeAirline({ hubs: ["PTY"] });
 
@@ -68,7 +72,10 @@ describe("getAircraftBaseHub", () => {
   });
 
   it("falls back to airline primary hub when unassigned", () => {
-    const aircraft = makeAircraft({ assignedRouteId: null, baseAirportIata: "BOG" });
+    const aircraft = makeAircraft({
+      assignedRouteId: null,
+      baseAirportIata: "BOG",
+    });
     const routes: Route[] = [];
     const airline = makeAirline({ hubs: ["PTY"] });
 
@@ -76,7 +83,10 @@ describe("getAircraftBaseHub", () => {
   });
 
   it("falls back to aircraft location when airline is missing", () => {
-    const aircraft = makeAircraft({ assignedRouteId: null, baseAirportIata: "BOG" });
+    const aircraft = makeAircraft({
+      assignedRouteId: null,
+      baseAirportIata: "BOG",
+    });
     const routes: Route[] = [];
 
     expect(getAircraftBaseHub(aircraft, routes, null)).toBe("BOG");

--- a/apps/web/src/features/identity/utils/airlineConflicts.test.ts
+++ b/apps/web/src/features/identity/utils/airlineConflicts.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { fp } from "@acars/core";
 import type { AirlineEntity } from "@acars/core";
+import { fp } from "@acars/core";
+import { describe, expect, it } from "vitest";
 import { findAirlineConflicts } from "./airlineConflicts";
 
 const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => ({
@@ -17,6 +17,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => (
   livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
   brandScore: 0.7,
   tier: 1,
+  cumulativeRevenue: fp(0),
   corporateBalance: fp(1000000),
   stockPrice: fp(0),
   fleetIds: [],

--- a/apps/web/src/features/network/components/RouteManager.test.tsx
+++ b/apps/web/src/features/network/components/RouteManager.test.tsx
@@ -38,7 +38,9 @@ vi.mock("@acars/data", () => {
         population: 1,
       },
     ],
-    HUB_CLASSIFICATIONS: { JFK: { baseCapacityPerHour: 100, slotControlled: false } },
+    HUB_CLASSIFICATIONS: {
+      JFK: { baseCapacityPerHour: 100, slotControlled: false },
+    },
   };
 });
 
@@ -87,7 +89,7 @@ describe("RouteManager", () => {
       competitors: new Map(),
     });
     mockUseActiveAirline.mockReturnValue({
-      airline: { hubs: ["JFK"], brandScore: 0.6 },
+      airline: { hubs: ["JFK"], brandScore: 0.6, cumulativeRevenue: 0 },
       routes: [],
       fleet: [],
       isViewingOther: false,

--- a/apps/web/src/features/network/components/RouteManager.test.tsx
+++ b/apps/web/src/features/network/components/RouteManager.test.tsx
@@ -1,3 +1,4 @@
+import type { FixedPoint } from "@acars/core";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { RouteManager } from "./RouteManager";
@@ -89,7 +90,11 @@ describe("RouteManager", () => {
       competitors: new Map(),
     });
     mockUseActiveAirline.mockReturnValue({
-      airline: { hubs: ["JFK"], brandScore: 0.6, cumulativeRevenue: 0 },
+      airline: {
+        hubs: ["JFK"],
+        brandScore: 0.6,
+        cumulativeRevenue: 0 as FixedPoint,
+      },
       routes: [],
       fleet: [],
       isViewingOther: false,

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -3,6 +3,7 @@ import {
   calculateDemand,
   calculatePriceElasticity,
   calculateShares,
+  canonicalRouteKey,
   computeRouteFrequency,
   type FixedPoint,
   type FlightOffer,
@@ -1087,7 +1088,10 @@ export function RouteManager() {
                           })()}
 
                           {(() => {
-                            const routeKey = `${route.originIata}-${route.destinationIata}`;
+                            const routeKey = canonicalRouteKey(
+                              route.originIata,
+                              route.destinationIata,
+                            );
                             const offers = globalRouteRegistry.get(routeKey) || [];
 
                             if (offers.length === 0) {

--- a/apps/web/src/features/network/utils/competitorHubs.test.ts
+++ b/apps/web/src/features/network/utils/competitorHubs.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { fp } from "@acars/core";
 import type { AirlineEntity } from "@acars/core";
+import { fp } from "@acars/core";
+import { describe, expect, it } from "vitest";
 import { buildCompetitorHubEntries } from "./competitorHubs";
 
 const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => ({
@@ -17,6 +17,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => (
   livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
   brandScore: 0.7,
   tier: 1,
+  cumulativeRevenue: fp(0),
   corporateBalance: fp(1000000),
   stockPrice: fp(0),
   fleetIds: [],
@@ -29,11 +30,21 @@ describe("buildCompetitorHubEntries", () => {
     const competitors = new Map([
       [
         "comp-1",
-        makeAirline({ ceoPubkey: "comp-1", name: "NorthWind", icaoCode: "NWD", hubs: ["JFK"] }),
+        makeAirline({
+          ceoPubkey: "comp-1",
+          name: "NorthWind",
+          icaoCode: "NWD",
+          hubs: ["JFK"],
+        }),
       ],
       [
         "comp-2",
-        makeAirline({ ceoPubkey: "comp-2", name: "Sunrise", icaoCode: "SUN", hubs: ["LAX"] }),
+        makeAirline({
+          ceoPubkey: "comp-2",
+          name: "Sunrise",
+          icaoCode: "SUN",
+          hubs: ["LAX"],
+        }),
       ],
     ]);
 
@@ -45,11 +56,21 @@ describe("buildCompetitorHubEntries", () => {
     const competitors = new Map([
       [
         "comp-1",
-        makeAirline({ ceoPubkey: "comp-1", name: "Avianca", icaoCode: "AVA", hubs: ["JFK"] }),
+        makeAirline({
+          ceoPubkey: "comp-1",
+          name: "Avianca",
+          icaoCode: "AVA",
+          hubs: ["JFK"],
+        }),
       ],
       [
         "comp-2",
-        makeAirline({ ceoPubkey: "comp-2", name: "Avianca", icaoCode: "AVC", hubs: ["JFK"] }),
+        makeAirline({
+          ceoPubkey: "comp-2",
+          name: "Avianca",
+          icaoCode: "AVC",
+          hubs: ["JFK"],
+        }),
       ],
     ]);
 

--- a/apps/web/src/features/network/utils/flightBoard.test.ts
+++ b/apps/web/src/features/network/utils/flightBoard.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import type { AircraftInstance, AirlineEntity } from "@acars/core";
 import { fp } from "@acars/core";
-import type { AirlineEntity, AircraftInstance } from "@acars/core";
+import { describe, expect, it } from "vitest";
 import { buildFlightBoardRows } from "./flightBoard";
 
 const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => ({
@@ -17,6 +17,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => (
   livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
   brandScore: 0.7,
   tier: 1,
+  cumulativeRevenue: fp(0),
   corporateBalance: fp(1000000),
   stockPrice: fp(0),
   fleetIds: [],

--- a/apps/web/src/features/network/utils/groundTraffic.test.ts
+++ b/apps/web/src/features/network/utils/groundTraffic.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import type { AircraftInstance, AirlineEntity } from "@acars/core";
 import { fp } from "@acars/core";
-import type { AirlineEntity, AircraftInstance } from "@acars/core";
+import { describe, expect, it } from "vitest";
 import { buildGroundPresenceByAirport, buildGroundTraffic, isGrounded } from "./groundTraffic";
 
 const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => ({
@@ -17,6 +17,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => (
   livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
   brandScore: 0.7,
   tier: 1,
+  cumulativeRevenue: fp(0),
   corporateBalance: fp(1000000),
   stockPrice: fp(0),
   fleetIds: [],
@@ -53,20 +54,41 @@ describe("buildGroundTraffic", () => {
     expect(isGrounded(makeAircraft({ status: "delivery" }))).toBe(false);
   });
   it("counts grounded aircraft for player and competitors", () => {
-    const airline = makeAirline({ ceoPubkey: "player", name: "Skyline Air", icaoCode: "SKY" });
+    const airline = makeAirline({
+      ceoPubkey: "player",
+      name: "Skyline Air",
+      icaoCode: "SKY",
+    });
     const competitors = new Map([
-      ["comp-1", makeAirline({ ceoPubkey: "comp-1", name: "NorthWind", icaoCode: "NWD" })],
+      [
+        "comp-1",
+        makeAirline({
+          ceoPubkey: "comp-1",
+          name: "NorthWind",
+          icaoCode: "NWD",
+        }),
+      ],
     ]);
 
     const fleet = [
-      makeAircraft({ id: "p1", ownerPubkey: "player", baseAirportIata: "JFK", status: "idle" }),
+      makeAircraft({
+        id: "p1",
+        ownerPubkey: "player",
+        baseAirportIata: "JFK",
+        status: "idle",
+      }),
       makeAircraft({
         id: "p2",
         ownerPubkey: "player",
         baseAirportIata: "JFK",
         status: "turnaround",
       }),
-      makeAircraft({ id: "p3", ownerPubkey: "player", baseAirportIata: "LAX", status: "idle" }),
+      makeAircraft({
+        id: "p3",
+        ownerPubkey: "player",
+        baseAirportIata: "LAX",
+        status: "idle",
+      }),
     ];
 
     const globalFleet = [
@@ -76,7 +98,12 @@ describe("buildGroundTraffic", () => {
         baseAirportIata: "JFK",
         status: "maintenance",
       }),
-      makeAircraft({ id: "c2", ownerPubkey: "comp-1", baseAirportIata: "JFK", status: "enroute" }),
+      makeAircraft({
+        id: "c2",
+        ownerPubkey: "comp-1",
+        baseAirportIata: "JFK",
+        status: "enroute",
+      }),
     ];
 
     const result = buildGroundTraffic("JFK", fleet, globalFleet, airline, competitors);
@@ -91,19 +118,38 @@ describe("buildGroundTraffic", () => {
   });
 
   it("sorts competitors by count and name after player", () => {
-    const airline = makeAirline({ ceoPubkey: "player", name: "Skyline Air", icaoCode: "SKY" });
+    const airline = makeAirline({
+      ceoPubkey: "player",
+      name: "Skyline Air",
+      icaoCode: "SKY",
+    });
     const competitors = new Map([
       ["alpha", makeAirline({ ceoPubkey: "alpha", name: "Alpha Air", icaoCode: "ALP" })],
       ["beta", makeAirline({ ceoPubkey: "beta", name: "Beta Air", icaoCode: "BET" })],
     ]);
 
     const fleet = [
-      makeAircraft({ id: "p1", ownerPubkey: "player", baseAirportIata: "JFK", status: "idle" }),
+      makeAircraft({
+        id: "p1",
+        ownerPubkey: "player",
+        baseAirportIata: "JFK",
+        status: "idle",
+      }),
     ];
 
     const globalFleet = [
-      makeAircraft({ id: "a1", ownerPubkey: "alpha", baseAirportIata: "JFK", status: "idle" }),
-      makeAircraft({ id: "b1", ownerPubkey: "beta", baseAirportIata: "JFK", status: "idle" }),
+      makeAircraft({
+        id: "a1",
+        ownerPubkey: "alpha",
+        baseAirportIata: "JFK",
+        status: "idle",
+      }),
+      makeAircraft({
+        id: "b1",
+        ownerPubkey: "beta",
+        baseAirportIata: "JFK",
+        status: "idle",
+      }),
       makeAircraft({
         id: "b2",
         ownerPubkey: "beta",
@@ -135,13 +181,22 @@ describe("buildGroundPresenceByAirport", () => {
         makeAirline({
           ceoPubkey: "comp-1",
           name: "NorthWind",
-          livery: { primary: "#ff0000", secondary: "#222222", accent: "#333333" },
+          livery: {
+            primary: "#ff0000",
+            secondary: "#222222",
+            accent: "#333333",
+          },
         }),
       ],
     ]);
 
     const fleet = [
-      makeAircraft({ id: "p1", ownerPubkey: "player", baseAirportIata: "JFK", status: "idle" }),
+      makeAircraft({
+        id: "p1",
+        ownerPubkey: "player",
+        baseAirportIata: "JFK",
+        status: "idle",
+      }),
       makeAircraft({
         id: "p2",
         ownerPubkey: "player",

--- a/apps/web/src/routes/-corporate.lazy.test.tsx
+++ b/apps/web/src/routes/-corporate.lazy.test.tsx
@@ -1,8 +1,8 @@
+import { fp } from "@acars/core";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fp } from "@acars/core";
 
 vi.mock("@/shared/components/layout/PanelLayout", () => {
   return {
@@ -61,6 +61,7 @@ const mockAirline = {
   status: "private",
   tier: 1,
   brandScore: 0.5,
+  cumulativeRevenue: 0,
 };
 
 const mockTimeline = [
@@ -183,13 +184,55 @@ describe("Corporate route", () => {
 
   it("renders sorted route performance without truncating to six routes", () => {
     routePerformanceMock.push(
-      { routeId: "r1", label: "A", fleetCount: 1, avgLoadFactor: 0.51, profitPerHour: fp(10) },
-      { routeId: "r2", label: "B", fleetCount: 1, avgLoadFactor: 0.52, profitPerHour: fp(20) },
-      { routeId: "r3", label: "C", fleetCount: 1, avgLoadFactor: 0.53, profitPerHour: fp(30) },
-      { routeId: "r4", label: "D", fleetCount: 1, avgLoadFactor: 0.54, profitPerHour: fp(40) },
-      { routeId: "r5", label: "E", fleetCount: 1, avgLoadFactor: 0.55, profitPerHour: fp(50) },
-      { routeId: "r6", label: "F", fleetCount: 1, avgLoadFactor: 0.56, profitPerHour: fp(60) },
-      { routeId: "r7", label: "G", fleetCount: 1, avgLoadFactor: 0.57, profitPerHour: fp(70) },
+      {
+        routeId: "r1",
+        label: "A",
+        fleetCount: 1,
+        avgLoadFactor: 0.51,
+        profitPerHour: fp(10),
+      },
+      {
+        routeId: "r2",
+        label: "B",
+        fleetCount: 1,
+        avgLoadFactor: 0.52,
+        profitPerHour: fp(20),
+      },
+      {
+        routeId: "r3",
+        label: "C",
+        fleetCount: 1,
+        avgLoadFactor: 0.53,
+        profitPerHour: fp(30),
+      },
+      {
+        routeId: "r4",
+        label: "D",
+        fleetCount: 1,
+        avgLoadFactor: 0.54,
+        profitPerHour: fp(40),
+      },
+      {
+        routeId: "r5",
+        label: "E",
+        fleetCount: 1,
+        avgLoadFactor: 0.55,
+        profitPerHour: fp(50),
+      },
+      {
+        routeId: "r6",
+        label: "F",
+        fleetCount: 1,
+        avgLoadFactor: 0.56,
+        profitPerHour: fp(60),
+      },
+      {
+        routeId: "r7",
+        label: "G",
+        fleetCount: 1,
+        avgLoadFactor: 0.57,
+        profitPerHour: fp(70),
+      },
     );
 
     render(<CorporateRoute />);

--- a/apps/web/src/routes/-corporate.lazy.test.tsx
+++ b/apps/web/src/routes/-corporate.lazy.test.tsx
@@ -61,7 +61,7 @@ const mockAirline = {
   status: "private",
   tier: 1,
   brandScore: 0.5,
-  cumulativeRevenue: 0,
+  cumulativeRevenue: fp(0),
 };
 
 const mockTimeline = [

--- a/apps/web/src/routes/-corporate.lazy.tsx
+++ b/apps/web/src/routes/-corporate.lazy.tsx
@@ -14,6 +14,7 @@ import {
 } from "@acars/core";
 import { getAircraftById, getHubPricingForIata } from "@acars/data";
 import { useActiveAirline, useAirlineStore, useEngineStore } from "@acars/store";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   AlertTriangle,
   Building2,
@@ -25,7 +26,6 @@ import {
   TrendingUp,
   X,
 } from "lucide-react";
-import { useVirtualizer } from "@tanstack/react-virtual";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { AirlineTimeline } from "@/features/airline/components/Timeline";
@@ -173,8 +173,8 @@ function FinancialPulse({
           <div className="flex items-center justify-between text-[10px] text-muted-foreground">
             <span className="font-bold uppercase tracking-wider">Billing Cycle</span>
             <span style={{ fontVariantNumeric: "tabular-nums" }}>
-              {billingCycle.daysRemaining} day{billingCycle.daysRemaining !== 1 ? "s" : ""}{" "}
-              remaining
+              {billingCycle.daysRemaining} day
+              {billingCycle.daysRemaining !== 1 ? "s" : ""} remaining
             </span>
           </div>
           <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted/30">
@@ -320,6 +320,7 @@ function CompanyProfile({
   callsign,
   tier,
   brandScore,
+  cumulativeRevenue,
   status,
   ceoPubkey,
 }: {
@@ -328,6 +329,7 @@ function CompanyProfile({
   callsign: string;
   tier: number;
   brandScore: number;
+  cumulativeRevenue: FixedPoint;
   status: string;
   ceoPubkey?: string | null;
 }) {
@@ -438,6 +440,9 @@ function CompanyProfile({
 
       {/* Tier label */}
       <p className="mt-2 text-[10px] text-muted-foreground">{tierLabels[tier] ?? `Tier ${tier}`}</p>
+      <p className="mt-1 text-[10px] text-muted-foreground">
+        Cumulative revenue: {fpFormat(cumulativeRevenue, 0)}
+      </p>
     </section>
   );
 }
@@ -1048,7 +1053,9 @@ export default function CorporateDashboard() {
             <div ref={routePerformanceContainerRef} className="max-h-64 overflow-y-auto">
               <div
                 className="relative w-full"
-                style={{ height: `${routePerformanceVirtualizer.getTotalSize()}px` }}
+                style={{
+                  height: `${routePerformanceVirtualizer.getTotalSize()}px`,
+                }}
               >
                 {routePerformanceVirtualizer.getVirtualItems().map((virtualItem) => {
                   const route = sortedRoutePerformance[virtualItem.index];
@@ -1093,6 +1100,7 @@ export default function CorporateDashboard() {
           callsign={airline.callsign}
           tier={airline.tier}
           brandScore={airline.brandScore}
+          cumulativeRevenue={airline.cumulativeRevenue}
           status={airline.status}
           ceoPubkey={airline.ceoPubkey}
         />

--- a/apps/web/src/shared/components/feedback/TimelineToastBridge.tsx
+++ b/apps/web/src/shared/components/feedback/TimelineToastBridge.tsx
@@ -18,6 +18,7 @@ const EVENT_TITLES: Record<TimelineEventType, string> = {
   ferry: "Ferry Flight",
   competitor_hub: "Competitor Alert",
   price_war: "Price War Detected",
+  tier_upgrade: "Tier Upgraded",
   bankruptcy: "⚠️ BANKRUPTCY FILED",
   financial_warning: "Financial Warning",
 };
@@ -35,6 +36,7 @@ const EVENT_TOAST_KIND: Record<TimelineEventType, "success" | "info" | "warning"
   ferry: "info",
   competitor_hub: "warning",
   price_war: "warning",
+  tier_upgrade: "success",
   bankruptcy: "warning",
   financial_warning: "warning",
 };

--- a/apps/web/src/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.test.tsx
@@ -60,6 +60,7 @@ describe("Topbar", () => {
       livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
       brandScore: 0.7,
       tier: 2,
+      cumulativeRevenue: fp(0),
       corporateBalance: fp(1000000),
       stockPrice: fp(12),
       fleetIds: [],

--- a/apps/web/src/shared/hooks/useNavBadges.test.ts
+++ b/apps/web/src/shared/hooks/useNavBadges.test.ts
@@ -1,7 +1,7 @@
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
 import type { AircraftInstance, AirlineEntity, Route } from "@acars/core";
 import { fp } from "@acars/core";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { useNavBadges } from "./useNavBadges";
 
 // Minimal factory helpers
@@ -59,6 +59,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity =>
     corporateBalance: fp(1000000),
     brandScore: 5,
     tier: 1,
+    cumulativeRevenue: fp(0),
     stockPrice: fp(10),
     livery: { primary: "#000", secondary: "#fff", accent: "#0f0" },
     status: "public",
@@ -79,7 +80,12 @@ vi.mock("@acars/store", () => ({
 
 describe("useNavBadges", () => {
   it("returns all zeros when no airline is loaded", () => {
-    mockState = { airline: null, fleet: [], routes: [], competitors: new Map() };
+    mockState = {
+      airline: null,
+      fleet: [],
+      routes: [],
+      competitors: new Map(),
+    };
     const { result } = renderHook(() => useNavBadges());
     expect(result.current).toEqual({
       fleetTotal: 0,
@@ -97,7 +103,11 @@ describe("useNavBadges", () => {
       fleet: [
         makeAircraft({ id: "ac-1", status: "idle", assignedRouteId: null }),
         makeAircraft({ id: "ac-2", status: "idle", assignedRouteId: "rt-1" }),
-        makeAircraft({ id: "ac-3", status: "enroute", assignedRouteId: "rt-1" }),
+        makeAircraft({
+          id: "ac-3",
+          status: "enroute",
+          assignedRouteId: "rt-1",
+        }),
       ],
       routes: [],
       competitors: new Map(),
@@ -114,7 +124,11 @@ describe("useNavBadges", () => {
       fleet: [],
       routes: [
         makeRoute({ id: "rt-1", status: "active", assignedAircraftIds: [] }),
-        makeRoute({ id: "rt-2", status: "active", assignedAircraftIds: ["ac-1"] }),
+        makeRoute({
+          id: "rt-2",
+          status: "active",
+          assignedAircraftIds: ["ac-1"],
+        }),
         makeRoute({ id: "rt-3", status: "suspended", assignedAircraftIds: [] }),
       ],
       competitors: new Map(),
@@ -126,8 +140,16 @@ describe("useNavBadges", () => {
 
   it("computes leaderboard rank correctly", () => {
     const airline = makeAirline({ id: "al-own", corporateBalance: fp(500000) });
-    const comp1 = makeAirline({ id: "al-comp1", ceoPubkey: "pk2", corporateBalance: fp(2000000) });
-    const comp2 = makeAirline({ id: "al-comp2", ceoPubkey: "pk3", corporateBalance: fp(100000) });
+    const comp1 = makeAirline({
+      id: "al-comp1",
+      ceoPubkey: "pk2",
+      corporateBalance: fp(2000000),
+    });
+    const comp2 = makeAirline({
+      id: "al-comp2",
+      ceoPubkey: "pk3",
+      corporateBalance: fp(100000),
+    });
     mockState = {
       airline,
       fleet: [],
@@ -143,8 +165,15 @@ describe("useNavBadges", () => {
   });
 
   it("returns rank 1 when airline is top by balance", () => {
-    const airline = makeAirline({ id: "al-own", corporateBalance: fp(9999999) });
-    const comp = makeAirline({ id: "al-comp", ceoPubkey: "pk2", corporateBalance: fp(100) });
+    const airline = makeAirline({
+      id: "al-own",
+      corporateBalance: fp(9999999),
+    });
+    const comp = makeAirline({
+      id: "al-comp",
+      ceoPubkey: "pk2",
+      corporateBalance: fp(100),
+    });
     mockState = {
       airline,
       fleet: [],

--- a/packages/core/CONTRACT.md
+++ b/packages/core/CONTRACT.md
@@ -73,6 +73,7 @@ interface AirlineEntity {
   livery: { primary: string; secondary: string; accent: string };
   brandScore: number;
   tier: number;
+  cumulativeRevenue: FixedPoint;
   corporateBalance: FixedPoint;
   stockPrice: FixedPoint;
   fleetIds: string[];
@@ -94,7 +95,7 @@ interface AirlineTickResult { /* see types.ts */ }
 interface RouteTickResult { /* see types.ts */ }
 
 // Timeline
-type TimelineEventType = "takeoff" | "landing" | "purchase" | /* ... */;
+type TimelineEventType = "takeoff" | "landing" | "purchase" | "tier_upgrade" | /* ... */;
 interface TimelineEvent { /* see types.ts */ }
 
 // Checkpoints

--- a/packages/core/src/checkpoint.test.ts
+++ b/packages/core/src/checkpoint.test.ts
@@ -29,6 +29,7 @@ describe("checkpoint hashing", () => {
       livery: { primary: "#000000", secondary: "#111111", accent: "#222222" },
       brandScore: 0.5,
       tier: 1,
+      cumulativeRevenue: 0 as FixedPoint,
       corporateBalance: 100000000,
       stockPrice: 100000,
       fleetIds: [],

--- a/packages/core/src/checkpoint.test.ts
+++ b/packages/core/src/checkpoint.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { computeActionChainHash, computeCheckpointStateHash } from "./checkpoint.js";
+import { fp } from "./fixed-point.js";
 
 describe("checkpoint hashing", () => {
   it("computes stable action chain hashes", async () => {
@@ -29,7 +30,7 @@ describe("checkpoint hashing", () => {
       livery: { primary: "#000000", secondary: "#111111", accent: "#222222" },
       brandScore: 0.5,
       tier: 1,
-      cumulativeRevenue: 0 as FixedPoint,
+      cumulativeRevenue: fp(0),
       corporateBalance: 100000000,
       stockPrice: 100000,
       fleetIds: [],

--- a/packages/core/src/cycle.ts
+++ b/packages/core/src/cycle.ts
@@ -92,6 +92,9 @@ export function getCyclePhase(
  *   but a landing exactly at `toTick` IS counted.
  * - Returns 0 when `toTick <= fromTick`, `durationTicks <= 0`, or `turnaroundTicks < 0`.
  */
+/**
+ * Counts landings between ticks using cycle algebra.
+ */
 export function countLandingsBetween(
   cycleStartTick: number,
   fromTick: number,
@@ -143,6 +146,9 @@ const DEFAULT_MAX_EVENTS = 200;
  *
  * Events are returned sorted by tick ascending.  A safety cap (`maxEvents`,
  * default 200) prevents runaway allocation for extremely long offline gaps.
+ */
+/**
+ * Enumerates takeoff/landing events within (fromTick, toTick].
  */
 export function enumerateFlightEvents(
   cycleStartTick: number,

--- a/packages/core/src/cycle.ts
+++ b/packages/core/src/cycle.ts
@@ -226,13 +226,11 @@ export function enumerateFlightEvents(
         originIata: t.originIata,
         destinationIata: t.destinationIata,
       });
-      if (events.length >= maxEvents) break;
     }
-    if (events.length >= maxEvents) break;
   }
 
   // Sort by tick ascending (transitions are interleaved across types)
   events.sort((a, b) => a.tick - b.tick);
 
-  return events;
+  return events.slice(0, maxEvents);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,6 +86,14 @@ export {
   getSolarDeclination,
   getSubsolarPoint,
 } from "./solar.js";
+// Tier
+export {
+  estimateHistoricRevenue,
+  evaluateTier,
+  getMaxHubs,
+  getMaxRouteDistanceKm,
+  TIER_THRESHOLDS,
+} from "./tier.js";
 export type {
   AircraftInstance,
   AircraftModel,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,8 @@ export { createLogger } from "./logger.js";
 export { createPRNG, createTickPRNG } from "./prng.js";
 // QSI
 export { allocatePassengers, calculateShares } from "./qsi.js";
+// Routes
+export { canonicalRouteKey } from "./route.js";
 // Season
 export { getSeason, getSeasonalMultiplier } from "./season.js";
 export type {

--- a/packages/core/src/route.ts
+++ b/packages/core/src/route.ts
@@ -1,0 +1,8 @@
+// @acars/core — Route utilities
+// ============================================================
+
+export function canonicalRouteKey(originIata: string, destinationIata: string): string {
+  return originIata < destinationIata
+    ? `${originIata}-${destinationIata}`
+    : `${destinationIata}-${originIata}`;
+}

--- a/packages/core/src/tier.test.ts
+++ b/packages/core/src/tier.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { fp } from "./fixed-point";
+import { evaluateTier, getMaxHubs, getMaxRouteDistanceKm, TIER_THRESHOLDS } from "./tier";
+
+describe("tier progression", () => {
+  it("keeps tier when requirements are unmet", () => {
+    const tier = evaluateTier(1, fp(1_000_000), 1);
+    expect(tier).toBe(1);
+  });
+
+  it("promotes to tier 2 when thresholds met", () => {
+    const { minCumulativeRevenue, minActiveRoutes } = TIER_THRESHOLDS[2];
+    const tier = evaluateTier(1, minCumulativeRevenue, minActiveRoutes);
+    expect(tier).toBe(2);
+  });
+
+  it("promotes to tier 3 when thresholds met", () => {
+    const { minCumulativeRevenue, minActiveRoutes } = TIER_THRESHOLDS[3];
+    const tier = evaluateTier(2, minCumulativeRevenue, minActiveRoutes);
+    expect(tier).toBe(3);
+  });
+
+  it("promotes multiple tiers when thresholds are met", () => {
+    const tier = evaluateTier(1, fp(60_000_000), 12);
+    expect(tier).toBe(3);
+  });
+
+  it("keeps tier when already above thresholds", () => {
+    const tier = evaluateTier(3, fp(500_000_000), 40);
+    expect(tier).toBe(4);
+  });
+
+  it("does not regress tiers when thresholds fall below", () => {
+    const tier = evaluateTier(4, fp(1_000_000), 0);
+    expect(tier).toBe(4);
+  });
+});
+
+describe("tier limits", () => {
+  it("returns distance limits by tier", () => {
+    expect(getMaxRouteDistanceKm(1)).toBe(3000);
+    expect(getMaxRouteDistanceKm(2)).toBe(7000);
+    expect(getMaxRouteDistanceKm(3)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("returns hub limits by tier", () => {
+    expect(getMaxHubs(1)).toBe(1);
+    expect(getMaxHubs(2)).toBe(3);
+    expect(getMaxHubs(3)).toBe(5);
+    expect(getMaxHubs(4)).toBe(Number.MAX_SAFE_INTEGER);
+  });
+});

--- a/packages/core/src/tier.test.ts
+++ b/packages/core/src/tier.test.ts
@@ -26,7 +26,7 @@ describe("tier progression", () => {
   });
 
   it("keeps tier when already above thresholds", () => {
-    const tier = evaluateTier(3, fp(500_000_000), 40);
+    const tier = evaluateTier(4, fp(500_000_000), 40);
     expect(tier).toBe(4);
   });
 

--- a/packages/core/src/tier.ts
+++ b/packages/core/src/tier.ts
@@ -1,0 +1,65 @@
+import { fp, fpSum } from "./fixed-point";
+import type { AircraftInstance, FixedPoint, Route } from "./types";
+
+export interface TierThreshold {
+  minCumulativeRevenue: FixedPoint;
+  minActiveRoutes: number;
+}
+
+export const TIER_THRESHOLDS: Record<number, TierThreshold> = {
+  2: {
+    minCumulativeRevenue: fp(5_000_000),
+    minActiveRoutes: 3,
+  },
+  3: {
+    minCumulativeRevenue: fp(50_000_000),
+    minActiveRoutes: 10,
+  },
+  4: {
+    minCumulativeRevenue: fp(250_000_000),
+    minActiveRoutes: 25,
+  },
+};
+
+const MAX_TIER = 4;
+
+export function evaluateTier(
+  currentTier: number,
+  cumulativeRevenue: FixedPoint,
+  activeRouteCount: number,
+): number {
+  let nextTier = currentTier;
+  for (let tier = currentTier + 1; tier <= MAX_TIER; tier += 1) {
+    const threshold = TIER_THRESHOLDS[tier];
+    if (!threshold) continue;
+    if (cumulativeRevenue < threshold.minCumulativeRevenue) break;
+    if (activeRouteCount < threshold.minActiveRoutes) break;
+    nextTier = tier;
+  }
+  return nextTier;
+}
+
+export function getMaxRouteDistanceKm(tier: number): number {
+  if (tier <= 1) return 3000;
+  if (tier === 2) return 7000;
+  return Number.POSITIVE_INFINITY;
+}
+
+export function getMaxHubs(tier: number): number {
+  if (tier <= 1) return 1;
+  if (tier === 2) return 3;
+  if (tier === 3) return 5;
+  return Number.MAX_SAFE_INTEGER;
+}
+
+export function estimateHistoricRevenue(fleet: AircraftInstance[], routes: Route[]): FixedPoint {
+  if (fleet.length === 0) return fp(0);
+  const fleetValue = fpSum(
+    fleet.map((aircraft) => {
+      return fp(aircraft.purchasePrice ?? 0);
+    }),
+  );
+  const activeRoutes = routes.filter((route) => route.status === "active").length;
+  const routeBonus = fp(Math.min(activeRoutes, 25) * 2_000_000);
+  return fpSum([fleetValue, routeBonus]);
+}

--- a/packages/core/src/tier.ts
+++ b/packages/core/src/tier.ts
@@ -23,6 +23,9 @@ export const TIER_THRESHOLDS: Record<number, TierThreshold> = {
 
 const MAX_TIER = 4;
 
+/**
+ * Computes the next tier based on cumulative revenue and active routes.
+ */
 export function evaluateTier(
   currentTier: number,
   cumulativeRevenue: FixedPoint,
@@ -39,12 +42,18 @@ export function evaluateTier(
   return nextTier;
 }
 
+/**
+ * Returns the maximum allowed route distance by tier.
+ */
 export function getMaxRouteDistanceKm(tier: number): number {
   if (tier <= 1) return 3000;
   if (tier === 2) return 7000;
   return Number.POSITIVE_INFINITY;
 }
 
+/**
+ * Returns the maximum allowed hub count by tier.
+ */
 export function getMaxHubs(tier: number): number {
   if (tier <= 1) return 1;
   if (tier === 2) return 3;
@@ -52,6 +61,9 @@ export function getMaxHubs(tier: number): number {
   return Number.MAX_SAFE_INTEGER;
 }
 
+/**
+ * Estimates legacy revenue to seed tier progression for existing airlines.
+ */
 export function estimateHistoricRevenue(fleet: AircraftInstance[], routes: Route[]): FixedPoint {
   if (fleet.length === 0) return fp(0);
   const fleetValue = fpSum(

--- a/packages/core/src/tier.ts
+++ b/packages/core/src/tier.ts
@@ -56,7 +56,7 @@ export function estimateHistoricRevenue(fleet: AircraftInstance[], routes: Route
   if (fleet.length === 0) return fp(0);
   const fleetValue = fpSum(
     fleet.map((aircraft) => {
-      return fp(aircraft.purchasePrice ?? 0);
+      return aircraft.purchasePrice ?? fp(0);
     }),
   );
   const activeRoutes = routes.filter((route) => route.status === "active").length;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -214,6 +214,7 @@ export interface AirlineEntity {
   };
   brandScore: number;
   tier: number;
+  cumulativeRevenue: FixedPoint;
 
   // Financials
   corporateBalance: FixedPoint;
@@ -330,6 +331,7 @@ export type TimelineEventType =
   | "ferry"
   | "competitor_hub"
   | "price_war"
+  | "tier_upgrade"
   | "bankruptcy"
   | "financial_warning";
 

--- a/packages/store/src/FlightEngine.test.ts
+++ b/packages/store/src/FlightEngine.test.ts
@@ -111,6 +111,7 @@ const runTick = (
     options.globalRouteRegistry ?? new Map(),
     options.playerPubkey ?? PLAYER_PUBKEY,
     options.brandScore ?? 0.5,
+    Number.POSITIVE_INFINITY,
   );
 
   return {

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -53,6 +53,9 @@ export interface EngineTickResult {
  * Separated from Zustand/Nostr to allow for headless simulation,
  * future worker-offloading, and easier testing.
  */
+/**
+ * Advances the deterministic flight engine for a single tick.
+ */
 export function processFlightEngine(
   tick: number,
   fleet: AircraftInstance[],
@@ -728,6 +731,9 @@ export interface LandingFinancialResult {
   details: NonNullable<TimelineEvent["details"]>;
 }
 
+/**
+ * Estimates revenue and costs for a landing without full demand simulation.
+ */
 export function estimateLandingFinancials(
   ac: AircraftInstance,
   route: Route,
@@ -883,6 +889,9 @@ export function estimateLandingFinancials(
  * Returns synthetic timeline events (takeoff/landing) for the reconciled
  * period so the activity log is populated even when the tick-by-tick engine
  * loop is skipped (e.g. after an overnight absence).
+ */
+/**
+ * Reconciles aircraft positions and generates synthetic events for offline gaps.
  */
 export function reconcileFleetToTick(
   fleet: AircraftInstance[],

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -45,6 +45,7 @@ export interface EngineTickResult {
   corporateBalance: FixedPoint;
   hasChanges: boolean;
   events: TimelineEvent[];
+  tickRevenue: FixedPoint;
 }
 
 /**
@@ -61,9 +62,11 @@ export function processFlightEngine(
   globalRouteRegistry: Map<string, FlightOffer[]> = new Map(),
   playerPubkey: string = "",
   playerBrandScore: number = 0.5,
+  distanceLimitKm: number = Number.POSITIVE_INFINITY,
 ): EngineTickResult {
   let hasChanges = false;
   let corporateBalance = initialBalance;
+  let tickRevenue = fp(0);
   const events: TimelineEvent[] = [];
   const simulatedTimestamp = GENESIS_TIME + tick * TICK_DURATION;
 
@@ -356,7 +359,16 @@ export function processFlightEngine(
             }
           }
 
-          const addressableDemand = scaleToAddressableMarket(weeklyDemandResult);
+          let addressableDemand = scaleToAddressableMarket(weeklyDemandResult);
+          if (route && route.distanceKm > distanceLimitKm) {
+            addressableDemand = {
+              origin: addressableDemand.origin,
+              destination: addressableDemand.destination,
+              economy: Math.floor(addressableDemand.economy * 0.5),
+              business: Math.floor(addressableDemand.business * 0.5),
+              first: Math.floor(addressableDemand.first * 0.5),
+            };
+          }
           const allocations = allocatePassengers(allOffers, addressableDemand);
           const ourWeeklyAllocation = allocations.get(playerPubkey) ?? {
             economy: 0,
@@ -429,6 +441,7 @@ export function processFlightEngine(
             fareFirst,
             seatsOffered: seatConfig.economy + seatConfig.business + seatConfig.first,
           });
+          tickRevenue = fpAdd(tickRevenue, rev.revenueTotal);
 
           ac.lastKnownLoadFactor = rev.loadFactor;
         }
@@ -608,6 +621,7 @@ export function processFlightEngine(
     corporateBalance,
     hasChanges,
     events,
+    tickRevenue,
   };
 }
 

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -7,6 +7,7 @@ import {
   calculateHubLandingFee,
   calculatePriceElasticity,
   calculateSupplyPressure,
+  canonicalRouteKey,
   computeRouteFrequency,
   countLandingsBetween,
   detectPriceWar,
@@ -233,8 +234,17 @@ export function processFlightEngine(
         ac.flight?.fareFirst !== undefined
       );
       if (route || isFerry || isOrphan) {
-        const originIata = route ? route.originIata : ac.flight?.originIata;
-        const destinationIata = route ? route.destinationIata : ac.flight?.destinationIata;
+        const isInboundLeg = ac.flight?.direction === "inbound";
+        const originIata = route
+          ? isInboundLeg
+            ? route.destinationIata
+            : route.originIata
+          : ac.flight?.originIata;
+        const destinationIata = route
+          ? isInboundLeg
+            ? route.originIata
+            : route.destinationIata
+          : ac.flight?.destinationIata;
         const origin = originIata ? (airportMap.get(originIata) ?? null) : null;
         const destination = destinationIata ? (airportMap.get(destinationIata) ?? null) : null;
 
@@ -303,7 +313,8 @@ export function processFlightEngine(
 
         if (route || (isOrphan && hasFareSnapshot)) {
           // --- NEW MP ALLOCATION LOGIC ---
-          const routeKey = originIata && destinationIata ? `${originIata}-${destinationIata}` : "";
+          const routeKey =
+            originIata && destinationIata ? canonicalRouteKey(originIata, destinationIata) : "";
           const competitorOffers = route && routeKey ? globalRouteRegistry.get(routeKey) || [] : [];
 
           // Frequency for our offer: how many planes we (the player) have on this route?

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -1236,6 +1236,7 @@ export function reconcileFleetToTick(
   const events: TimelineEvent[] = [];
   for (const params of eventGenQueue) {
     if (params.cappedLandings <= 0) continue;
+    let remainingLandings = params.cappedLandings;
 
     // For phase-offset routes (aircraft starting at destination), we need to
     // adjust the effective cycle start so that enumerateFlightEvents (which
@@ -1253,10 +1254,12 @@ export function reconcileFleetToTick(
     );
 
     for (const evt of rawEvents) {
+      if (remainingLandings <= 0) break;
       const simulatedTimestamp = GENESIS_TIME + evt.tick * TICK_DURATION;
       const idSuffix = evt.direction === "outbound" ? "" : "-rtn";
 
       if (evt.type === "takeoff") {
+        if (remainingLandings <= 0) break;
         events.push({
           id: `evt-takeoff${idSuffix}-${params.ac.id}-${evt.tick}`,
           tick: evt.tick,
@@ -1273,6 +1276,7 @@ export function reconcileFleetToTick(
               : `${params.ac.name} returning: ${evt.originIata} → ${evt.destinationIata}`,
         });
       } else {
+        remainingLandings -= 1;
         // Landing — include estimated financial details
         const model = getAircraftById(params.ac.modelId);
         const hoursPerLeg = Math.min(24, params.durationTicks / TICKS_PER_HOUR);

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -156,6 +156,9 @@ export async function buildActionChainHashFromRecords(
   return hash;
 }
 
+/**
+ * Replays the action log to rebuild airline state.
+ */
 export async function replayActionLog(params: {
   pubkey: string;
   actions: ActionRecord[];

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -71,6 +71,7 @@ const TIMELINE_EVENT_TYPES: ReadonlySet<TimelineEventType> = new Set([
   "ferry",
   "competitor_hub",
   "price_war",
+  "tier_upgrade",
   "bankruptcy",
   "financial_warning",
 ]);
@@ -384,6 +385,9 @@ export async function replayActionLog(params: {
               ? (payload.status as AirlineEntity["status"])
               : "private";
           const tier = clampInt(payload.tier, 1, 10) ?? 1;
+          const brandScore = clampNumber(payload.brandScore, 0, 1) ?? 0.5;
+          const cumulativeRevenue =
+            clampFixedPoint(payload.cumulativeRevenue, fp(0), MAX_BALANCE) ?? fp(0);
           const payloadFleetIds = asStringArray(payload.fleetIds);
           const payloadRouteIds = asStringArray(payload.routeIds);
           if (payloadFleetIds.length > 0) authoritativeFleetIds = payloadFleetIds;
@@ -403,8 +407,9 @@ export async function replayActionLog(params: {
             callsign,
             hubs,
             livery,
-            brandScore: 0.5,
+            brandScore,
             tier,
+            cumulativeRevenue,
             corporateBalance,
             stockPrice: fp(10),
             fleetIds: payloadFleetIds,
@@ -485,6 +490,7 @@ export async function replayActionLog(params: {
         livery,
         brandScore: 0.5,
         tier: 1,
+        cumulativeRevenue: fp(0),
         corporateBalance,
         stockPrice: fp(10),
         fleetIds: [],
@@ -531,6 +537,11 @@ export async function replayActionLog(params: {
           airline = { ...airline, status: status as AirlineEntity["status"] };
         }
 
+        const tier = clampInt(payload.tier, 1, 10);
+        if (tier != null) {
+          airline = { ...airline, tier };
+        }
+
         // Track authoritative fleet/route IDs from the TICK_UPDATE payload.
         // The publishing client includes these from its local state, so they
         // reflect the true set of aircraft and routes regardless of whether
@@ -575,6 +586,21 @@ export async function replayActionLog(params: {
 
         const previousTick = airline.lastTick ?? 0;
         if (actionTick > previousTick) {
+          const authoritativeBrandScore = clampNumber(payload.brandScore, 0, 1);
+          if (authoritativeBrandScore != null) {
+            airline = { ...airline, brandScore: authoritativeBrandScore };
+          }
+          const authoritativeCumulativeRevenue = clampFixedPoint(
+            payload.cumulativeRevenue,
+            fp(0),
+            MAX_BALANCE,
+          );
+          if (authoritativeCumulativeRevenue != null) {
+            airline = {
+              ...airline,
+              cumulativeRevenue: authoritativeCumulativeRevenue,
+            };
+          }
           const { fleet: reconciledFleet, balanceDelta } = reconcileFleetToTick(
             Array.from(fleetById.values()),
             Array.from(routesById.values()),

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -537,11 +537,6 @@ export async function replayActionLog(params: {
           airline = { ...airline, status: status as AirlineEntity["status"] };
         }
 
-        const tier = clampInt(payload.tier, 1, 10);
-        if (tier != null) {
-          airline = { ...airline, tier };
-        }
-
         // Track authoritative fleet/route IDs from the TICK_UPDATE payload.
         // The publishing client includes these from its local state, so they
         // reflect the true set of aircraft and routes regardless of whether
@@ -586,6 +581,10 @@ export async function replayActionLog(params: {
 
         const previousTick = airline.lastTick ?? 0;
         if (actionTick > previousTick) {
+          const tier = clampInt(payload.tier, 1, 10);
+          if (tier != null) {
+            airline = { ...airline, tier };
+          }
           const authoritativeBrandScore = clampNumber(payload.brandScore, 0, 1);
           if (authoritativeBrandScore != null) {
             airline = { ...airline, brandScore: authoritativeBrandScore };

--- a/packages/store/src/localLoader.ts
+++ b/packages/store/src/localLoader.ts
@@ -7,6 +7,9 @@ import type { AirlineState } from "./types.js";
 
 const MAX_PLAYER_CATCHUP = 50000;
 
+/**
+ * Loads and reconciles identity state from local storage and snapshots.
+ */
 export async function hydrateIdentityFromStorage(
   pubkey: string,
   set: (state: Partial<AirlineState>) => void,

--- a/packages/store/src/localLoader.ts
+++ b/packages/store/src/localLoader.ts
@@ -1,4 +1,4 @@
-import { type Checkpoint, decompressSnapshotString } from "@acars/core";
+import { type Checkpoint, decompressSnapshotString, fpAdd } from "@acars/core";
 import { loadSnapshot } from "@acars/nostr";
 import { db } from "./db.js";
 import { useEngineStore } from "./engine.js";
@@ -96,9 +96,14 @@ export async function hydrateIdentityFromStorage(
   // Reconcile to the current engine tick, not the snapshot's lastTick
   let reconciledTimeline = airline.timeline || [];
   if (airline.lastTick != null && fleet.length > 0 && engineTick > airline.lastTick) {
-    const { fleet: reconciled, events } = reconcileFleetToTick(fleet, routes, engineTick);
+    const {
+      fleet: reconciled,
+      events,
+      balanceDelta,
+    } = reconcileFleetToTick(fleet, routes, engineTick);
     fleet = reconciled;
     airline.lastTick = engineTick;
+    airline.corporateBalance = fpAdd(airline.corporateBalance, balanceDelta);
 
     // Merge synthetic takeoff/landing events into the timeline so the
     // activity log reflects what happened while the client was offline.
@@ -107,6 +112,7 @@ export async function hydrateIdentityFromStorage(
       const newEvents = events.filter((e) => !existingIds.has(e.id));
       if (newEvents.length > 0) {
         reconciledTimeline = [...newEvents, ...reconciledTimeline].slice(0, 1000);
+        airline.timeline = reconciledTimeline;
       }
     }
   }

--- a/packages/store/src/slices/engineSlice.test.ts
+++ b/packages/store/src/slices/engineSlice.test.ts
@@ -75,6 +75,7 @@ const makeAirline = (lastTick: number): AirlineEntity => ({
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
+  cumulativeRevenue: 0 as FixedPoint,
   corporateBalance: 1000000000 as FixedPoint,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],
@@ -214,6 +215,7 @@ describe("engineSlice fast-path", () => {
           corporateBalance,
           events: [],
           hasChanges: false,
+          tickRevenue: fp(0),
         };
       },
     );
@@ -256,6 +258,7 @@ describe("engineSlice lock diagnostics", () => {
         corporateBalance,
         events: [],
         hasChanges: false,
+        tickRevenue: fp(0),
       }),
     );
 
@@ -316,6 +319,7 @@ describe("immediate visual reconciliation during catch-up", () => {
       corporateBalance: 1000000000 as FixedPoint,
       events: [],
       hasChanges: true,
+      tickRevenue: fp(0),
     });
 
     const route = makeRoute("rt-1", 4000);
@@ -350,6 +354,7 @@ describe("immediate visual reconciliation during catch-up", () => {
       corporateBalance: 1000000000 as FixedPoint,
       events: [],
       hasChanges: false,
+      tickRevenue: fp(0),
     });
 
     const route = makeRoute("rt-1", 400);
@@ -388,6 +393,7 @@ describe("TICK_UPDATE publish cadence", () => {
         corporateBalance,
         events: [],
         hasChanges: true,
+        tickRevenue: fp(0),
       }),
     );
 
@@ -427,6 +433,7 @@ describe("TICK_UPDATE publish cadence", () => {
               ]
             : [],
         hasChanges: true,
+        tickRevenue: fp(0),
       }),
     );
 
@@ -470,6 +477,7 @@ describe("TICK_UPDATE publish cadence", () => {
           corporateBalance,
           events: [],
           hasChanges: true,
+          tickRevenue: fp(0),
         };
       },
     );
@@ -489,6 +497,7 @@ describe("TICK_UPDATE publish cadence", () => {
       callsign: "BROKE",
       hubs: ["BOG"],
       tier: 3,
+      cumulativeRevenue: fp(50000000),
     };
     const { state } = createSliceState({
       airline: bankruptAirline,
@@ -507,6 +516,8 @@ describe("TICK_UPDATE publish cadence", () => {
     expect(publishedAction.payload.callsign).toBe("BROKE");
     expect(publishedAction.payload.hubs).toEqual(["BOG"]);
     expect(publishedAction.payload.tier).toBe(3);
+    expect(publishedAction.payload.cumulativeRevenue).toBe(bankruptAirline.cumulativeRevenue);
+    expect(publishedAction.payload.brandScore).toBe(bankruptAirline.brandScore);
   });
 
   it("throttles retry attempts when publish fails", async () => {
@@ -517,6 +528,7 @@ describe("TICK_UPDATE publish cadence", () => {
         corporateBalance,
         events: [],
         hasChanges: true,
+        tickRevenue: fp(0),
       }),
     );
     vi.mocked(publishAction).mockRejectedValue(new Error("Not enough relays received the event"));
@@ -551,6 +563,7 @@ describe("TICK_UPDATE publish cadence", () => {
       corporateBalance: updatedBalance,
       events: [],
       hasChanges: true,
+      tickRevenue: fp(0),
     }));
 
     const route = makeRoute("rt-1", 400);

--- a/packages/store/src/slices/engineSlice.test.ts
+++ b/packages/store/src/slices/engineSlice.test.ts
@@ -75,7 +75,7 @@ const makeAirline = (lastTick: number): AirlineEntity => ({
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
-  cumulativeRevenue: 0 as FixedPoint,
+  cumulativeRevenue: fp(0),
   corporateBalance: 1000000000 as FixedPoint,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -61,6 +61,9 @@ export function _resetTickLockDiagnostics(): void {
   tickMutex.reset();
 }
 
+/**
+ * Engine slice handles tick processing, tier progression, and sync cadence.
+ */
 export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> = (set, get) => ({
   processTick: async (tick: number) => {
     if (!tickMutex.tryLock()) {

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -1,11 +1,15 @@
 import {
   CHAPTER11_BALANCE_THRESHOLD_USD,
+  estimateHistoricRevenue,
+  evaluateTier,
   fp,
   fpAdd,
   fpScale,
   fpSub,
   GENESIS_TIME,
+  getMaxRouteDistanceKm,
   TICK_DURATION,
+  TICKS_PER_HOUR,
   TICKS_PER_MONTH,
 } from "@acars/core";
 import { getAircraftById, getHubPricingForIata } from "@acars/data";
@@ -149,6 +153,8 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
               callsign: updatedAirline.callsign,
               hubs: updatedAirline.hubs,
               livery: updatedAirline.livery,
+              brandScore: updatedAirline.brandScore,
+              cumulativeRevenue: updatedAirline.cumulativeRevenue,
               tier: updatedAirline.tier,
             },
           },
@@ -194,10 +200,19 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
       let currentFleet = [...fleet];
       let currentBalance = airline.corporateBalance;
       let currentBrandScore = airline.brandScore || 0.5;
+      let currentCumulativeRevenue = airline.cumulativeRevenue ?? fp(0);
       const currentHubs = airline.hubs || [];
       let currentTimeline = [...get().timeline];
       const timelineEventIds = new Set(currentTimeline.map((event) => event.id));
       const initialAirlineStatus = airline.status;
+      let evaluatedTier = airline.tier;
+      const distanceLimitKm = getMaxRouteDistanceKm(airline.tier);
+      const brandScorePerTick = 0.002 / TICKS_PER_HOUR;
+      const brandPenaltyPerTick = 0.003 / TICKS_PER_HOUR;
+
+      if (airline.cumulativeRevenue == null) {
+        currentCumulativeRevenue = estimateHistoricRevenue(currentFleet, routes);
+      }
 
       let consumedDeletedFleetIds = new Set<string>();
 
@@ -251,6 +266,8 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
           ...(refreshedAirline ?? airline),
           corporateBalance: currentBalance,
           brandScore: currentBrandScore,
+          cumulativeRevenue: currentCumulativeRevenue,
+          tier: evaluatedTier,
           lastTick: targetTick,
           timeline: currentTimeline,
         };
@@ -284,6 +301,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
               payload: {
                 tick: tickUpdateTick,
                 corporateBalance: updatedAirline.corporateBalance,
+                cumulativeRevenue: updatedAirline.cumulativeRevenue,
                 fleetIds: currentFleet.map((ac) => ac.id),
                 routeIds: routes.map((r) => r.id),
                 timeline: currentTimeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
@@ -295,6 +313,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
                 livery: updatedAirline.livery,
                 status: updatedAirline.status,
                 tier: updatedAirline.tier,
+                brandScore: currentBrandScore,
               },
             },
             get,
@@ -343,6 +362,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             get().globalRouteRegistry,
             get().pubkey || "",
             currentBrandScore,
+            distanceLimitKm,
           );
         } catch (error) {
           processingError = true;
@@ -358,12 +378,32 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
         lastProcessedTick = t;
         currentFleet = result.updatedFleet;
         currentBalance = result.corporateBalance;
+        currentCumulativeRevenue = fpAdd(currentCumulativeRevenue, result.tickRevenue);
 
         if (result.events && result.events.length > 0) {
           // Handle Price War Brand Damage
           const pwEvents = result.events.filter((e) => e.type === "price_war");
           if (pwEvents.length > 0) {
             currentBrandScore = Math.max(0.1, currentBrandScore - 0.005 * pwEvents.length);
+          }
+
+          let landingCount = 0;
+          let landingLoadFactorTotal = 0;
+          for (const event of result.events) {
+            if (event.type !== "landing") continue;
+            const loadFactor = event.details?.loadFactor;
+            if (loadFactor == null) continue;
+            landingCount += 1;
+            landingLoadFactorTotal += loadFactor;
+          }
+          if (landingCount > 0) {
+            const avgLoadFactor = landingLoadFactorTotal / landingCount;
+            if (avgLoadFactor > 0.85) {
+              currentBrandScore += brandScorePerTick;
+            }
+            if (avgLoadFactor < 0.5) {
+              currentBrandScore -= brandPenaltyPerTick;
+            }
           }
 
           // Deduplicate events by ID before merging into the timeline
@@ -375,6 +415,8 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             for (const event of currentTimeline) timelineEventIds.add(event.id);
           }
         }
+
+        currentBrandScore = Math.max(0, Math.min(1, currentBrandScore));
 
         // Monthly hub OPEX
         if (t % ticksPerMonth === 0 && currentHubs.length > 0) {
@@ -411,6 +453,30 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
           });
           await new Promise((resolve) => setTimeout(resolve, 0));
         }
+      }
+
+      const activeRouteCount = routes.filter((route) => route.status === "active").length;
+      if (activeRouteCount > 20) {
+        currentBrandScore = Math.min(1, currentBrandScore + 0.001);
+      }
+
+      currentBrandScore = Math.max(0, Math.min(1, currentBrandScore));
+
+      evaluatedTier = evaluateTier(airline.tier, currentCumulativeRevenue, activeRouteCount);
+      let tierUpgradeEvent: (typeof currentTimeline)[number] | null = null;
+      if (evaluatedTier > airline.tier) {
+        currentBrandScore = Math.min(1, currentBrandScore + 0.05);
+        tierUpgradeEvent = {
+          id: `evt-tier-up-${evaluatedTier}-${targetTick}`,
+          tick: targetTick,
+          timestamp: GENESIS_TIME + targetTick * TICK_DURATION,
+          type: "tier_upgrade" as const,
+          description: `Your airline has been promoted to Tier ${evaluatedTier}.`,
+        };
+      }
+
+      if (tierUpgradeEvent && !timelineEventIds.has(tierUpgradeEvent.id)) {
+        currentTimeline = [tierUpgradeEvent, ...currentTimeline].slice(0, 1000);
       }
 
       const latestFleet = get().fleet;
@@ -461,6 +527,8 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
         ...(refreshedAirline ?? airline),
         corporateBalance: currentBalance,
         brandScore: currentBrandScore,
+        cumulativeRevenue: currentCumulativeRevenue,
+        tier: evaluatedTier,
         lastTick: processingError ? lastProcessedTick : targetTick,
         timeline: currentTimeline,
       };
@@ -497,6 +565,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
             payload: {
               tick: tickUpdateTick,
               corporateBalance: currentBalance,
+              cumulativeRevenue: currentCumulativeRevenue,
               fleetIds: currentFleet.map((ac) => ac.id),
               routeIds: routes.map((r) => r.id),
               timeline: currentTimeline.slice(0, TICK_UPDATE_TIMELINE_EVENTS),
@@ -508,6 +577,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
               livery: updatedAirline.livery,
               status: updatedAirline.status,
               tier: updatedAirline.tier,
+              brandScore: currentBrandScore,
             },
           },
           get,

--- a/packages/store/src/slices/engineSlice.ts
+++ b/packages/store/src/slices/engineSlice.ts
@@ -328,6 +328,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
       // deterministic cycle algebra so the map shows correct positions while
       // the tick-by-tick financial simulation catches up. Without this, the
       // fleet appears stuck at stale arrivalTick positions during catch-up.
+      const shouldSeedSyntheticEvents = targetTick - lastTick > 1 && routes.length === 0;
       if (targetTick - lastTick > 1) {
         const { fleet: projectedFleet, events: reconciledEvents } = reconcileFleetToTick(
           fleet,
@@ -338,7 +339,7 @@ export const createEngineSlice: StateCreator<AirlineState, [], [], EngineSlice> 
 
         // Merge synthetic timeline events from reconciliation so the activity
         // log is immediately populated even before the tick-by-tick loop runs.
-        if (reconciledEvents.length > 0) {
+        if (shouldSeedSyntheticEvents && reconciledEvents.length > 0) {
           const newEvents = reconciledEvents.filter((e) => !timelineEventIds.has(e.id));
           if (newEvents.length > 0) {
             currentTimeline = [...newEvents, ...currentTimeline].slice(0, 1000);

--- a/packages/store/src/slices/fleetSlice.test.ts
+++ b/packages/store/src/slices/fleetSlice.test.ts
@@ -108,6 +108,7 @@ const makeAirline = (
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
+  cumulativeRevenue: 0 as FixedPoint,
   corporateBalance: balance,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],

--- a/packages/store/src/slices/fleetSlice.test.ts
+++ b/packages/store/src/slices/fleetSlice.test.ts
@@ -1,5 +1,5 @@
 import type { AircraftInstance, AirlineEntity, FixedPoint, TimelineEvent } from "@acars/core";
-import { fpAdd } from "@acars/core";
+import { fp, fpAdd } from "@acars/core";
 import { getAircraftById } from "@acars/data";
 import { describe, expect, it, vi } from "vitest";
 import type { StateCreator } from "zustand";
@@ -108,7 +108,7 @@ const makeAirline = (
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
-  cumulativeRevenue: 0 as FixedPoint,
+  cumulativeRevenue: fp(0),
   corporateBalance: balance,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],

--- a/packages/store/src/slices/fleetSlice.ts
+++ b/packages/store/src/slices/fleetSlice.ts
@@ -63,6 +63,9 @@ const logger = createLogger("Fleet");
 // modelId:purchaseType so the same model can't be bought twice in flight.
 const purchasesInFlight = new Set<string>();
 
+/**
+ * Fleet slice manages aircraft purchases, listings, and maintenance actions.
+ */
 export const createFleetSlice: StateCreator<AirlineState, [], [], FleetSlice> = (set, get) => ({
   fleet: [],
   fleetDeletedDuringCatchup: [],

--- a/packages/store/src/slices/fleetSlice.ts
+++ b/packages/store/src/slices/fleetSlice.ts
@@ -16,6 +16,7 @@ import { airports, getAircraftById } from "@acars/data";
 
 /** Module-level O(1) airport lookup */
 const airportMap = new Map(airports.map((a) => [a.iata, a]));
+
 import {
   attachSigner,
   ensureConnected,
@@ -92,6 +93,12 @@ export const createFleetSlice: StateCreator<AirlineState, [], [], FleetSlice> = 
     if (airline.corporateBalance < upfrontCost) {
       const label = purchaseType === "buy" ? "purchase" : "lease deposit";
       throw new Error(`Insufficient corporate balance for ${label} of ${model.name}.`);
+    }
+
+    if (model.unlockTier > airline.tier) {
+      throw new Error(
+        `${model.name} requires Airline Tier ${model.unlockTier}. Your airline is Tier ${airline.tier}.`,
+      );
     }
 
     const engineStore = useEngineStore.getState();

--- a/packages/store/src/slices/fleetSlice.ts
+++ b/packages/store/src/slices/fleetSlice.ts
@@ -574,6 +574,15 @@ export const createFleetSlice: StateCreator<AirlineState, [], [], FleetSlice> = 
     const { airline, pubkey, fleet } = get();
     if (!airline || !pubkey) throw new Error("No active identity or airline loaded.");
 
+    const model = getAircraftById(listing.modelId);
+    if (!model) throw new Error(`Unknown aircraft model ID: ${listing.modelId}`);
+
+    if (model.unlockTier > airline.tier) {
+      throw new Error(
+        `${model.name} requires Airline Tier ${model.unlockTier}. Your airline is Tier ${airline.tier}.`,
+      );
+    }
+
     // Price is already validated as FixedPoint by parseMarketplaceListing
     const price = listing.marketplacePrice;
 

--- a/packages/store/src/slices/identitySlice.ts
+++ b/packages/store/src/slices/identitySlice.ts
@@ -1,4 +1,3 @@
-import { computeActionChainHash, fp, fpSub } from "@acars/core";
 import type {
   AircraftInstance,
   AirlineEntity,
@@ -6,6 +5,7 @@ import type {
   Route,
   TimelineEvent,
 } from "@acars/core";
+import { computeActionChainHash, fp, fpSub } from "@acars/core";
 import { getHubPricingForIata } from "@acars/data";
 import {
   attachSigner,
@@ -18,8 +18,8 @@ import {
 import type { StateCreator } from "zustand";
 import { publishActionWithChain } from "../actionChain";
 import { useEngineStore } from "../engine";
-import type { AirlineState } from "../types";
 import { hydrateIdentityFromStorage } from "../localLoader";
+import type { AirlineState } from "../types";
 
 export interface IdentitySlice {
   pubkey: string | null;
@@ -114,7 +114,11 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
       await hydrateIdentityFromStorage(pubkey, set);
     } catch (error) {
       console.warn("[IdentitySlice] nsec login failed", error);
-      set({ error: "Invalid nsec key.", identityStatus: "ready", isLoading: false });
+      set({
+        error: "Invalid nsec key.",
+        identityStatus: "ready",
+        isLoading: false,
+      });
     }
   },
 
@@ -169,6 +173,7 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
         shareholders: { [pubkey]: 10000000 },
         brandScore: 0.5,
         tier: 1,
+        cumulativeRevenue: fp(0),
         corporateBalance: postHubBalance,
         stockPrice: fp(10),
         fleetIds: [],

--- a/packages/store/src/slices/networkSlice.test.ts
+++ b/packages/store/src/slices/networkSlice.test.ts
@@ -110,6 +110,7 @@ const makeAirline = (
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
+  cumulativeRevenue: 0 as FixedPoint,
   corporateBalance: balance,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],

--- a/packages/store/src/slices/networkSlice.test.ts
+++ b/packages/store/src/slices/networkSlice.test.ts
@@ -5,7 +5,7 @@ import type {
   Route,
   TimelineEvent,
 } from "@acars/core";
-import { fpAdd } from "@acars/core";
+import { fp, fpAdd } from "@acars/core";
 import { describe, expect, it, vi } from "vitest";
 import type { StateCreator } from "zustand";
 import type { AirlineState } from "../types";
@@ -110,7 +110,7 @@ const makeAirline = (
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
-  cumulativeRevenue: 0 as FixedPoint,
+  cumulativeRevenue: fp(0),
   corporateBalance: balance,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],

--- a/packages/store/src/slices/networkSlice.ts
+++ b/packages/store/src/slices/networkSlice.ts
@@ -41,6 +41,9 @@ export interface NetworkSlice {
   ) => Promise<void>;
 }
 
+/**
+ * Network slice manages hubs, routes, and fare updates.
+ */
 export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice> = (set, get) => ({
   routes: [],
 

--- a/packages/store/src/slices/networkSlice.ts
+++ b/packages/store/src/slices/networkSlice.ts
@@ -6,6 +6,7 @@ import {
   fpScale,
   fpSub,
   GENESIS_TIME,
+  getMaxHubs,
   getSuggestedFares,
   ROUTE_SLOT_FEE,
   TICK_DURATION,
@@ -14,6 +15,7 @@ import { airports, getAircraftById, getHubPricingForIata, HUB_CLASSIFICATIONS } 
 
 /** Module-level O(1) airport lookup */
 const airportMap = new Map(airports.map((a) => [a.iata, a]));
+
 import type { StateCreator } from "zustand";
 import { publishActionWithChain } from "../actionChain";
 import { useEngineStore } from "../engine";
@@ -56,6 +58,12 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
     switch (action.type) {
       case "add": {
         if (currentHubs.includes(action.iata)) return;
+        const maxHubs = getMaxHubs(airline.tier);
+        if (currentHubs.length >= maxHubs) {
+          throw new Error(
+            `Tier ${airline.tier} airlines can operate a maximum of ${maxHubs} hub(s). Upgrade your tier to expand.`,
+          );
+        }
         newHubs = [...currentHubs, action.iata];
         hubFee = getHubTierCost(action.iata);
         description = `Opened new operations hub at ${action.iata}. Hub development fee: ${fpFormat(hubFee, 0)}.`;

--- a/packages/store/src/slices/networkSlice.ts
+++ b/packages/store/src/slices/networkSlice.ts
@@ -71,6 +71,14 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
       }
       case "switch": {
         if (currentHubs[0] === action.iata) return; // Already active
+        if (!currentHubs.includes(action.iata)) {
+          const maxHubs = getMaxHubs(airline.tier);
+          if (currentHubs.length >= maxHubs) {
+            throw new Error(
+              `Tier ${airline.tier} airlines can operate a maximum of ${maxHubs} hub(s). Upgrade your tier to expand.`,
+            );
+          }
+        }
         newHubs = [action.iata, ...currentHubs.filter((h) => h !== action.iata)];
         hubFee = fpScale(getHubTierCost(action.iata), 0.25);
         description = `Transferred main operations hub to ${action.iata}. Relocation fee: ${fpFormat(hubFee, 0)}.`;

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -115,6 +115,7 @@ const makeAirline = (pubkey: string, lastTick: number): AirlineEntity => ({
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
+  cumulativeRevenue: 0 as FixedPoint,
   corporateBalance: 1000000000 as FixedPoint,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -1,4 +1,4 @@
-import type { AircraftInstance, AirlineEntity, FixedPoint } from "@acars/core";
+import type { AircraftInstance, AirlineEntity } from "@acars/core";
 import { fp } from "@acars/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateCreator } from "zustand";
@@ -117,8 +117,8 @@ const makeAirline = (pubkey: string, lastTick: number): AirlineEntity => ({
   brandScore: 0.5,
   tier: 1,
   cumulativeRevenue: fp(0),
-  corporateBalance: 1000000000 as FixedPoint,
-  stockPrice: 0 as FixedPoint,
+  corporateBalance: fp(1000000000),
+  stockPrice: fp(0),
   fleetIds: [],
   routeIds: [],
   lastTick,
@@ -134,7 +134,7 @@ const makeAircraft = (id: string, ownerPubkey: string): AircraftInstance => ({
   assignedRouteId: null,
   baseAirportIata: "JFK",
   purchasedAtTick: 0,
-  purchasePrice: 1000000 as FixedPoint,
+  purchasePrice: fp(1000000),
   birthTick: 0,
   flight: null,
   purchaseType: "buy",

--- a/packages/store/src/slices/worldSlice.test.ts
+++ b/packages/store/src/slices/worldSlice.test.ts
@@ -1,4 +1,5 @@
 import type { AircraftInstance, AirlineEntity, FixedPoint } from "@acars/core";
+import { fp } from "@acars/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { StateCreator } from "zustand";
 import type { AirlineState } from "../types";
@@ -115,7 +116,7 @@ const makeAirline = (pubkey: string, lastTick: number): AirlineEntity => ({
   livery: { primary: "#000000", secondary: "#ffffff", accent: "#ffffff" },
   brandScore: 0.5,
   tier: 1,
-  cumulativeRevenue: 0 as FixedPoint,
+  cumulativeRevenue: fp(0),
   corporateBalance: 1000000000 as FixedPoint,
   stockPrice: 0 as FixedPoint,
   fleetIds: [],

--- a/packages/store/src/slices/worldSlice.ts
+++ b/packages/store/src/slices/worldSlice.ts
@@ -8,6 +8,7 @@ import type {
   TimelineEvent,
 } from "@acars/core";
 import {
+  canonicalRouteKey,
   computeRouteFrequency,
   createLogger,
   fp,
@@ -247,7 +248,7 @@ export const createWorldSlice: StateCreator<AirlineState, [], [], WorldSlice> = 
             for (const route of routes) {
               if (route.status !== "active") continue;
 
-              const key = `${route.originIata}-${route.destinationIata}`;
+              const key = canonicalRouteKey(route.originIata, route.destinationIata);
               const offers = registry.get(key) || [];
 
               let avgSpeed = 800;


### PR DESCRIPTION
## Summary
- canonicalize route keys so reverse-direction routes compete in QSI/monopoly checks
- fix inbound leg demand to use swapped origin/destination for asymmetric gravity model
- reuse canonical route key in world registry and network panel competition view