### PR TITLE
fix: make panel headers scroll with content on mobile

### DIFF
--- a/apps/web/src/features/competition/components/Leaderboard.tsx
+++ b/apps/web/src/features/competition/components/Leaderboard.tsx
@@ -241,8 +241,8 @@ export function Leaderboard() {
   });
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col gap-3 sm:gap-4">
-      <div className="shrink-0 rounded-2xl border border-border/50 bg-card/90 p-3 shadow-sm backdrop-blur-xl sm:p-4">
+    <div className="flex w-full flex-col gap-3 sm:gap-4">
+      <div className="rounded-2xl border border-border/50 bg-card/90 p-3 shadow-sm backdrop-blur-xl sm:p-4">
         <div className="flex items-center gap-3">
           <div className="rounded-lg bg-primary/10 p-2">
             <Trophy className="h-5 w-5 text-primary sm:h-6 sm:w-6" aria-hidden="true" />
@@ -274,7 +274,7 @@ export function Leaderboard() {
         </div>
       </div>
 
-      <div ref={parentRef} className="custom-scrollbar flex-1 overflow-y-auto">
+      <div ref={parentRef} className="custom-scrollbar h-[70vh] overflow-y-auto">
         <div className="relative" style={{ height: `${virtualizer.getTotalSize()}px` }}>
           {virtualizer.getVirtualItems().map((virtualRow) => {
             const row = rows[virtualRow.index];

--- a/apps/web/src/features/fleet/components/AircraftDealer.tsx
+++ b/apps/web/src/features/fleet/components/AircraftDealer.tsx
@@ -194,9 +194,9 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
   });
 
   return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col gap-4 overflow-hidden sm:gap-6">
+    <div className="flex min-w-0 flex-col gap-4 sm:gap-6">
       {/* Mode Switcher */}
-      <div className="grid shrink-0 grid-cols-2 gap-2 border-b border-border/40 pb-4">
+      <div className="grid grid-cols-2 gap-2 border-b border-border/40 pb-4">
         <button
           type="button"
           onClick={() => setMode("factory")}
@@ -219,7 +219,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
       </div>
 
       {/* Header & Filters */}
-      <div className="shrink-0 rounded-2xl border border-border/40 bg-card p-3 shadow-sm backdrop-blur-xl sm:p-4">
+      <div className="rounded-2xl border border-border/40 bg-card p-3 shadow-sm backdrop-blur-xl sm:p-4">
         <div className="flex min-w-0 flex-col gap-3">
           <div className="relative flex-1">
             <Search className="absolute left-3 h-4 w-4 text-muted-foreground" />
@@ -281,7 +281,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
       {/* Grid */}
       <div
         ref={scrollRef}
-        className="custom-scrollbar flex-1 overflow-y-auto overflow-x-hidden pb-8 sm:pr-2 sm:pb-10"
+        className="custom-scrollbar h-[70vh] overflow-y-auto overflow-x-hidden pb-8 sm:pr-2 sm:pb-10"
       >
         {displayMode === "used-empty" ? (
           <div className="py-20 text-center flex flex-col items-center border border-dashed border-border/50 rounded-2xl bg-card/20">

--- a/apps/web/src/features/fleet/components/FleetManager.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.tsx
@@ -227,7 +227,7 @@ export function FleetManager() {
 
   if (view === "dealer") {
     return (
-      <div className="flex flex-col h-full w-full">
+      <div className="flex flex-col w-full">
         <div className="mb-4">
           <button
             type="button"
@@ -237,7 +237,7 @@ export function FleetManager() {
             &larr; Back to My Fleet
           </button>
         </div>
-        <div className="flex-1 overflow-hidden min-h-0">
+        <div>
           <AircraftDealer onPurchaseSuccess={() => setView("owned")} />
         </div>
       </div>
@@ -245,8 +245,8 @@ export function FleetManager() {
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3 sm:gap-4">
-      <div className="shrink-0 rounded-2xl border border-border/50 bg-card/90 p-3 shadow-sm backdrop-blur-xl sm:p-4">
+    <div className="flex flex-col gap-3 sm:gap-4">
+      <div className="rounded-2xl border border-border/50 bg-card/90 p-3 shadow-sm backdrop-blur-xl sm:p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="relative flex items-center flex-1 sm:max-w-[320px]">
             <Search className="absolute left-3 h-4 w-4 text-muted-foreground" />
@@ -275,7 +275,7 @@ export function FleetManager() {
         </div>
       </div>
 
-      <div ref={fleetListRef} className="custom-scrollbar flex-1 overflow-y-auto pb-8">
+      <div ref={fleetListRef} className="custom-scrollbar h-[70vh] overflow-y-auto pb-8">
         {fleet.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center border-2 border-dashed border-border/50 rounded-2xl bg-card/10">
             <Plane className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -572,7 +572,7 @@ export function RouteManager() {
   if (!airline || !homeAirport || !planningOriginAirport) return null;
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+    <div className="flex flex-col">
       <PanelHeader
         title="Network"
         subtitle={`Manage your routes and flight frequencies from ${planningOriginAirport.name}.`}
@@ -583,8 +583,8 @@ export function RouteManager() {
         }
       />
 
-      <div className="flex min-h-0 flex-1 flex-col px-4 py-3 sm:px-6 sm:py-4">
-        <div className="mb-3 shrink-0 rounded-2xl border border-border/50 bg-card/90 p-3 shadow-sm backdrop-blur-xl sm:p-4">
+      <div className="flex flex-1 flex-col px-4 py-3 sm:px-6 sm:py-4">
+        <div className="mb-3 rounded-2xl border border-border/50 bg-card/90 p-3 shadow-sm backdrop-blur-xl sm:p-4">
           <div className="flex flex-col gap-3">
             {airline.hubs.length > 1 ? (
               <div className="flex items-center gap-2 rounded-xl border border-border/50 bg-muted/30 px-3 py-2">
@@ -623,9 +623,9 @@ export function RouteManager() {
           </div>
         </div>
 
-        <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
+        <div className="flex flex-col">
           {suspendedRoutes.length > 0 && !isViewingOther && (
-            <div className="mb-3 shrink-0 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 sm:p-5">
+            <div className="mb-3 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 sm:p-5">
               <div className="flex items-center justify-between gap-4">
                 <div>
                   <p className="text-xs font-bold uppercase tracking-[0.2em] text-amber-200">
@@ -752,7 +752,7 @@ export function RouteManager() {
             </div>
           )}
           {tab === "opportunities" && (
-            <div className="mb-3 shrink-0 flex items-center gap-3 rounded-2xl border border-border/50 bg-muted/30 p-3 sm:p-4">
+            <div className="mb-3 flex items-center gap-3 rounded-2xl border border-border/50 bg-muted/30 p-3 sm:p-4">
               <div className="relative flex-1">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <input
@@ -794,7 +794,7 @@ export function RouteManager() {
                 )}
               </div>
             ) : (
-              <div ref={listParentRef} className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
+              <div ref={listParentRef} className="h-[70vh] overflow-y-auto custom-scrollbar">
                 <div
                   style={{
                     height: `${activeRoutesVirtualizer.getTotalSize()}px`,
@@ -1344,7 +1344,7 @@ export function RouteManager() {
               </div>
             )
           ) : (
-            <div ref={listParentRef} className="flex-1 min-h-0 overflow-y-auto custom-scrollbar">
+            <div ref={listParentRef} className="h-[70vh] overflow-y-auto custom-scrollbar">
               <div
                 style={{
                   height: `${opportunitiesVirtualizer.getTotalSize()}px`,

--- a/apps/web/src/routes/-fleet.lazy.tsx
+++ b/apps/web/src/routes/-fleet.lazy.tsx
@@ -45,7 +45,7 @@ export default function FleetDashboard() {
           </span>
         }
       />
-      <PanelBody className="overflow-hidden pt-3 sm:pt-4">
+      <PanelBody className="pt-3 sm:pt-4">
         {isBankrupt && !isViewingOther && (
           <div className="mb-3 flex items-center gap-2 rounded-xl border border-rose-500/20 bg-rose-950/30 px-4 py-3">
             <AlertTriangle className="h-4 w-4 shrink-0 text-rose-400" />
@@ -56,9 +56,7 @@ export default function FleetDashboard() {
             </span>
           </div>
         )}
-        <div className="min-h-0 h-full">
-          <FleetManager />
-        </div>
+        <FleetManager />
       </PanelBody>
     </PanelLayout>
   );

--- a/apps/web/src/routes/-leaderboard.lazy.tsx
+++ b/apps/web/src/routes/-leaderboard.lazy.tsx
@@ -5,7 +5,7 @@ export default function LeaderboardPage() {
   return (
     <PanelLayout>
       <PanelHeader title="Leaderboard" subtitle="Multiplayer standings across the active world." />
-      <PanelBody className="overflow-hidden pt-3 sm:pt-4">
+      <PanelBody className="pt-3 sm:pt-4">
         <Leaderboard />
       </PanelBody>
     </PanelLayout>

--- a/apps/web/src/shared/components/layout/PanelLayout.tsx
+++ b/apps/web/src/shared/components/layout/PanelLayout.tsx
@@ -5,7 +5,9 @@ import { cn } from "@/shared/lib/utils";
 export function PanelLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="pointer-events-auto relative flex h-full w-full min-w-0 max-w-2xl flex-col overflow-hidden rounded-[24px] border border-border/80 bg-background/85 shadow-[0_0_40px_rgba(0,0,0,0.6)] backdrop-blur-2xl duration-300 animate-in fade-in slide-in-from-left-4 sm:rounded-[28px]">
-      <div className="flex h-full w-full min-h-0 flex-col">{children}</div>
+      <div className="custom-scrollbar flex h-full w-full min-h-0 flex-col overflow-y-auto">
+        {children}
+      </div>
     </div>
   );
 }
@@ -28,7 +30,7 @@ export function PanelHeader({
   return (
     <div
       className={cn(
-        "shrink-0 border-b border-border/60 bg-background/88 px-4 py-3 backdrop-blur-xl sm:px-6 sm:py-4",
+        "border-b border-border/60 bg-background/88 px-4 py-3 backdrop-blur-xl sm:px-6 sm:py-4",
         className,
       )}
     >
@@ -69,14 +71,5 @@ export function PanelBody({
   children: React.ReactNode;
   className?: string;
 }) {
-  return (
-    <div
-      className={cn(
-        "flex-1 min-h-0 overflow-y-auto px-4 py-3 custom-scrollbar sm:px-6 sm:py-4",
-        className,
-      )}
-    >
-      {children}
-    </div>
-  );
+  return <div className={cn("min-w-0 px-4 py-3 sm:px-6 sm:py-4", className)}>{children}</div>;
 }


### PR DESCRIPTION
## Summary

- Panel headers on mobile were fixed at the top (via `shrink-0`), consuming ~50% of viewport and leaving insufficient space for scrollable content
- Moved scroll ownership from `PanelBody` to the `PanelLayout` wrapper so the entire panel (header + body) scrolls as one unit — headers now scroll away as the user scrolls down
- Virtualized list containers (Fleet, Dealer, Network routes, Leaderboard) use explicit `h-[70vh]` instead of `flex-1` since virtualizers require a bounded scroll container

## Changes

**Core layout** (`PanelLayout.tsx`):
- Inner wrapper now has `overflow-y-auto` instead of child PanelBody
- `PanelHeader` no longer uses `shrink-0` — scrolls naturally with content
- `PanelBody` simplified to a plain wrapper (no flex-1, no overflow, no min-h-0)

**Feature components** (FleetManager, AircraftDealer, RouteManager, Leaderboard):
- Removed `h-full`, `min-h-0`, `shrink-0`, `overflow-hidden` constraints that assumed parent-bounded scrolling
- Virtualized scroll containers use `h-[70vh]` for bounded height

**Route files** (`-fleet.lazy.tsx`, `-leaderboard.lazy.tsx`):
- Removed `overflow-hidden` from PanelBody className
- Removed unnecessary wrapper div around FleetManager

## Validation

- `pnpm --filter @acars/web typecheck` — pass
- `pnpm --filter @acars/web test -- --run` — 124/124 pass
- `pnpm --filter @acars/web build` — pass