### PR TITLE
fix: eliminate double scroll in mobile panels

### DIFF
--- a/apps/web/src/features/competition/components/Leaderboard.test.tsx
+++ b/apps/web/src/features/competition/components/Leaderboard.test.tsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { Leaderboard } from "./Leaderboard";
 
+vi.mock("@/shared/components/layout/PanelLayout", () => ({
+  usePanelScrollRef: () => ({ current: null }),
+}));
+
 type Selector<T> = (state: T) => unknown;
 type AirlineStoreState = {
   competitors: Map<string, unknown>;
@@ -59,6 +63,7 @@ vi.mock("@tanstack/react-virtual", () => {
           size: 84,
         })),
       measureElement: () => {},
+      options: { scrollMargin: 0 },
     }),
   };
 });
@@ -93,7 +98,9 @@ describe("Leaderboard", () => {
     render(<Leaderboard />);
     expect(screen.getByText("Test Air")).toBeInTheDocument();
 
-    fireEvent.change(screen.getByRole("combobox"), { target: { value: "fleet" } });
+    fireEvent.change(screen.getByRole("combobox"), {
+      target: { value: "fleet" },
+    });
     expect(screen.getAllByText("Fleet Size").length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/features/competition/components/Leaderboard.tsx
+++ b/apps/web/src/features/competition/components/Leaderboard.tsx
@@ -12,6 +12,7 @@ import {
   buildLeaderboardRows,
   sortLeaderboardRows,
 } from "@/features/competition/leaderboardMetrics";
+import { usePanelScrollRef } from "@/shared/components/layout/PanelLayout";
 import { useNostrProfile } from "@/shared/hooks/useNostrProfile";
 import { cn } from "@/shared/lib/utils";
 
@@ -231,13 +232,15 @@ export function Leaderboard() {
   }, [competitors, airline, aircraftById, routeById, currentTick, metric]);
 
   const ownId = airline?.id ?? null;
+  const panelScrollRef = usePanelScrollRef();
   const parentRef = useRef<HTMLDivElement | null>(null);
   // eslint-disable-next-line react-hooks/incompatible-library
   const virtualizer = useVirtualizer({
     count: rows.length,
-    getScrollElement: () => parentRef.current,
+    getScrollElement: () => panelScrollRef.current,
     estimateSize: () => ROW_HEIGHT,
     overscan: 6,
+    scrollMargin: parentRef.current?.offsetTop ?? 0,
   });
 
   return (
@@ -274,7 +277,7 @@ export function Leaderboard() {
         </div>
       </div>
 
-      <div ref={parentRef} className="custom-scrollbar h-[70vh] overflow-y-auto">
+      <div ref={parentRef}>
         <div className="relative" style={{ height: `${virtualizer.getTotalSize()}px` }}>
           {virtualizer.getVirtualItems().map((virtualRow) => {
             const row = rows[virtualRow.index];
@@ -298,7 +301,9 @@ export function Leaderboard() {
                 data-index={virtualRow.index}
                 ref={virtualizer.measureElement}
                 className="absolute left-0 right-0 pb-2"
-                style={{ transform: `translateY(${virtualRow.start}px)` }}
+                style={{
+                  transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
+                }}
               >
                 <LeaderboardRow
                   row={row}

--- a/apps/web/src/features/fleet/components/AircraftDealer.tsx
+++ b/apps/web/src/features/fleet/components/AircraftDealer.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { usePanelScrollRef } from "@/shared/components/layout/PanelLayout";
 import { useConfirm } from "@/shared/lib/useConfirm";
 
 /**
@@ -41,12 +42,13 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
     () => Array.from({ length: 6 }, (_, index) => `skeleton-${index}`),
     [],
   );
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const panelScrollRef = usePanelScrollRef();
+  const measureRef = useRef<HTMLDivElement>(null);
   const [gridColumns, setGridColumns] = useState(1);
 
   useEffect(() => {
     const updateColumns = () => {
-      const width = scrollRef.current?.clientWidth ?? 0;
+      const width = measureRef.current?.clientWidth ?? 0;
       if (width >= 1536) {
         setGridColumns(3);
       } else if (width >= 1280) {
@@ -188,9 +190,10 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
           : 320;
   const virtualizer = useVirtualizer({
     count: rowCount,
-    getScrollElement: () => scrollRef.current,
+    getScrollElement: () => panelScrollRef.current,
     estimateSize: () => rowHeight,
     overscan: 2,
+    scrollMargin: measureRef.current?.offsetTop ?? 0,
   });
 
   return (
@@ -279,10 +282,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
       </div>
 
       {/* Grid */}
-      <div
-        ref={scrollRef}
-        className="custom-scrollbar h-[70vh] overflow-y-auto overflow-x-hidden pb-8 sm:pr-2 sm:pb-10"
-      >
+      <div ref={measureRef} className="overflow-x-hidden pb-8 sm:pr-2 sm:pb-10">
         {displayMode === "used-empty" ? (
           <div className="py-20 text-center flex flex-col items-center border border-dashed border-border/50 rounded-2xl bg-card/20">
             <History className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />
@@ -342,7 +342,7 @@ export function AircraftDealer({ onPurchaseSuccess }: { onPurchaseSuccess?: () =
                     left: 0,
                     width: "100%",
                     height: `${row.size}px`,
-                    transform: `translateY(${row.start}px)`,
+                    transform: `translateY(${row.start - virtualizer.options.scrollMargin}px)`,
                     gridTemplateColumns: `repeat(${gridColumns}, minmax(0, 1fr))`,
                   }}
                 >

--- a/apps/web/src/features/fleet/components/FleetManager.test.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.test.tsx
@@ -2,6 +2,12 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FLEET_TWO_COLUMN_BREAKPOINT, FleetManager } from "./FleetManager";
 
+vi.mock("@/shared/components/layout/PanelLayout", () => ({
+  PanelHeader: ({ title }: { title: string }) => <div>{title}</div>,
+  PanelBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  usePanelScrollRef: () => ({ current: null }),
+}));
+
 type Selector<T> = (state: T) => unknown;
 type AirlineStoreState = {
   airline: { hubs: string[] } | null;
@@ -29,6 +35,7 @@ vi.mock("@tanstack/react-virtual", () => {
       getVirtualItems: () => mockVirtualItems,
       getTotalSize: () => (mockVirtualItems.length > 0 ? 730 : 0),
       measureElement: mockMeasureElement,
+      options: { scrollMargin: 0 },
     }),
   };
 });

--- a/apps/web/src/features/fleet/components/FleetManager.test.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
-import { FleetManager, FLEET_TWO_COLUMN_BREAKPOINT } from "./FleetManager";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FLEET_TWO_COLUMN_BREAKPOINT, FleetManager } from "./FleetManager";
 
 type Selector<T> = (state: T) => unknown;
 type AirlineStoreState = {
@@ -20,6 +20,18 @@ type EngineStoreState = { tick: number; tickProgress: number };
 const mockUseAirlineStore = vi.fn();
 const mockUseEngineStore = vi.fn();
 const mockUseActiveAirline = vi.fn();
+const mockMeasureElement = vi.fn();
+let mockVirtualItems: Array<{ key: string; index: number; start: number }> = [];
+
+vi.mock("@tanstack/react-virtual", () => {
+  return {
+    useVirtualizer: () => ({
+      getVirtualItems: () => mockVirtualItems,
+      getTotalSize: () => (mockVirtualItems.length > 0 ? 730 : 0),
+      measureElement: mockMeasureElement,
+    }),
+  };
+});
 
 vi.mock("@acars/store", () => {
   return {
@@ -57,8 +69,20 @@ vi.mock("@/shared/lib/useConfirm", () => {
 vi.mock("@/features/network/hooks/useRouteDemand", () => {
   return {
     getRouteDemandSnapshot: vi.fn(() => ({
-      totalDemand: { origin: "JFK", destination: "LAX", economy: 0, business: 0, first: 0 },
-      addressableDemand: { origin: "JFK", destination: "LAX", economy: 0, business: 0, first: 0 },
+      totalDemand: {
+        origin: "JFK",
+        destination: "LAX",
+        economy: 0,
+        business: 0,
+        first: 0,
+      },
+      addressableDemand: {
+        origin: "JFK",
+        destination: "LAX",
+        economy: 0,
+        business: 0,
+        first: 0,
+      },
       pressureMultiplier: 0.7,
       totalWeeklySeats: 0,
       suggestedFleetDelta: 0,
@@ -81,6 +105,69 @@ vi.mock("./AircraftLiveryImage", () => {
 });
 
 describe("FleetManager", () => {
+  beforeEach(() => {
+    mockMeasureElement.mockClear();
+    mockVirtualItems = [];
+  });
+
+  it("measures virtual rows so taller cards expand the row height", () => {
+    mockVirtualItems = [{ key: "row-0", index: 0, start: 0 }];
+
+    mockUseAirlineStore.mockReturnValue({
+      sellAircraft: vi.fn(),
+      buyoutAircraft: vi.fn(),
+      assignAircraftToRoute: vi.fn(),
+      listAircraft: vi.fn(),
+      cancelListing: vi.fn(),
+      ferryAircraft: vi.fn(),
+    });
+    mockUseActiveAirline.mockReturnValue({
+      airline: { hubs: ["JFK"] },
+      fleet: [
+        {
+          id: "ac-1",
+          name: "Tall Card Jet",
+          modelId: "a320neo",
+          status: "idle",
+          assignedRouteId: null,
+          baseAirportIata: "JFK",
+          configuration: { economy: 120, business: 0, first: 0, cargoKg: 0 },
+          condition: 1,
+          flightHoursTotal: 0,
+          flightHoursSinceCheck: 0,
+          purchaseType: "buy",
+          purchasedAtTick: 0,
+          birthTick: 0,
+          purchasePrice: 100000,
+          flight: null,
+        },
+      ],
+      routes: [],
+      timeline: [
+        {
+          type: "landing",
+          aircraftId: "ac-1",
+          originIata: "JFK",
+          destinationIata: "LAX",
+          profit: 1000,
+          details: {
+            flightDurationTicks: 1200,
+            loadFactor: 0.9,
+            passengers: { total: 100, economy: 100, business: 0, first: 0 },
+            spilledPassengers: 0,
+          },
+        },
+      ],
+      isViewingOther: false,
+    });
+    mockUseEngineStore.mockReturnValue({ tick: 0, tickProgress: 0 });
+
+    render(<FleetManager />);
+
+    expect(mockMeasureElement).toHaveBeenCalled();
+    expect(screen.getByText("Last Flight Outcome")).toBeInTheDocument();
+  });
+
   it("renders empty state when fleet is empty", () => {
     mockUseAirlineStore.mockReturnValue({
       sellAircraft: vi.fn(),
@@ -100,8 +187,10 @@ describe("FleetManager", () => {
     mockUseEngineStore.mockReturnValue({ tick: 0, tickProgress: 0 });
 
     render(<FleetManager />);
+
+    expect(mockMeasureElement).not.toHaveBeenCalled();
     expect(screen.getByText("Your hangar is empty")).toBeInTheDocument();
-    expect(screen.getByText("Purchase Aircraft")).toBeInTheDocument();
+    expect(screen.getByText("Open Global Marketplace")).toBeInTheDocument();
   });
 
   it("uses elasticity-adjusted load factor in route options", () => {

--- a/apps/web/src/features/fleet/components/FleetManager.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.tsx
@@ -32,6 +32,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getRouteDemandSnapshot } from "@/features/network/hooks/useRouteDemand";
+import { usePanelScrollRef } from "@/shared/components/layout/PanelLayout";
 import { navigateToAircraft, navigateToAirport } from "@/shared/lib/permalinkNavigation";
 import { useConfirm } from "@/shared/lib/useConfirm";
 import { cn } from "@/shared/lib/utils";
@@ -124,6 +125,7 @@ export function FleetManager() {
   const [listingError, setListingError] = useState<string | null>(null);
   const [isListing, setIsListing] = useState(false);
   const [ferryTargets, setFerryTargets] = useState<Record<string, string>>({});
+  const panelScrollRef = usePanelScrollRef();
   const fleetListRef = useRef<HTMLDivElement | null>(null);
   const [fleetColumns, setFleetColumns] = useState(1);
   const minListingPrice = fp(1000);
@@ -173,10 +175,11 @@ export function FleetManager() {
   const fleetRows = Math.ceil(filteredFleet.length / fleetColumns);
   const fleetVirtualizer = useVirtualizer({
     count: fleetRows,
-    getScrollElement: () => fleetListRef.current,
+    getScrollElement: () => panelScrollRef.current,
     estimateSize: () => 730,
     initialRect: { width: 1024, height: 1200 },
     overscan: 2,
+    scrollMargin: fleetListRef.current?.offsetTop ?? 0,
   });
   const virtualRows = fleetVirtualizer.getVirtualItems();
   const isVirtualized = virtualRows.length > 0;
@@ -275,7 +278,7 @@ export function FleetManager() {
         </div>
       </div>
 
-      <div ref={fleetListRef} className="custom-scrollbar h-[70vh] overflow-y-auto pb-8">
+      <div ref={fleetListRef} className="pb-8">
         {fleet.length === 0 ? (
           <div className="h-full flex flex-col items-center justify-center border-2 border-dashed border-border/50 rounded-2xl bg-card/10">
             <Plane className="h-12 w-12 text-muted-foreground mb-4 opacity-20" />
@@ -314,7 +317,11 @@ export function FleetManager() {
                     isVirtualized ? "absolute left-0 right-0 pb-4 sm:pb-6" : "pb-4 sm:pb-6"
                   }
                   style={
-                    isVirtualized ? { transform: `translateY(${virtualRow.start}px)` } : undefined
+                    isVirtualized
+                      ? {
+                          transform: `translateY(${virtualRow.start - fleetVirtualizer.options.scrollMargin}px)`,
+                        }
+                      : undefined
                   }
                 >
                   <div

--- a/apps/web/src/features/fleet/components/FleetManager.tsx
+++ b/apps/web/src/features/fleet/components/FleetManager.tsx
@@ -307,6 +307,8 @@ export function FleetManager() {
               return (
                 <div
                   key={virtualRow.key}
+                  data-index={virtualRow.index}
+                  ref={isVirtualized ? fleetVirtualizer.measureElement : undefined}
                   data-testid="fleet-row"
                   className={
                     isVirtualized ? "absolute left-0 right-0 pb-4 sm:pb-6" : "pb-4 sm:pb-6"

--- a/apps/web/src/features/network/components/RouteManager.test.tsx
+++ b/apps/web/src/features/network/components/RouteManager.test.tsx
@@ -3,6 +3,12 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { RouteManager } from "./RouteManager";
 
+vi.mock("@/shared/components/layout/PanelLayout", () => ({
+  PanelHeader: ({ title }: { title: string }) => <div>{title}</div>,
+  PanelBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  usePanelScrollRef: () => ({ current: null }),
+}));
+
 vi.mock("@/features/network/utils/routeEconomics", () => ({
   getPrimaryAssignedAircraft: vi.fn(() => null),
   estimateRouteEconomics: vi.fn(() => null),

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -47,7 +47,7 @@ import {
   estimateRouteEconomics,
   getPrimaryAssignedAircraft,
 } from "@/features/network/utils/routeEconomics";
-import { PanelHeader } from "@/shared/components/layout/PanelLayout";
+import { PanelHeader, usePanelScrollRef } from "@/shared/components/layout/PanelLayout";
 import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
 import { useConfirm } from "@/shared/lib/useConfirm";
 
@@ -544,6 +544,7 @@ export function RouteManager() {
   };
 
   // --- Virtualization (hooks must come before any conditional return) ---
+  const panelScrollRef = usePanelScrollRef();
   const listParentRef = useRef<HTMLDivElement>(null);
 
   const displayedOpportunities = useMemo(() => {
@@ -557,16 +558,18 @@ export function RouteManager() {
 
   const activeRoutesVirtualizer = useVirtualizer({
     count: activeRoutes.length,
-    getScrollElement: () => listParentRef.current,
+    getScrollElement: () => panelScrollRef.current,
     estimateSize: () => 420,
     overscan: 3,
+    scrollMargin: listParentRef.current?.offsetTop ?? 0,
   });
 
   const opportunitiesVirtualizer = useVirtualizer({
     count: displayedOpportunities.length,
-    getScrollElement: () => listParentRef.current,
+    getScrollElement: () => panelScrollRef.current,
     estimateSize: () => 220,
     overscan: 5,
+    scrollMargin: listParentRef.current?.offsetTop ?? 0,
   });
 
   if (!airline || !homeAirport || !planningOriginAirport) return null;
@@ -794,7 +797,7 @@ export function RouteManager() {
                 )}
               </div>
             ) : (
-              <div ref={listParentRef} className="h-[70vh] overflow-y-auto custom-scrollbar">
+              <div ref={listParentRef}>
                 <div
                   style={{
                     height: `${activeRoutesVirtualizer.getTotalSize()}px`,
@@ -884,7 +887,7 @@ export function RouteManager() {
                           top: 0,
                           left: 0,
                           width: "100%",
-                          transform: `translateY(${virtualItem.start}px)`,
+                          transform: `translateY(${virtualItem.start - activeRoutesVirtualizer.options.scrollMargin}px)`,
                         }}
                       >
                         <div className="group relative rounded-2xl bg-card border border-border overflow-hidden p-4 sm:p-5 transition-all hover:border-primary/50 hover:shadow-md mb-3">
@@ -1344,7 +1347,7 @@ export function RouteManager() {
               </div>
             )
           ) : (
-            <div ref={listParentRef} className="h-[70vh] overflow-y-auto custom-scrollbar">
+            <div ref={listParentRef}>
               <div
                 style={{
                   height: `${opportunitiesVirtualizer.getTotalSize()}px`,
@@ -1386,7 +1389,7 @@ export function RouteManager() {
                         top: 0,
                         left: 0,
                         width: "100%",
-                        transform: `translateY(${virtualItem.start}px)`,
+                        transform: `translateY(${virtualItem.start - opportunitiesVirtualizer.options.scrollMargin}px)`,
                       }}
                     >
                       <div className="group relative rounded-2xl bg-card border border-border overflow-hidden p-5 transition-all hover:border-primary/50 mb-4">

--- a/apps/web/src/routes/-corporate.lazy.test.tsx
+++ b/apps/web/src/routes/-corporate.lazy.test.tsx
@@ -9,6 +9,7 @@ vi.mock("@/shared/components/layout/PanelLayout", () => {
     PanelLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     PanelHeader: ({ title }: { title: string }) => <div>{title}</div>,
     PanelBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    usePanelScrollRef: () => ({ current: null }),
   };
 });
 

--- a/apps/web/src/routes/-fleet.lazy.test.tsx
+++ b/apps/web/src/routes/-fleet.lazy.test.tsx
@@ -29,6 +29,7 @@ vi.mock("@/shared/components/layout/PanelLayout", () => {
     PanelLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     PanelHeader: ({ title }: { title: string }) => <div>{title}</div>,
     PanelBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    usePanelScrollRef: () => ({ current: null }),
   };
 });
 

--- a/apps/web/src/routes/-leaderboard.lazy.test.tsx
+++ b/apps/web/src/routes/-leaderboard.lazy.test.tsx
@@ -7,6 +7,7 @@ vi.mock("@/shared/components/layout/PanelLayout", () => {
     PanelLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     PanelHeader: ({ title }: { title: string }) => <div>{title}</div>,
     PanelBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    usePanelScrollRef: () => ({ current: null }),
   };
 });
 

--- a/apps/web/src/routes/-network.lazy.test.tsx
+++ b/apps/web/src/routes/-network.lazy.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@acars/store", () => {
 vi.mock("@/shared/components/layout/PanelLayout", () => {
   return {
     PanelLayout: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    usePanelScrollRef: () => ({ current: null }),
   };
 });
 

--- a/apps/web/src/shared/components/layout/PanelLayout.tsx
+++ b/apps/web/src/shared/components/layout/PanelLayout.tsx
@@ -1,14 +1,35 @@
 import { useNavigate } from "@tanstack/react-router";
 import { X } from "lucide-react";
+import { createContext, useContext, useRef } from "react";
 import { cn } from "@/shared/lib/utils";
 
+const PanelScrollContext = createContext<React.RefObject<HTMLDivElement | null> | null>(null);
+
+/**
+ * Returns a ref to the PanelLayout scroll container.
+ * Use this as `getScrollElement` in useVirtualizer to share
+ * a single scroll surface with the panel header.
+ */
+export function usePanelScrollRef() {
+  const ref = useContext(PanelScrollContext);
+  if (!ref) throw new Error("usePanelScrollRef must be used inside a PanelLayout");
+  return ref;
+}
+
 export function PanelLayout({ children }: { children: React.ReactNode }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
   return (
-    <div className="pointer-events-auto relative flex h-full w-full min-w-0 max-w-2xl flex-col overflow-hidden rounded-[24px] border border-border/80 bg-background/85 shadow-[0_0_40px_rgba(0,0,0,0.6)] backdrop-blur-2xl duration-300 animate-in fade-in slide-in-from-left-4 sm:rounded-[28px]">
-      <div className="custom-scrollbar flex h-full w-full min-h-0 flex-col overflow-y-auto">
-        {children}
+    <PanelScrollContext.Provider value={scrollRef}>
+      <div className="pointer-events-auto relative flex h-full w-full min-w-0 max-w-2xl flex-col overflow-hidden rounded-[24px] border border-border/80 bg-background/85 shadow-[0_0_40px_rgba(0,0,0,0.6)] backdrop-blur-2xl duration-300 animate-in fade-in slide-in-from-left-4 sm:rounded-[28px]">
+        <div
+          ref={scrollRef}
+          className="custom-scrollbar flex h-full w-full min-h-0 flex-col overflow-y-auto"
+        >
+          {children}
+        </div>
       </div>
-    </div>
+    </PanelScrollContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary

- Uses PanelLayout's scroll container as the single scroll surface for all virtualized lists via React Context + `scrollMargin`
- Headers and filters now scroll away naturally while virtualizers track position correctly within the shared scroll area
- Eliminates the nested scroll containers that caused confusing touch behavior on mobile (touching cards would scroll only the inner list, not the whole panel)

## Changes

**PanelLayout.tsx**: Added `PanelScrollContext` and `usePanelScrollRef()` hook to expose the panel's scroll element to child components.

**Virtualized components updated**:
- `FleetManager.tsx`
- `AircraftDealer.tsx`
- `RouteManager.tsx` (both active routes and opportunities tabs)
- `Leaderboard.tsx`

Each now:
1. Calls `usePanelScrollRef()` to get the panel's scroll element
2. Passes it to `useVirtualizer({ getScrollElement: () => panelScrollRef.current, scrollMargin: ... })`
3. Removes `h-[70vh] overflow-y-auto` from the list container div
4. Adjusts `translateY` to account for `scrollMargin`

**Test mocks updated** (7 files): Added `usePanelScrollRef` and `options.scrollMargin` to mocks where needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified scroll container management across Leaderboard, Fleet Manager, Aircraft Dealer, and Route Manager components through a shared panel scroll reference system.
  * Adjusted virtualization calculations to properly account for scroll offsets in scrollable panels.

* **Tests**
  * Updated test mocks to support new panel scroll functionality across multiple features.
  * Added test case for virtualized list measurement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->