### PR TITLE
fix: normalize route unassignments

### DIFF
--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -890,7 +890,18 @@ export async function replayActionLog(params: {
         const routeId = resolveRouteId(clampString(payload.routeId, 64));
         if (!aircraftId) break;
         const aircraft = fleetById.get(aircraftId);
-        if (aircraft) aircraft.assignedRouteId = null;
+        if (aircraft) {
+          aircraft.assignedRouteId = null;
+          aircraft.routeAssignedAtTick = undefined;
+          aircraft.routeAssignedAtIata = undefined;
+          aircraft.lastKnownLoadFactor = undefined;
+          if (aircraft.status === "turnaround") {
+            aircraft.status = "idle";
+            aircraft.flight = null;
+            aircraft.turnaroundEndTick = undefined;
+            aircraft.arrivalTickProcessed = undefined;
+          }
+        }
         if (routeId) {
           const route = routesById.get(routeId);
           if (route) {

--- a/packages/store/src/actionReducer.ts
+++ b/packages/store/src/actionReducer.ts
@@ -861,6 +861,7 @@ export async function replayActionLog(params: {
         aircraft.assignedRouteId = routeId;
         aircraft.routeAssignedAtTick = actionTick;
         aircraft.routeAssignedAtIata = aircraft.baseAirportIata;
+        aircraft.lastKnownLoadFactor = undefined;
         // Clear stale flight state from a previous cycle so reconcileFleetToTick
         // uses routeAssignedAtTick as the new cycle anchor instead of old departureTick.
         if (aircraft.flight && actionTick >= aircraft.flight.departureTick) {

--- a/packages/store/src/slices/networkSlice.ts
+++ b/packages/store/src/slices/networkSlice.ts
@@ -788,8 +788,26 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
           assignedRouteId: routeId,
           routeAssignedAtTick: currentTick,
           routeAssignedAtIata: ac.baseAirportIata,
+          lastKnownLoadFactor: undefined,
         };
         if (nextAircraft.flight && currentTick >= nextAircraft.flight.departureTick) {
+          nextAircraft.status = "idle";
+          nextAircraft.flight = null;
+          nextAircraft.turnaroundEndTick = undefined;
+          nextAircraft.arrivalTickProcessed = undefined;
+        }
+        return nextAircraft;
+      }
+
+      if (!routeId) {
+        const nextAircraft: AircraftInstance = {
+          ...ac,
+          assignedRouteId: null,
+          routeAssignedAtTick: undefined,
+          routeAssignedAtIata: undefined,
+          lastKnownLoadFactor: undefined,
+        };
+        if (nextAircraft.status === "turnaround") {
           nextAircraft.status = "idle";
           nextAircraft.flight = null;
           nextAircraft.turnaroundEndTick = undefined;
@@ -819,7 +837,7 @@ export const createNetworkSlice: StateCreator<AirlineState, [], [], NetworkSlice
       id: `evt-assign-${aircraftId}-${currentTick}`,
       tick: currentTick,
       timestamp: simulatedTimestamp,
-      type: "maintenance",
+      type: "route_change",
       aircraftId,
       aircraftName,
       routeId: routeId || undefined,


### PR DESCRIPTION
## Summary
- clear route assignment anchors and load-factor cache when unassigning aircraft
- normalize unassign replay to reset turnaround-only flight state
- align route assignment timeline events with `route_change`

## Testing
- not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset all aircraft route-related state and metadata when unassigning from a route, including load factor and assignment timestamps.
  * Ensure aircraft in turnaround correctly transition to idle and clear turnaround fields when detached from a route.

* **Improvements**
  * Initialize and track last-known load factor during route assignment.
  * Use clearer timeline event labeling for route changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->