### PR TITLE
prepare Android release flow and polish mobile moderation UX

### DIFF
--- a/apps/web/src/app/AppInitializer.test.tsx
+++ b/apps/web/src/app/AppInitializer.test.tsx
@@ -4,15 +4,22 @@ import { AppInitializer } from "./AppInitializer";
 
 const mockUseAirlineStore = vi.hoisted(() => vi.fn());
 const mockUseEngineStore = vi.hoisted(() => vi.fn());
+const mockFindPreferredHub = vi.hoisted(() => vi.fn());
 
 type Selector<T> = (state: T) => unknown;
 type AirlineStoreState = {
   airline: unknown;
   identityStatus: string;
   initializeIdentity: () => void;
+  competitors: Map<string, unknown>;
 };
 type EngineStoreState = {
   homeAirport: unknown;
+  userLocation: {
+    latitude: number;
+    longitude: number;
+    source: "gps" | "timezone" | "manual";
+  } | null;
   setHub: (...args: unknown[]) => void;
   startEngine: () => void;
 };
@@ -25,10 +32,13 @@ vi.mock("@acars/store", () => {
     },
     { getState: () => mockUseAirlineStore() as AirlineStoreState },
   );
+  const useEngineStore = Object.assign(
+    (selector: Selector<EngineStoreState>) => selector(mockUseEngineStore() as EngineStoreState),
+    { getState: () => mockUseEngineStore() as EngineStoreState },
+  );
   return {
     useAirlineStore,
-    useEngineStore: (selector: Selector<EngineStoreState>) =>
-      selector(mockUseEngineStore() as EngineStoreState),
+    useEngineStore,
   };
 });
 
@@ -36,25 +46,33 @@ vi.mock("@acars/data", () => {
   return {
     airports: [
       { iata: "JFK", latitude: 0, longitude: 0, timezone: "UTC", city: "City", population: 1 },
+      { iata: "EWR", latitude: 1, longitude: 1, timezone: "UTC", city: "City", population: 1 },
     ],
-    findPreferredHub: () => ({ iata: "JFK", latitude: 0, longitude: 0 }),
+    findPreferredHub: mockFindPreferredHub,
   };
 });
 
 describe("AppInitializer", () => {
   const originalGeolocation = navigator.geolocation;
+  let airlineState: AirlineStoreState;
+  let engineState: EngineStoreState;
 
   beforeEach(() => {
-    mockUseAirlineStore.mockReturnValue({
+    airlineState = {
       airline: null,
       identityStatus: "ready",
       initializeIdentity: vi.fn(),
-    });
-    mockUseEngineStore.mockReturnValue({
+      competitors: new Map(),
+    };
+    engineState = {
       homeAirport: null,
+      userLocation: null,
       setHub: vi.fn(),
       startEngine: vi.fn(),
-    });
+    };
+    mockUseAirlineStore.mockImplementation(() => airlineState);
+    mockUseEngineStore.mockImplementation(() => engineState);
+    mockFindPreferredHub.mockReturnValue({ iata: "JFK", latitude: 0, longitude: 0 });
     (navigator as unknown as { geolocation?: Geolocation }).geolocation = undefined;
   });
 
@@ -65,11 +83,7 @@ describe("AppInitializer", () => {
 
   it("initializes identity on mount", () => {
     const initializeIdentity = vi.fn();
-    mockUseAirlineStore.mockReturnValue({
-      airline: null,
-      identityStatus: "ready",
-      initializeIdentity,
-    });
+    airlineState.initializeIdentity = initializeIdentity;
 
     (navigator as unknown as { geolocation?: Geolocation }).geolocation = {
       getCurrentPosition: vi.fn(),
@@ -89,11 +103,8 @@ describe("AppInitializer", () => {
   it("falls back to timezone when geolocation unavailable", () => {
     const setHub = vi.fn();
     const startEngine = vi.fn();
-    mockUseEngineStore.mockReturnValue({
-      homeAirport: null,
-      setHub,
-      startEngine,
-    });
+    engineState.setHub = setHub;
+    engineState.startEngine = startEngine;
     delete (navigator as unknown as { geolocation?: Geolocation }).geolocation;
 
     render(
@@ -103,6 +114,85 @@ describe("AppInitializer", () => {
     );
 
     expect(setHub).toHaveBeenCalled();
+    expect(startEngine).toHaveBeenCalled();
+  });
+
+  it("re-evaluates an occupied suggested hub once competitors and location are available", () => {
+    const setHub = vi.fn();
+    engineState.homeAirport = { iata: "JFK" };
+    engineState.userLocation = null;
+    engineState.setHub = setHub;
+    airlineState.competitors = new Map([["comp-1", { hubs: ["JFK"] }]]);
+    mockFindPreferredHub.mockReturnValue({ iata: "EWR", latitude: 1, longitude: 1 });
+
+    const view = render(
+      <AppInitializer>
+        <div>App</div>
+      </AppInitializer>,
+    );
+
+    expect(setHub).not.toHaveBeenCalledWith(
+      expect.objectContaining({ iata: "EWR" }),
+      expect.anything(),
+      "auto-distributed",
+    );
+
+    engineState.userLocation = { latitude: 40.6, longitude: -73.7, source: "gps" };
+    view.rerender(
+      <AppInitializer>
+        <div>App</div>
+      </AppInitializer>,
+    );
+
+    const lastFindCall =
+      mockFindPreferredHub.mock.calls[mockFindPreferredHub.mock.calls.length - 1];
+    expect(lastFindCall?.[0]).toBe(40.6);
+    expect(lastFindCall?.[1]).toBe(-73.7);
+    expect(lastFindCall?.[2]).toBeUndefined();
+    expect(lastFindCall?.[3]).toBeInstanceOf(Set);
+    expect((lastFindCall?.[3] as Set<string>).has("JFK")).toBe(true);
+    expect(setHub).toHaveBeenCalledWith(
+      expect.objectContaining({ iata: "EWR" }),
+      { latitude: 40.6, longitude: -73.7, source: "gps" },
+      "auto-distributed",
+    );
+  });
+
+  it("does not overwrite a manual hub while geolocation is still in flight", () => {
+    const setHub = vi.fn();
+    const startEngine = vi.fn();
+    let onSuccess: ((pos: GeolocationPosition) => void) | undefined;
+
+    engineState.setHub = setHub;
+    engineState.startEngine = startEngine;
+    (navigator as unknown as { geolocation?: Geolocation }).geolocation = {
+      getCurrentPosition: vi.fn((success: PositionCallback) => {
+        onSuccess = success;
+      }),
+      clearWatch: vi.fn(),
+      watchPosition: vi.fn(),
+    } as Geolocation;
+
+    render(
+      <AppInitializer>
+        <div>App</div>
+      </AppInitializer>,
+    );
+
+    engineState.userLocation = { latitude: 10, longitude: 20, source: "manual" };
+
+    onSuccess?.({
+      coords: {
+        latitude: 40.6,
+        longitude: -73.7,
+      },
+    } as GeolocationPosition);
+
+    expect(setHub).not.toHaveBeenCalledWith(
+      expect.objectContaining({ iata: "JFK" }),
+      expect.objectContaining({ source: "gps" }),
+      "GPS",
+    );
     expect(startEngine).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/AppInitializer.tsx
+++ b/apps/web/src/app/AppInitializer.tsx
@@ -2,7 +2,7 @@ import type { Airport } from "@acars/core";
 import { airports as AIRPORTS, findPreferredHub } from "@acars/data";
 import type { UserLocation } from "@acars/store";
 import { useAirlineStore, useEngineStore } from "@acars/store";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 /** Fallback: estimate location from UTC offset */
 function estimateLocationFromOffset(): UserLocation {
@@ -13,19 +13,26 @@ function estimateLocationFromOffset(): UserLocation {
 }
 
 /** IANA timezone detection */
-function findAirportByTimezone(): Airport | null {
+function findAirportByTimezone(occupiedIatas?: ReadonlySet<string>): Airport | null {
   try {
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
     const matches = AIRPORTS.filter((a) => a.timezone === tz);
     if (matches.length > 0) {
-      return [...matches].sort((a, b) => (b.population || 0) - (a.population || 0))[0];
+      const sorted = [...matches].sort((a, b) => (b.population || 0) - (a.population || 0));
+      const available = occupiedIatas ? sorted.find((a) => !occupiedIatas.has(a.iata)) : sorted[0];
+      if (available) return available;
+      // All timezone matches occupied — fall through to city match
     }
 
     const tzCity = tz.split("/").pop()?.replace(/_/g, " ").toLowerCase();
     if (tzCity) {
       const cityMatches = AIRPORTS.filter((a) => a.city.toLowerCase() === tzCity);
       if (cityMatches.length > 0) {
-        return [...cityMatches].sort((a, b) => (b.population || 0) - (a.population || 0))[0];
+        const sorted = [...cityMatches].sort((a, b) => (b.population || 0) - (a.population || 0));
+        const available = occupiedIatas
+          ? sorted.find((a) => !occupiedIatas.has(a.iata))
+          : sorted[0];
+        if (available) return available;
       }
     }
     return null;
@@ -34,16 +41,44 @@ function findAirportByTimezone(): Airport | null {
   }
 }
 
+/** Collect all IATA codes used as hubs by competitor airlines. */
+function collectOccupiedHubs(
+  competitors: ReadonlyMap<string, { hubs: readonly string[] }>,
+): Set<string> {
+  const occupied = new Set<string>();
+  competitors.forEach((airline) => {
+    for (const hub of airline.hubs) {
+      occupied.add(hub);
+    }
+  });
+  return occupied;
+}
+
 export function AppInitializer({ children }: { children: React.ReactNode }) {
   const { airline, initializeIdentity } = useAirlineStore();
   const identityStatus = useAirlineStore((s) => s.identityStatus);
+  const competitors = useAirlineStore((s) => s.competitors);
   const homeAirport = useEngineStore((s) => s.homeAirport);
+  const userLocation = useEngineStore((s) => s.userLocation);
   const setHub = useEngineStore((s) => s.setHub);
   const startEngine = useEngineStore((s) => s.startEngine);
+
+  // Track whether the user has manually picked a hub via HubPicker.
+  // When they do, we must not override their choice.
+  const userManuallyPickedHub = useRef(false);
+
+  const isHubSelectionLocked = () =>
+    userManuallyPickedHub.current || useEngineStore.getState().userLocation?.source === "manual";
 
   useEffect(() => {
     initializeIdentity();
   }, [initializeIdentity]);
+
+  useEffect(() => {
+    if (userLocation?.source === "manual") {
+      userManuallyPickedHub.current = true;
+    }
+  }, [userLocation]);
 
   // Once airline loads from Nostr, authoritatively set engine hub to hubs[0].
   // This takes priority over any geo-detection that may have run first.
@@ -70,6 +105,10 @@ export function AppInitializer({ children }: { children: React.ReactNode }) {
     const fallbackLocate = () => {
       // Guard: airline may have loaded while geo was pending
       if (useAirlineStore.getState().airline) return;
+      if (isHubSelectionLocked()) {
+        startEngine();
+        return;
+      }
 
       const tzAirport = findAirportByTimezone();
       if (tzAirport) {
@@ -92,6 +131,10 @@ export function AppInitializer({ children }: { children: React.ReactNode }) {
         (pos) => {
           // Guard: airline may have loaded while geo was pending
           if (useAirlineStore.getState().airline) return;
+          if (isHubSelectionLocked()) {
+            startEngine();
+            return;
+          }
 
           const loc: UserLocation = {
             latitude: pos.coords.latitude,
@@ -109,6 +152,33 @@ export function AppInitializer({ children }: { children: React.ReactNode }) {
       fallbackLocate();
     }
   }, [homeAirport, identityStatus, airline, setHub, startEngine]);
+
+  // Re-evaluate the suggested hub once competitor data loads from Nostr.
+  // This only fires for new users who haven't created an airline yet and
+  // haven't manually selected a hub via the HubPicker.
+  useEffect(() => {
+    if (airline) return; // Returning user — don't touch their hub
+    if (competitors.size === 0) return; // No competitor data yet
+    if (!userLocation || !homeAirport) return;
+
+    // Check if the user manually picked a hub (source === "manual")
+    if (userLocation.source === "manual") {
+      userManuallyPickedHub.current = true;
+      return;
+    }
+    if (userManuallyPickedHub.current) return;
+
+    const occupied = collectOccupiedHubs(competitors);
+    if (occupied.size === 0) return;
+    if (!occupied.has(homeAirport.iata)) return; // Current suggestion is fine
+
+    // Re-run hub suggestion with competitor awareness
+    const { latitude, longitude } = userLocation;
+    const better = findPreferredHub(latitude, longitude, undefined, occupied);
+    if (better.iata !== homeAirport.iata) {
+      setHub(better, { latitude, longitude, source: userLocation.source }, "auto-distributed");
+    }
+  }, [airline, competitors, homeAirport, userLocation, setHub]);
 
   return <>{children}</>;
 }

--- a/packages/data/src/geo.test.ts
+++ b/packages/data/src/geo.test.ts
@@ -1,45 +1,137 @@
-import { describe, it, expect } from 'vitest';
-import { findPreferredHub } from './geo.js';
+import { describe, it, expect } from "vitest";
+import { findPreferredHub } from "./geo.js";
 
 const airports = [
-    { iata: 'SM1', country: 'AA', latitude: 10, longitude: 10, population: 100000 },
-    { iata: 'SM2', country: 'AA', latitude: 12, longitude: 10, population: 200000 },
-    { iata: 'BIG', country: 'AA', latitude: 30, longitude: 30, population: 1000000 },
-    { iata: 'BIG2', country: 'AA', latitude: 31, longitude: 30, population: 1000000 },
-    { iata: 'FAR', country: 'AA', latitude: 80, longitude: 80, population: 900000 },
-    { iata: 'BB1', country: 'BB', latitude: -10, longitude: -10, population: 900000 },
-    { iata: 'BB2', country: 'BB', latitude: -11, longitude: -11, population: 1000000 },
-    { iata: 'NONE', country: 'CC', latitude: 5, longitude: 5, population: 0 },
-    { iata: 'NONE2', country: 'CC', latitude: 6, longitude: 6, population: 0 },
+  { iata: "SM1", country: "AA", latitude: 10, longitude: 10, population: 100000 },
+  { iata: "SM2", country: "AA", latitude: 12, longitude: 10, population: 200000 },
+  { iata: "BIG", country: "AA", latitude: 30, longitude: 30, population: 1000000 },
+  { iata: "BIG2", country: "AA", latitude: 31, longitude: 30, population: 1000000 },
+  { iata: "FAR", country: "AA", latitude: 80, longitude: 80, population: 900000 },
+  { iata: "BB1", country: "BB", latitude: -10, longitude: -10, population: 900000 },
+  { iata: "BB2", country: "BB", latitude: -11, longitude: -11, population: 1000000 },
+  { iata: "NONE", country: "CC", latitude: 5, longitude: 5, population: 0 },
+  { iata: "NONE2", country: "CC", latitude: 6, longitude: 6, population: 0 },
 ] as const;
 
-describe('findPreferredHub', () => {
-    it('prefers largest city in nearest country', () => {
-        const result = findPreferredHub(10.2, 10.1, airports as any);
-        expect(result.iata).toBe('BIG');
-    });
+describe("findPreferredHub", () => {
+  it("prefers largest city in nearest country", () => {
+    const result = findPreferredHub(10.2, 10.1, airports as any);
+    expect(result.iata).toBe("BIG");
+  });
 
-    it('uses distance to break ties for largest city', () => {
-        const result = findPreferredHub(30.6, 30.0, airports as any);
-        expect(result.iata).toBe('BIG2');
-    });
+  it("uses distance to break ties for largest city", () => {
+    const result = findPreferredHub(30.6, 30.0, airports as any);
+    expect(result.iata).toBe("BIG2");
+  });
 
-    it('falls back to nearest when country population missing', () => {
-        const result = findPreferredHub(5.1, 5.1, airports as any);
-        expect(result.iata).toBe('NONE');
-    });
+  it("falls back to nearest when country population missing", () => {
+    const result = findPreferredHub(5.1, 5.1, airports as any);
+    expect(result.iata).toBe("NONE");
+  });
 
-    it('chooses nearest country by geography, not max population', () => {
-        const result = findPreferredHub(-10.2, -10.1, airports as any);
-        expect(result.country).toBe('BB');
-    });
+  it("chooses nearest country by geography, not max population", () => {
+    const result = findPreferredHub(-10.2, -10.1, airports as any);
+    expect(result.country).toBe("BB");
+  });
 
-    it('returns nearest when country is unknown', () => {
-        const unknownAirports = [
-            { iata: 'UNK1', country: 'XX', latitude: 1, longitude: 1, population: 100 },
-            { iata: 'UNK2', country: 'XX', latitude: 2, longitude: 2, population: 200 },
-        ] as const;
-        const result = findPreferredHub(1.1, 1.1, unknownAirports as any);
-        expect(result.iata).toBe('UNK1');
-    });
+  it("returns nearest when country is unknown", () => {
+    const unknownAirports = [
+      { iata: "UNK1", country: "XX", latitude: 1, longitude: 1, population: 100 },
+      { iata: "UNK2", country: "XX", latitude: 2, longitude: 2, population: 200 },
+    ] as const;
+    const result = findPreferredHub(1.1, 1.1, unknownAirports as any);
+    expect(result.iata).toBe("UNK1");
+  });
+
+  it("behaves identically when occupiedIatas is empty", () => {
+    const result = findPreferredHub(10.2, 10.1, airports as any, new Set());
+    expect(result.iata).toBe("BIG");
+  });
+
+  it("skips occupied largest city and falls back to second largest in-country", () => {
+    const occupied = new Set(["BIG", "BIG2"]);
+    const result = findPreferredHub(10.2, 10.1, airports as any, occupied);
+    // FAR (900k) > SM2 (200k) > SM1 (100k)
+    expect(result.iata).toBe("FAR");
+  });
+
+  it("skips occupied airports in order and picks next biggest", () => {
+    const occupied = new Set(["BIG", "BIG2", "FAR"]);
+    const result = findPreferredHub(10.2, 10.1, airports as any, occupied);
+    // SM2 (200k) > SM1 (100k)
+    expect(result.iata).toBe("SM2");
+  });
+
+  it("expands globally when all in-country airports are occupied", () => {
+    const occupied = new Set(["BIG", "BIG2", "FAR", "SM1", "SM2"]);
+    // User near AA (lat 10, lon 10) — all AA airports occupied.
+    // BB1 (-10,-10) pop 900k, BB2 (-11,-11) pop 1M → BB2 wins on population/distance score.
+    const result = findPreferredHub(10.2, 10.1, airports as any, occupied);
+    expect(result.country).toBe("BB");
+  });
+
+  it("falls back to biggest in-country when everything globally is occupied", () => {
+    const allIatas = new Set(airports.map((a) => a.iata));
+    const result = findPreferredHub(10.2, 10.1, airports as any, allIatas);
+    // Falls back to the biggest city in nearest country (BIG)
+    expect(result.iata).toBe("BIG");
+  });
+
+  it("keeps zero-population domestic airports in the in-country fallback", () => {
+    const result = findPreferredHub(5.1, 5.1, airports as any, new Set(["NONE"]));
+    expect(result.iata).toBe("NONE2");
+  });
+
+  it("prefers close smaller city over far megacity when expanding globally", () => {
+    // Airports: close small city vs far megacity
+    const testAirports = [
+      { iata: "HOME", country: "XX1", latitude: 0, longitude: 0, population: 500000 },
+      { iata: "NEAR", country: "YY", latitude: 2, longitude: 2, population: 800000 },
+      { iata: "MEGA", country: "ZZ", latitude: 60, longitude: 60, population: 5000000 },
+    ] as const;
+    const occupied = new Set(["HOME"]);
+    const result = findPreferredHub(0.1, 0.1, testAirports as any, occupied);
+    // NEAR is much closer → score(NEAR) should beat score(MEGA)
+    expect(result.iata).toBe("NEAR");
+  });
+
+  it("distributes Colombian-style scenario across cities", () => {
+    // Simulates the exact user scenario: multiple friends in Colombia
+    const colombiaAirports = [
+      { iata: "BOG", country: "CO", latitude: 4.7, longitude: -74.14, population: 7400000 },
+      { iata: "MDE", country: "CO", latitude: 6.17, longitude: -75.43, population: 2500000 },
+      { iata: "CLO", country: "CO", latitude: 3.54, longitude: -76.38, population: 2200000 },
+      { iata: "BAQ", country: "CO", latitude: 10.89, longitude: -74.78, population: 1200000 },
+      { iata: "CTG", country: "CO", latitude: 10.39, longitude: -75.51, population: 900000 },
+    ] as const;
+
+    // All users are near Bogota
+    const lat = 4.65;
+    const lon = -74.1;
+
+    // First user → Bogota (biggest)
+    const r1 = findPreferredHub(lat, lon, colombiaAirports as any, new Set());
+    expect(r1.iata).toBe("BOG");
+
+    // Second user → Medellin (second biggest)
+    const r2 = findPreferredHub(lat, lon, colombiaAirports as any, new Set(["BOG"]));
+    expect(r2.iata).toBe("MDE");
+
+    // Third user → Cali (third biggest)
+    const r3 = findPreferredHub(lat, lon, colombiaAirports as any, new Set(["BOG", "MDE"]));
+    expect(r3.iata).toBe("CLO");
+
+    // Fourth user → Barranquilla
+    const r4 = findPreferredHub(lat, lon, colombiaAirports as any, new Set(["BOG", "MDE", "CLO"]));
+    expect(r4.iata).toBe("BAQ");
+
+    // Fifth user → Cartagena
+    const r5 = findPreferredHub(
+      lat,
+      lon,
+      colombiaAirports as any,
+      new Set(["BOG", "MDE", "CLO", "BAQ"]),
+    );
+    expect(r5.iata).toBe("CTG");
+  });
 });

--- a/packages/data/src/geo.ts
+++ b/packages/data/src/geo.ts
@@ -3,13 +3,49 @@ import { haversineDistance } from "@acars/core";
 import { airports as AIRPORTS } from "./airports.js";
 
 /**
- * Find the best hub near a location: largest city in nearest country,
- * with distance as a tie-breaker.
+ * Reference distance (km) used to normalise the distance penalty when
+ * scoring airports outside the user's home country.  An airport this far
+ * away receives half of its raw population score.
+ */
+const DISTANCE_REF_KM = 500;
+
+function isBetterHubCandidate(
+  candidate: Airport,
+  candidateDistance: number,
+  current: Airport,
+  currentDistance: number,
+): boolean {
+  const candidatePopulation = candidate.population || 0;
+  const currentPopulation = current.population || 0;
+  return (
+    candidatePopulation > currentPopulation ||
+    (candidatePopulation === currentPopulation && candidateDistance < currentDistance)
+  );
+}
+
+/**
+ * Find the best hub near a location, avoiding airports that already have
+ * a competitor hub.
+ *
+ * Algorithm:
+ * 1. Determine the user's country from the geographically nearest airport.
+ * 2. Within that country, pick the most-populated **unoccupied** airport
+ *    (distance breaks ties).
+ * 3. If every airport in the country is occupied, score **all** unoccupied
+ *    airports globally with `population / (1 + distance_km / 500)` so that
+ *    nearby-but-smaller cities rank higher than far-away megacities.
+ * 4. If every airport worldwide is occupied (or no population data exists),
+ *    fall back to the original biggest-city-in-country logic.
  */
 export function findPreferredHub(
   lat: number,
   lon: number,
   airports: Airport[] = AIRPORTS,
+  /** IATA codes of airports that already serve as a competitor airline's hub.
+   *  When provided, the algorithm prefers unoccupied airports so that new
+   *  players are distributed across cities instead of clustering at the
+   *  biggest airport. */
+  occupiedIatas?: ReadonlySet<string>,
 ): Airport {
   let nearest = airports[0];
   let minDist = Infinity;
@@ -25,28 +61,65 @@ export function findPreferredHub(
   if (country === "XX") {
     return nearest;
   }
+
+  const occupied = occupiedIatas ?? new Set<string>();
   const countryAirports = airports.filter((a) => a.country === country);
-  const populated = countryAirports.filter((a) => (a.population || 0) > 0);
+  if (countryAirports.length > 0) {
+    let bestInCountry = countryAirports[0];
+    let bestInCountryDistance = haversineDistance(
+      lat,
+      lon,
+      bestInCountry.latitude,
+      bestInCountry.longitude,
+    );
+    let bestAvailable = occupied.has(countryAirports[0].iata) ? null : countryAirports[0];
+    let bestAvailableDistance = bestAvailable ? bestInCountryDistance : Infinity;
 
-  if (populated.length > 0) {
-    let maxPopulation = 0;
-    for (const airport of populated) {
-      const pop = airport.population || 0;
-      if (pop > maxPopulation) maxPopulation = pop;
-    }
+    for (let index = 1; index < countryAirports.length; index += 1) {
+      const airport = countryAirports[index];
+      const distance = haversineDistance(lat, lon, airport.latitude, airport.longitude);
 
-    const topByPopulation = populated.filter((a) => (a.population || 0) === maxPopulation);
+      if (isBetterHubCandidate(airport, distance, bestInCountry, bestInCountryDistance)) {
+        bestInCountry = airport;
+        bestInCountryDistance = distance;
+      }
 
-    let best = topByPopulation[0];
-    let bestDist = Infinity;
-    for (const airport of topByPopulation) {
-      const dist = haversineDistance(lat, lon, airport.latitude, airport.longitude);
-      if (dist < bestDist) {
-        bestDist = dist;
-        best = airport;
+      if (occupied.has(airport.iata)) continue;
+      if (!bestAvailable) {
+        bestAvailable = airport;
+        bestAvailableDistance = distance;
+        continue;
+      }
+
+      if (isBetterHubCandidate(airport, distance, bestAvailable, bestAvailableDistance)) {
+        bestAvailable = airport;
+        bestAvailableDistance = distance;
       }
     }
-    return best;
+
+    if (bestAvailable) return bestAvailable;
+
+    // All in-country airports occupied — expand globally
+    const globalCandidates = airports.filter(
+      (a) => (a.population || 0) > 0 && !occupied.has(a.iata),
+    );
+
+    if (globalCandidates.length > 0) {
+      let bestScore = -Infinity;
+      let best = globalCandidates[0];
+      for (const airport of globalCandidates) {
+        const dist = haversineDistance(lat, lon, airport.latitude, airport.longitude);
+        const score = (airport.population || 0) / (1 + dist / DISTANCE_REF_KM);
+        if (score > bestScore) {
+          bestScore = score;
+          best = airport;
+        }
+      }
+      return best;
+    }
+
+    // Every airport worldwide is occupied — fall back to biggest in-country
+    return bestInCountry;
   }
 
   return nearest;


### PR DESCRIPTION
## Summary
- prepare ACARS for Android release with signed-build scaffolding, generated launcher and splash assets, in-app privacy and terms routes, and a documented local JDK/SDK/signing workflow
- add mobile-friendly NIP-46 remote signer onboarding plus policy scaffolding for airline creation, reporting, and local block management
- merge the latest `main`, adopt the compact mobile bottom-nav labels, and add an unblock manager in `Info > About` so mistaken local blocks can always be undone

## Verification
- pnpm --filter @acars/web test -- --run Sidebar.test.tsx \"src/routes/-about.lazy.test.tsx\" AirlineModerationActions.test.tsx
- pnpm --filter @acars/store test -- --run worldSlice.test.ts
- pnpm --filter @acars/web typecheck
- pnpm --filter @acars/web build
- export JAVA_HOME=\"/home/ana/.local/share/jdks/jdk-21.0.10+7\" && ./gradlew :app:assembleRelease