### PR TITLE
fix: enforce hub origin and base hub fallback

### DIFF
--- a/apps/web/src/features/fleet/utils/aircraftBaseHub.test.ts
+++ b/apps/web/src/features/fleet/utils/aircraftBaseHub.test.ts
@@ -82,7 +82,7 @@ describe("getAircraftBaseHub", () => {
     expect(getAircraftBaseHub(aircraft, routes, airline)).toBe("BOG");
   });
 
-  it("falls back to airline primary hub when location is missing", () => {
+  it("falls back to airline primary hub when location is blank", () => {
     const aircraft = makeAircraft({
       assignedRouteId: null,
       baseAirportIata: "",

--- a/apps/web/src/features/fleet/utils/aircraftBaseHub.test.ts
+++ b/apps/web/src/features/fleet/utils/aircraftBaseHub.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
-import { fp } from "@acars/core";
 import type { AircraftInstance, AirlineEntity, Route } from "@acars/core";
+import { fp } from "@acars/core";
+import { describe, expect, it } from "vitest";
 import { getAircraftBaseHub } from "./aircraftBaseHub";
 
 const makeAircraft = (overrides: Partial<AircraftInstance> = {}): AircraftInstance => ({
@@ -37,6 +37,7 @@ const makeAirline = (overrides: Partial<AirlineEntity> = {}): AirlineEntity => (
   livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
   brandScore: 0.7,
   tier: 1,
+  cumulativeRevenue: fp(0),
   corporateBalance: fp(1000000),
   stockPrice: fp(0),
   fleetIds: [],
@@ -60,25 +61,35 @@ const makeRoute = (overrides: Partial<Route> = {}): Route => ({
 
 describe("getAircraftBaseHub", () => {
   it("prefers assigned route origin over current location", () => {
-    const aircraft = makeAircraft({ assignedRouteId: "route-1", baseAirportIata: "BOG" });
+    const aircraft = makeAircraft({
+      assignedRouteId: "route-1",
+      baseAirportIata: "BOG",
+    });
     const routes = [makeRoute({ id: "route-1", originIata: "PTY" })];
     const airline = makeAirline({ hubs: ["PTY"] });
 
     expect(getAircraftBaseHub(aircraft, routes, airline)).toBe("PTY");
   });
 
-  it("falls back to airline primary hub when unassigned", () => {
-    const aircraft = makeAircraft({ assignedRouteId: null, baseAirportIata: "BOG" });
+  it("falls back to aircraft location when unassigned", () => {
+    const aircraft = makeAircraft({
+      assignedRouteId: null,
+      baseAirportIata: "BOG",
+    });
+    const routes: Route[] = [];
+    const airline = makeAirline({ hubs: ["PTY"] });
+
+    expect(getAircraftBaseHub(aircraft, routes, airline)).toBe("BOG");
+  });
+
+  it("falls back to airline primary hub when location is missing", () => {
+    const aircraft = makeAircraft({
+      assignedRouteId: null,
+      baseAirportIata: "",
+    });
     const routes: Route[] = [];
     const airline = makeAirline({ hubs: ["PTY"] });
 
     expect(getAircraftBaseHub(aircraft, routes, airline)).toBe("PTY");
-  });
-
-  it("falls back to aircraft location when airline is missing", () => {
-    const aircraft = makeAircraft({ assignedRouteId: null, baseAirportIata: "BOG" });
-    const routes: Route[] = [];
-
-    expect(getAircraftBaseHub(aircraft, routes, null)).toBe("BOG");
   });
 });

--- a/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
+++ b/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
@@ -9,5 +9,7 @@ export const getAircraftBaseHub = (
     ? routes.find((route) => route.id === aircraft.assignedRouteId)
     : null;
 
-  return assignedRoute?.originIata ?? aircraft.baseAirportIata ?? airline?.hubs[0];
+  const baseIata = aircraft.baseAirportIata?.trim();
+
+  return assignedRoute?.originIata ?? (baseIata ? baseIata : airline?.hubs[0]);
 };

--- a/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
+++ b/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
@@ -11,5 +11,7 @@ export const getAircraftBaseHub = (
 
   const baseIata = aircraft.baseAirportIata?.trim();
 
-  return assignedRoute?.originIata ?? baseIata ?? airline?.hubs[0] ?? "";
+  const resolvedBase = baseIata && baseIata.length > 0 ? baseIata : (airline?.hubs[0] ?? "");
+
+  return assignedRoute?.originIata ?? resolvedBase;
 };

--- a/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
+++ b/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
@@ -1,4 +1,4 @@
-import type { AirlineEntity, AircraftInstance, Route } from "@acars/core";
+import type { AircraftInstance, AirlineEntity, Route } from "@acars/core";
 
 export const getAircraftBaseHub = (
   aircraft: AircraftInstance,
@@ -9,5 +9,5 @@ export const getAircraftBaseHub = (
     ? routes.find((route) => route.id === aircraft.assignedRouteId)
     : null;
 
-  return assignedRoute?.originIata ?? airline?.hubs[0] ?? aircraft.baseAirportIata;
+  return assignedRoute?.originIata ?? aircraft.baseAirportIata ?? airline?.hubs[0];
 };

--- a/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
+++ b/apps/web/src/features/fleet/utils/aircraftBaseHub.ts
@@ -11,5 +11,5 @@ export const getAircraftBaseHub = (
 
   const baseIata = aircraft.baseAirportIata?.trim();
 
-  return assignedRoute?.originIata ?? (baseIata ? baseIata : airline?.hubs[0]);
+  return assignedRoute?.originIata ?? baseIata ?? airline?.hubs[0] ?? "";
 };

--- a/apps/web/src/features/network/components/RouteManager.test.tsx
+++ b/apps/web/src/features/network/components/RouteManager.test.tsx
@@ -73,7 +73,11 @@ describe("RouteManager", () => {
       fleet: [],
       isViewingOther: false,
     });
-    mockUseEngineStore.mockReturnValue({ homeAirport: null, tick: 0 });
+    mockUseEngineStore.mockReturnValue({
+      homeAirport: null,
+      tick: 0,
+      setActiveHubIata: vi.fn(),
+    });
     const { container } = render(<RouteManager />);
     expect(container.firstChild).toBeNull();
   });
@@ -109,6 +113,7 @@ describe("RouteManager", () => {
         longitude: 0,
       },
       tick: 0,
+      setActiveHubIata: vi.fn(),
     });
 
     render(<RouteManager />);

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -28,7 +28,6 @@ import { airports as ALL_AIRPORTS, HUB_CLASSIFICATIONS } from "@acars/data";
 import { useActiveAirline, useAirlineStore, useEngineStore } from "@acars/store";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
 import {
   AlertCircle,
   ArrowDown,
@@ -43,6 +42,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getRouteDemandSnapshot } from "@/features/network/hooks/useRouteDemand";
+import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
 import { useConfirm } from "@/shared/lib/useConfirm";
 
 const toneDotClass = {
@@ -110,7 +110,7 @@ export function RouteManager() {
     competitors,
   } = useAirlineStore();
   const confirm = useConfirm();
-  const { homeAirport, tick } = useEngineStore();
+  const { homeAirport, tick, setActiveHubIata } = useEngineStore();
   const { tab } = useSearch({ from: "/network" });
   const navigate = useNavigate({ from: "/network" });
   const setTab = (newTab: "active" | "opportunities") => {
@@ -122,7 +122,11 @@ export function RouteManager() {
     destinationIata: string;
     distanceKm: number;
   } | null>(null);
-  const [fareInputs, setFareInputs] = useState<{ e: string; b: string; f: string }>({
+  const [fareInputs, setFareInputs] = useState<{
+    e: string;
+    b: string;
+    f: string;
+  }>({
     e: "",
     b: "",
     f: "",
@@ -147,6 +151,12 @@ export function RouteManager() {
       setPlanningOriginIata(airline.hubs[0]);
     }
   }, [airline?.hubs, planningOriginIata]);
+
+  useEffect(() => {
+    if (planningOriginIata) {
+      setActiveHubIata(planningOriginIata, "route planner");
+    }
+  }, [planningOriginIata, setActiveHubIata]);
 
   const planningOriginAirport = useMemo(() => {
     if (planningOriginIata) {
@@ -250,7 +260,14 @@ export function RouteManager() {
           ),
           fpScale(fares.first, demand.first / 7),
         );
-        return { origin, destination: dest, distance, demand, estimatedDailyRevenue, season };
+        return {
+          origin,
+          destination: dest,
+          distance,
+          demand,
+          estimatedDailyRevenue,
+          season,
+        };
       });
     },
     [tick],
@@ -609,7 +626,10 @@ export function RouteManager() {
                             ""
                           }
                           onChange={(e) =>
-                            setRebaseTargets((prev) => ({ ...prev, [route.id]: e.target.value }))
+                            setRebaseTargets((prev) => ({
+                              ...prev,
+                              [route.id]: e.target.value,
+                            }))
                           }
                           className="h-9 rounded-lg border border-border/60 bg-background px-3 text-xs font-bold text-foreground"
                         >
@@ -634,7 +654,9 @@ export function RouteManager() {
                             } catch (err) {
                               const message =
                                 err instanceof Error ? err.message : "Route rebase failed";
-                              toast.error("Route rebase failed", { description: message });
+                              toast.error("Route rebase failed", {
+                                description: message,
+                              });
                             }
                           }}
                           className="h-9 rounded-lg bg-amber-500 px-3 text-xs font-bold text-amber-950 hover:bg-amber-400 transition"
@@ -661,7 +683,9 @@ export function RouteManager() {
                           await closeRoute(route.id);
                         } catch (err) {
                           const message = err instanceof Error ? err.message : "Route close failed";
-                          toast.error("Route close failed", { description: message });
+                          toast.error("Route close failed", {
+                            description: message,
+                          });
                         }
                       }}
                       className="h-9 rounded-lg border border-amber-500/30 bg-transparent px-3 text-xs font-bold text-amber-100 hover:bg-amber-500/20 transition"
@@ -810,7 +834,8 @@ export function RouteManager() {
                               </span>
                               <span className="text-xs text-muted-foreground font-semibold mt-1">
                                 {destinationAirport?.city}, {destinationAirport?.country} •{" "}
-                                {Math.round(route.distanceKm).toLocaleString()}km
+                                {Math.round(route.distanceKm).toLocaleString()}
+                                km
                               </span>
                             </div>
 
@@ -901,7 +926,9 @@ export function RouteManager() {
                                       } catch (err) {
                                         const message =
                                           err instanceof Error ? err.message : "Route close failed";
-                                        toast.error("Route close failed", { description: message });
+                                        toast.error("Route close failed", {
+                                          description: message,
+                                        });
                                       }
                                     }}
                                     className="px-3 py-2 rounded-xl border border-red-500/30 text-red-200/80 text-sm font-bold hover:bg-red-500/15 transition-all"
@@ -963,15 +990,17 @@ export function RouteManager() {
                               <div className="mt-1 h-2 w-full rounded-full bg-background/70 overflow-hidden">
                                 <div
                                   className={`h-full ${lfFill} transition-all duration-500`}
-                                  style={{ width: `${Math.min(100, loadFactor)}%` }}
+                                  style={{
+                                    width: `${Math.min(100, loadFactor)}%`,
+                                  }}
                                 />
                               </div>
                               <div className="mt-2 flex justify-between text-[9px] text-muted-foreground">
                                 <span>Target {Math.round(NATURAL_LF_CEILING * 100)}%</span>
                                 <span>
                                   {supplyRatio > 1.05
-                                    ? `Oversupply ${(supplyRatio).toFixed(2)}x`
-                                    : `Coverage ${(supplyRatio).toFixed(2)}x`}
+                                    ? `Oversupply ${supplyRatio.toFixed(2)}x`
+                                    : `Coverage ${supplyRatio.toFixed(2)}x`}
                                 </span>
                               </div>
                               {showPriceEffect && (
@@ -1373,7 +1402,9 @@ export function RouteManager() {
                         />
                         <div
                           className="h-full bg-yellow-500"
-                          style={{ width: `${(market.demand.first / (totalDemand || 1)) * 100}%` }}
+                          style={{
+                            width: `${(market.demand.first / (totalDemand || 1)) * 100}%`,
+                          }}
                           title="First"
                         />
                       </div>

--- a/apps/web/src/routes/-corporate.lazy.test.tsx
+++ b/apps/web/src/routes/-corporate.lazy.test.tsx
@@ -100,7 +100,11 @@ vi.mock("@acars/store", () => {
       isViewingOther: false,
     }),
     useEngineStore: (selector?: (s: unknown) => unknown) => {
-      const state = { homeAirport: { iata: "JFK" }, tick: 200 };
+      const state = {
+        homeAirport: { iata: "JFK" },
+        tick: 200,
+        setActiveHubIata: vi.fn(),
+      };
       return selector ? selector(state) : state;
     },
   };

--- a/apps/web/src/routes/-corporate.lazy.tsx
+++ b/apps/web/src/routes/-corporate.lazy.tsx
@@ -901,6 +901,7 @@ export default function CorporateDashboard() {
   const { airline, modifyHubs, dissolveAirline, initializeIdentity, isLoading } = useAirlineStore();
   const { fleet, timeline, routes, isViewingOther } = useActiveAirline();
   const homeAirport = useEngineStore((s) => s.homeAirport);
+  const setActiveHubIata = useEngineStore((s) => s.setActiveHubIata);
 
   const [pendingAction, setPendingAction] = useState<{
     type: "add" | "switch" | "remove";
@@ -984,6 +985,7 @@ export default function CorporateDashboard() {
   const handleSwitchActiveHub = (iata: string) => {
     setActionError(null);
     setPendingAction({ type: "switch", iata });
+    setActiveHubIata(iata, "corporate hub");
   };
 
   const handleCloseHub = (iata: string) => {

--- a/packages/store/src/engine.ts
+++ b/packages/store/src/engine.ts
@@ -109,6 +109,7 @@ export interface EngineState {
 
   syncTick: () => void;
   setHub: (airport: Airport, loc: UserLocation, method: string) => void;
+  setActiveHubIata: (iata: string, method?: string) => void;
   startEngine: () => void;
   stopEngine: () => void;
   setPermalinkAirport: (iata: string | null) => void;
@@ -163,6 +164,30 @@ export const useEngineStore = create<EngineState>((set, get) => ({
     set({
       tick: currentTick,
       userLocation: loc,
+      homeAirport: airport,
+      locationMethod: method,
+      routes: generateRoutes(airport, currentTick),
+    });
+  },
+
+  setActiveHubIata: (iata, method = "hub selection") => {
+    const { homeAirport, userLocation } = get();
+    if (homeAirport?.iata === iata) return;
+    const airport = AIRPORTS.find((entry) => entry.iata === iata);
+    if (!airport) return;
+
+    const currentTick = calculateGlobalTick();
+    const location =
+      userLocation ??
+      ({
+        latitude: airport.latitude,
+        longitude: airport.longitude,
+        source: "manual",
+      } as const);
+
+    set({
+      tick: currentTick,
+      userLocation: location,
       homeAirport: airport,
       locationMethod: method,
       routes: generateRoutes(airport, currentTick),

--- a/packages/store/src/slices/networkSlice.ts
+++ b/packages/store/src/slices/networkSlice.ts
@@ -594,6 +594,10 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
     const { airline, routes, pubkey } = get();
     if (!airline || !pubkey) throw new Error("No airline loaded.");
 
+    if (!airline.hubs.includes(originIata)) {
+      throw new Error("Route origin must be one of your active hubs.");
+    }
+
     if (airline.corporateBalance < ROUTE_SLOT_FEE) {
       throw new Error(`Insufficient funds to open route. Cost: ${fpFormat(ROUTE_SLOT_FEE, 0)}`);
     }


### PR DESCRIPTION
## Summary
- enforce route openings to start from an active hub to prevent non-hub origins
- prefer an aircraft's actual location when unassigned, with a fallback to the primary hub
- adjust aircraft base hub tests to match the updated priority

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved aircraft base hub selection logic: assigned routes are now prioritized, followed by the aircraft's own base location, with airline hubs as a final fallback.
  * Added validation to ensure route origins are one of the airline's active hubs, preventing invalid route creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->