### PR TITLE
feat: add frictionless Nostr onboarding

### DIFF
--- a/apps/web/src/features/competition/components/Leaderboard.test.tsx
+++ b/apps/web/src/features/competition/components/Leaderboard.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Leaderboard } from "./Leaderboard";
 
 vi.mock("@/shared/components/layout/panelScrollContext", () => ({
@@ -20,6 +20,8 @@ type EngineStoreState = { tick: number };
 
 const mockUseAirlineStore = vi.fn();
 const mockUseEngineStore = vi.fn();
+const mockBuildLeaderboardRows = vi.fn();
+const mockSortLeaderboardRows = vi.fn((...args) => args[0]);
 
 vi.mock("@acars/store", () => {
   return {
@@ -32,22 +34,13 @@ vi.mock("@acars/store", () => {
 
 vi.mock("@/features/competition/leaderboardMetrics", () => {
   return {
-    buildLeaderboardRows: () => [
-      {
-        id: "airline-1",
-        name: "Test Air",
-        icaoCode: "TST",
-        ceoPubkey: "pubkey",
-        liveryPrimary: "#ff3333",
-        balance: 0,
-        fleet: 1,
-        routes: 2,
-        brand: 0.5,
-        fleetValue: 0,
-        networkDistance: 1000,
-      },
-    ],
-    sortLeaderboardRows: <T,>(rows: T) => rows,
+    buildLeaderboardRows: (
+      airlines: unknown,
+      aircraftById: unknown,
+      routeById: unknown,
+      currentTick: unknown,
+    ) => mockBuildLeaderboardRows(airlines, aircraftById, routeById, currentTick),
+    sortLeaderboardRows: (rows: unknown, metric: unknown) => mockSortLeaderboardRows(rows, metric),
   };
 });
 
@@ -83,7 +76,30 @@ vi.mock("@/shared/hooks/useNostrProfile", () => {
 });
 
 describe("Leaderboard", () => {
+  beforeEach(() => {
+    mockUseAirlineStore.mockReset();
+    mockUseEngineStore.mockReset();
+    mockBuildLeaderboardRows.mockReset();
+    mockSortLeaderboardRows.mockReset();
+    mockSortLeaderboardRows.mockImplementation((rows) => rows);
+  });
+
   it("renders rows and toggles metrics", () => {
+    mockBuildLeaderboardRows.mockReturnValue([
+      {
+        id: "airline-1",
+        name: "Test Air",
+        icaoCode: "TST",
+        ceoPubkey: "pubkey",
+        liveryPrimary: "#ff3333",
+        balance: 0,
+        fleet: 1,
+        routes: 2,
+        brand: 0.5,
+        fleetValue: 0,
+        networkDistance: 1000,
+      },
+    ]);
     mockUseAirlineStore.mockReturnValue({
       competitors: new Map(),
       airline: { id: "airline-1" },
@@ -102,5 +118,23 @@ describe("Leaderboard", () => {
       target: { value: "fleet" },
     });
     expect(screen.getAllByText("Fleet Size").length).toBeGreaterThan(0);
+  });
+
+  it("renders an empty state when no airlines qualify for the leaderboard", () => {
+    mockBuildLeaderboardRows.mockReturnValue([]);
+    mockUseAirlineStore.mockReturnValue({
+      competitors: new Map(),
+      airline: { id: "airline-1" },
+      fleet: [],
+      routes: [],
+      fleetByOwner: new Map(),
+      routesByOwner: new Map(),
+      viewAs: vi.fn(),
+    });
+    mockUseEngineStore.mockReturnValue({ tick: 0 });
+
+    render(<Leaderboard />);
+
+    expect(screen.getByText("No active airlines on the board yet")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/competition/components/Leaderboard.tsx
+++ b/apps/web/src/features/competition/components/Leaderboard.tsx
@@ -277,47 +277,58 @@ export function Leaderboard() {
         </div>
       </div>
 
-      <div ref={parentRef}>
-        <div className="relative" style={{ height: `${virtualizer.getTotalSize()}px` }}>
-          {virtualizer.getVirtualItems().map((virtualRow) => {
-            const row = rows[virtualRow.index];
-            if (!row) return null;
-            const isOwn = ownId === row.id;
-            const value =
-              metric === "balance"
-                ? row.balance
-                : metric === "fleet"
-                  ? row.fleet
-                  : metric === "routes"
-                    ? row.routes
-                    : metric === "brand"
-                      ? row.brand
-                      : metric === "fleetValue"
-                        ? row.fleetValue
-                        : row.networkDistance;
-            return (
-              <div
-                key={virtualRow.key}
-                data-index={virtualRow.index}
-                ref={virtualizer.measureElement}
-                className="absolute left-0 right-0 pb-2"
-                style={{
-                  transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
-                }}
-              >
-                <LeaderboardRow
-                  row={row}
-                  index={virtualRow.index}
-                  isOwn={isOwn}
-                  metric={metric}
-                  value={value}
-                  onView={viewAs}
-                />
-              </div>
-            );
-          })}
+      {rows.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-border/60 bg-background/40 px-4 py-8 text-center">
+          <p className="text-sm font-semibold text-foreground">
+            No active airlines on the board yet
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Airlines appear here once they launch aircraft, open routes, or log real activity.
+          </p>
         </div>
-      </div>
+      ) : (
+        <div ref={parentRef}>
+          <div className="relative" style={{ height: `${virtualizer.getTotalSize()}px` }}>
+            {virtualizer.getVirtualItems().map((virtualRow) => {
+              const row = rows[virtualRow.index];
+              if (!row) return null;
+              const isOwn = ownId === row.id;
+              const value =
+                metric === "balance"
+                  ? row.balance
+                  : metric === "fleet"
+                    ? row.fleet
+                    : metric === "routes"
+                      ? row.routes
+                      : metric === "brand"
+                        ? row.brand
+                        : metric === "fleetValue"
+                          ? row.fleetValue
+                          : row.networkDistance;
+              return (
+                <div
+                  key={virtualRow.key}
+                  data-index={virtualRow.index}
+                  ref={virtualizer.measureElement}
+                  className="absolute left-0 right-0 pb-2"
+                  style={{
+                    transform: `translateY(${virtualRow.start - virtualizer.options.scrollMargin}px)`,
+                  }}
+                >
+                  <LeaderboardRow
+                    row={row}
+                    index={virtualRow.index}
+                    isOwn={isOwn}
+                    metric={metric}
+                    value={value}
+                    onView={viewAs}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/features/competition/leaderboardMetrics.test.ts
+++ b/apps/web/src/features/competition/leaderboardMetrics.test.ts
@@ -1,4 +1,4 @@
-import type { AircraftInstance, AirlineEntity, Route } from "@acars/core";
+import type { AircraftInstance, AirlineEntity, Route, TimelineEvent } from "@acars/core";
 import { fp } from "@acars/core";
 import { describe, expect, it } from "vitest";
 import {
@@ -105,6 +105,27 @@ describe("leaderboardMetrics", () => {
     expect(rows[0].routes).toBe(1);
     expect(rows[0].networkDistance).toBe(987);
     expect(rows[0].fleetValue).toBeGreaterThan(0);
+  });
+
+  it("filters brand-new airlines with no assets or activity", () => {
+    const historyEvent: TimelineEvent = {
+      id: "evt-1",
+      tick: 12,
+      timestamp: 1700000000,
+      type: "purchase",
+      description: "Bought a starter aircraft",
+    };
+    const rows = buildLeaderboardRows(
+      [
+        makeAirline({ id: "inactive-shell" }),
+        makeAirline({ id: "historical-airline", timeline: [historyEvent] }),
+      ],
+      new Map(),
+      new Map(),
+      0,
+    );
+
+    expect(rows.map((row) => row.id)).toEqual(["historical-airline"]);
   });
 
   it("sorts leaderboard rows by fleet value", () => {

--- a/apps/web/src/features/competition/leaderboardMetrics.ts
+++ b/apps/web/src/features/competition/leaderboardMetrics.ts
@@ -55,13 +55,22 @@ export function computeNetworkDistance(routeIds: string[], routeById: Map<string
   }, 0);
 }
 
+export function hasLeaderboardActivity(entry: AirlineEntity): boolean {
+  return (
+    entry.fleetIds.length > 0 ||
+    entry.routeIds.length > 0 ||
+    entry.cumulativeRevenue > 0 ||
+    (entry.timeline?.length ?? 0) > 0
+  );
+}
+
 export function buildLeaderboardRows(
   airlines: AirlineEntity[],
   aircraftById: Map<string, AircraftInstance>,
   routeById: Map<string, Route>,
   currentTick: number,
 ): LeaderboardRow[] {
-  return airlines.map((entry) => ({
+  return airlines.filter(hasLeaderboardActivity).map((entry) => ({
     id: entry.id,
     name: entry.name,
     icaoCode: entry.icaoCode,

--- a/apps/web/src/features/identity/components/AirlineCreator.test.tsx
+++ b/apps/web/src/features/identity/components/AirlineCreator.test.tsx
@@ -70,7 +70,8 @@ describe("AirlineCreator", () => {
     });
 
     render(<AirlineCreator />);
-    expect(screen.getByText("JFK")).toBeInTheDocument();
+    expect(screen.getByText("Launch Your Airline")).toBeInTheDocument();
+    expect(screen.getAllByText("JFK").length).toBeGreaterThan(0);
     expect(screen.getByText(/John F Kennedy International/)).toBeInTheDocument();
   });
 
@@ -96,7 +97,7 @@ describe("AirlineCreator", () => {
     });
 
     render(<AirlineCreator />);
-    const submit = screen.getAllByRole("button", { name: /Establish Corporation/i })[0];
+    const submit = screen.getAllByRole("button", { name: /Launch Airline/i })[0];
     expect(submit).toBeDisabled();
 
     fireEvent.change(screen.getAllByPlaceholderText("Apex Global")[0], {

--- a/apps/web/src/features/identity/components/AirlineCreator.test.tsx
+++ b/apps/web/src/features/identity/components/AirlineCreator.test.tsx
@@ -9,6 +9,7 @@ type AirlineStoreState = {
   isLoading: boolean;
   error: unknown;
   competitors: Map<string, unknown>;
+  isEphemeral?: boolean;
 };
 type EngineStoreState = {
   homeAirport: {
@@ -27,7 +28,10 @@ const mockUseEngineStore = vi.fn();
 
 vi.mock("@acars/store", () => {
   return {
-    useAirlineStore: () => mockUseAirlineStore() as AirlineStoreState,
+    useAirlineStore: (selector?: Selector<AirlineStoreState>) => {
+      const state = mockUseAirlineStore() as AirlineStoreState;
+      return selector ? selector(state) : state;
+    },
     useEngineStore: (selector: Selector<EngineStoreState>) =>
       selector(mockUseEngineStore() as EngineStoreState),
   };
@@ -38,6 +42,12 @@ vi.mock("../../network/components/HubPicker", () => {
     HubPicker: ({ currentHub }: { currentHub: { iata: string } | null }) => (
       <div>Hub Picker {currentHub?.iata ?? "none"}</div>
     ),
+  };
+});
+
+vi.mock("./EphemeralKeyBackupActions", () => {
+  return {
+    EphemeralKeyBackupActions: () => <div>Backup Actions</div>,
   };
 });
 
@@ -105,5 +115,33 @@ describe("AirlineCreator", () => {
     });
     fireEvent.change(screen.getAllByPlaceholderText("APX")[0], { target: { value: "apx" } });
     expect(submit).not.toBeDisabled();
+  });
+
+  it("shows account key tools for ephemeral identities", () => {
+    mockUseAirlineStore.mockReturnValue({
+      createAirline: vi.fn(),
+      identityStatus: "ready",
+      isLoading: false,
+      error: null,
+      competitors: new Map(),
+      isEphemeral: true,
+    });
+
+    mockUseEngineStore.mockReturnValue({
+      homeAirport: {
+        iata: "JFK",
+        city: "New York",
+        name: "John F Kennedy International",
+        latitude: 0,
+        longitude: 0,
+        country: "US",
+      },
+      setHub: vi.fn(),
+    });
+
+    render(<AirlineCreator />);
+    fireEvent.click(screen.getByRole("button", { name: /Account key/i }));
+
+    expect(screen.getByText("Backup Actions")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/identity/components/AirlineCreator.tsx
+++ b/apps/web/src/features/identity/components/AirlineCreator.tsx
@@ -23,6 +23,9 @@ export function AirlineCreator() {
     () => findAirlineConflicts(competitors, name, icao),
     [competitors, name, icao],
   );
+  const hubPricing = homeAirport ? getHubPricingForIata(homeAirport.iata) : null;
+  const normalizedIcao = icao.toUpperCase();
+  const suggestedCallsign = callsign || (normalizedIcao ? `${normalizedIcao} HEAVY` : "APX HEAVY");
 
   const handleHubChange = (airport: Airport | null) => {
     if (!airport) return;
@@ -40,8 +43,8 @@ export function AirlineCreator() {
     try {
       await createAirline({
         name,
-        icaoCode: icao.toUpperCase(),
-        callsign: callsign || icao.toUpperCase() + " HEAVY",
+        icaoCode: normalizedIcao,
+        callsign: suggestedCallsign,
         hubs: [homeAirport.iata],
         livery: {
           primary,
@@ -65,20 +68,22 @@ export function AirlineCreator() {
   }
 
   return (
-    <div className="w-full max-w-2xl mx-auto backdrop-blur-md bg-card/80 border border-border shadow-2xl rounded-2xl overflow-hidden">
-      <div className="bg-muted px-8 py-6 border-b border-border flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold tracking-tight text-foreground flex items-center">
-            <PlaneTakeoff className="mr-3 h-6 w-6 text-primary" />
-            Found Corporate Entity
-          </h2>
-          <p className="text-sm text-muted-foreground mt-1">
-            Establish your global airline identity on the Nostr network.
-          </p>
+    <div className="mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-border bg-card/80 shadow-2xl backdrop-blur-md">
+      <div className="border-b border-border bg-muted px-8 py-6">
+        <div className="mb-3 inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+          Connected - create your airline
         </div>
+        <h2 className="flex items-center text-2xl font-bold tracking-tight text-foreground">
+          <PlaneTakeoff className="mr-3 h-6 w-6 text-primary" />
+          Launch Your Airline
+        </h2>
+        <p className="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground">
+          Pick a home hub, name your carrier, and choose its colors. You can be ready to operate in
+          under a minute.
+        </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="p-8 space-y-8">
+      <form onSubmit={handleSubmit} className="space-y-6 p-8">
         {error && (
           <div className="p-4 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start">
             <ShieldAlert className="h-5 w-5 text-destructive mr-3 mt-0.5 shrink-0" />
@@ -89,51 +94,81 @@ export function AirlineCreator() {
         {/* Hub Selection */}
         <div className="space-y-4">
           <div className="flex items-center justify-between">
-            <h3 className="text-lg font-semibold tracking-tight">Primary Hub</h3>
+            <div>
+              <h3 className="text-lg font-semibold tracking-tight">Primary Hub</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                We suggest a nearby airport to get you started, but you can change it before launch.
+              </p>
+            </div>
             <HubPicker currentHub={homeAirport} onSelect={handleHubChange} />
           </div>
 
           {homeAirport ? (
-            <div className="p-4 border border-border bg-background rounded-xl flex items-center justify-between">
-              <div>
-                <div className="flex items-center space-x-3">
-                  <span className="text-3xl font-black tracking-tighter text-foreground">
-                    {homeAirport.iata}
-                  </span>
-                  <div>
-                    <p className="font-medium leading-none">{homeAirport.city}</p>
-                    <p className="text-sm text-muted-foreground mt-1">{homeAirport.name}</p>
+            <div className="rounded-xl border border-border bg-background p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="mb-2 inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-[11px] font-semibold text-primary">
+                    Recommended start
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <span className="text-3xl font-black tracking-tighter text-foreground">
+                      {homeAirport.iata}
+                    </span>
+                    <div>
+                      <p className="font-medium leading-none">{homeAirport.city}</p>
+                      <p className="mt-1 text-sm text-muted-foreground">{homeAirport.name}</p>
+                    </div>
                   </div>
                 </div>
-                <div className="mt-2 flex flex-wrap items-center gap-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-                  <span className="font-bold">
-                    Tier {getHubPricingForIata(homeAirport.iata).tier}
-                  </span>
-                  <span className="opacity-40">•</span>
-                  <span>
-                    Setup {fpFormat(fp(getHubPricingForIata(homeAirport.iata).openFee), 0)}
-                  </span>
-                  <span className="opacity-40">•</span>
-                  <span>
-                    OPEX {fpFormat(fp(getHubPricingForIata(homeAirport.iata).monthlyOpex), 0)}/mo
+                <div className="text-right">
+                  <span className="inline-flex items-center rounded-full border bg-primary/10 px-2.5 py-0.5 text-xs font-semibold text-primary">
+                    {homeAirport.country}
                   </span>
                 </div>
               </div>
-              <div className="text-right">
-                <span className="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold bg-primary/10 text-primary">
-                  {homeAirport.country}
-                </span>
-              </div>
+              {hubPricing ? (
+                <div className="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-3">
+                  <div className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      Hub Tier
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-foreground">
+                      Tier {hubPricing.tier}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      Setup Cost
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-foreground">
+                      {fpFormat(fp(hubPricing.openFee), 0)}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-border/70 bg-muted/30 px-3 py-2">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                      Monthly OPEX
+                    </p>
+                    <p className="mt-1 text-sm font-semibold text-foreground">
+                      {fpFormat(fp(hubPricing.monthlyOpex), 0)}/mo
+                    </p>
+                  </div>
+                </div>
+              ) : null}
             </div>
           ) : (
-            <div className="p-4 border border-border bg-background rounded-xl flex items-center justify-center animate-pulse h-24">
-              <span className="text-sm text-muted-foreground">
-                Triangulating global position...
-              </span>
+            <div className="flex h-24 items-center justify-center rounded-xl border border-border bg-background px-4">
+              <div className="text-center">
+                <p className="text-sm font-medium text-foreground">
+                  Finding your best starting hub…
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  We&apos;re using your location to suggest a strong launch airport.
+                </p>
+              </div>
             </div>
           )}
           <p className="text-xs text-muted-foreground">
-            Your hub determines your initial routes and regional dominance. Choose strategically.
+            Your hub determines your initial operating region and startup costs.
           </p>
         </div>
 
@@ -141,14 +176,19 @@ export function AirlineCreator() {
 
         {/* Corporate Identity */}
         <div className="space-y-4">
-          <h3 className="text-lg font-semibold tracking-tight">Corporate Branding</h3>
+          <div>
+            <h3 className="text-lg font-semibold tracking-tight">Airline Identity</h3>
+            <p className="mt-1 text-xs text-muted-foreground">
+              These details are how other players will recognize your airline across the network.
+            </p>
+          </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div className="space-y-2">
               <label
                 htmlFor="airline-name"
                 className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
               >
-                Company Name
+                Airline Name
               </label>
               <input
                 id="airline-name"
@@ -162,7 +202,11 @@ export function AirlineCreator() {
                 <p className="text-xs text-destructive">
                   An airline named "{nameConflict}" already exists.
                 </p>
-              ) : null}
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Keep it short, memorable, and easy to spot on the map.
+                </p>
+              )}
             </div>
             <div className="space-y-2">
               <label
@@ -176,7 +220,7 @@ export function AirlineCreator() {
                 required
                 maxLength={3}
                 value={icao}
-                onChange={(e) => setIcao(e.target.value)}
+                onChange={(e) => setIcao(e.target.value.replace(/[^a-z]/gi, "").toUpperCase())}
                 placeholder="APX"
                 className="flex h-10 w-full uppercase rounded-md border border-input bg-background/50 px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               />
@@ -184,7 +228,11 @@ export function AirlineCreator() {
                 <p className="text-xs text-destructive">
                   ICAO code "{icaoConflict}" is already in use.
                 </p>
-              ) : null}
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  This 3-letter code appears on routes and aircraft.
+                </p>
+              )}
             </div>
             <div className="space-y-2 md:col-span-2">
               <label
@@ -196,17 +244,39 @@ export function AirlineCreator() {
               <input
                 id="airline-callsign"
                 value={callsign}
-                onChange={(e) => setCallsign(e.target.value)}
-                placeholder={icao ? `${icao.toUpperCase()} HEAVY` : "APEX HEAVY"}
+                onChange={(e) => setCallsign(e.target.value.toUpperCase())}
+                placeholder={normalizedIcao ? `${normalizedIcao} HEAVY` : "APEX HEAVY"}
                 className="flex h-10 w-full uppercase rounded-md border border-input bg-background/50 px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
               />
+              <p className="text-xs text-muted-foreground">
+                Leave blank to use{" "}
+                <span className="font-semibold text-foreground">{suggestedCallsign}</span>.
+              </p>
             </div>
           </div>
         </div>
 
         <div className="space-y-4">
-          <h3 className="text-sm font-medium text-muted-foreground">Livery Colors</h3>
-          <div className="flex space-x-6">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h3 className="text-sm font-medium text-muted-foreground">Livery Colors</h3>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Pick two colors to define your airline&apos;s visual identity.
+              </p>
+            </div>
+            <div className="flex items-center gap-1.5 rounded-full border border-border/70 bg-background/70 px-2.5 py-1">
+              <span
+                className="h-3.5 w-3.5 rounded-full border border-black/10"
+                style={{ backgroundColor: primary }}
+              />
+              <span
+                className="h-3.5 w-3.5 rounded-full border border-black/10"
+                style={{ backgroundColor: secondary }}
+              />
+              <span className="text-[11px] font-medium text-muted-foreground">Preview</span>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-6">
             <div className="flex items-center space-x-3">
               <input
                 type="color"
@@ -228,6 +298,23 @@ export function AirlineCreator() {
           </div>
         </div>
 
+        <div className="rounded-xl border border-border/70 bg-muted/20 p-4">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+            Launch Summary
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-sm text-foreground">
+            <span className="rounded-full bg-background px-3 py-1 font-semibold">
+              {homeAirport?.iata ?? "Hub pending"}
+            </span>
+            <span className="rounded-full bg-background px-3 py-1 font-semibold">
+              {normalizedIcao || "ICAO pending"}
+            </span>
+            <span className="rounded-full bg-background px-3 py-1 font-semibold">
+              {suggestedCallsign}
+            </span>
+          </div>
+        </div>
+
         <button
           type="submit"
           disabled={
@@ -241,11 +328,11 @@ export function AirlineCreator() {
           className="w-full inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-11 px-8"
         >
           {isLoading ? (
-            "Publishing to Nostr..."
+            "Launching airline..."
           ) : (
             <>
               <CheckCircle2 className="mr-2 h-4 w-4" />
-              Establish Corporation
+              Launch Airline
             </>
           )}
         </button>

--- a/apps/web/src/features/identity/components/AirlineCreator.tsx
+++ b/apps/web/src/features/identity/components/AirlineCreator.tsx
@@ -2,14 +2,16 @@ import type { Airport } from "@acars/core";
 import { fp, fpFormat } from "@acars/core";
 import { getHubPricingForIata } from "@acars/data";
 import { useAirlineStore, useEngineStore } from "@acars/store";
-import { CheckCircle2, PlaneTakeoff, ShieldAlert } from "lucide-react";
+import { CheckCircle2, KeyRound, PlaneTakeoff, ShieldAlert } from "lucide-react";
 import { type FormEvent, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { HubPicker } from "../../network/components/HubPicker";
+import { EphemeralKeyBackupActions } from "./EphemeralKeyBackupActions";
 import { findAirlineConflicts } from "../utils/airlineConflicts";
 
 export function AirlineCreator() {
   const { createAirline, identityStatus, isLoading, error, competitors } = useAirlineStore();
+  const isEphemeral = useAirlineStore((state) => state.isEphemeral);
   const homeAirport = useEngineStore((s) => s.homeAirport);
   const setHub = useEngineStore((s) => s.setHub);
 
@@ -18,6 +20,7 @@ export function AirlineCreator() {
   const [callsign, setCallsign] = useState("");
   const [primary, setPrimary] = useState("#1a1a2e");
   const [secondary, setSecondary] = useState("#10b981"); // neon greenish accent
+  const [showKeyTools, setShowKeyTools] = useState(false);
 
   const { nameConflict, icaoConflict } = useMemo(
     () => findAirlineConflicts(competitors, name, icao),
@@ -70,17 +73,45 @@ export function AirlineCreator() {
   return (
     <div className="mx-auto w-full max-w-2xl overflow-hidden rounded-2xl border border-border bg-card/80 shadow-2xl backdrop-blur-md">
       <div className="border-b border-border bg-muted px-8 py-6">
-        <div className="mb-3 inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
-          Connected - create your airline
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="mb-3 inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary">
+              Connected - create your airline
+            </div>
+            <h2 className="flex items-center text-2xl font-bold tracking-tight text-foreground">
+              <PlaneTakeoff className="mr-3 h-6 w-6 text-primary" />
+              Launch Your Airline
+            </h2>
+            <p className="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground">
+              Pick a home hub, name your carrier, and choose its colors. You can be ready to operate
+              in under a minute.
+            </p>
+          </div>
+          {isEphemeral && (
+            <button
+              type="button"
+              onClick={() => setShowKeyTools((open) => !open)}
+              className="inline-flex items-center gap-2 self-start rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.16em] text-amber-200 transition hover:bg-amber-500/20"
+            >
+              <KeyRound className="h-3.5 w-3.5" />
+              {showKeyTools ? "Hide key tools" : "Account key"}
+            </button>
+          )}
         </div>
-        <h2 className="flex items-center text-2xl font-bold tracking-tight text-foreground">
-          <PlaneTakeoff className="mr-3 h-6 w-6 text-primary" />
-          Launch Your Airline
-        </h2>
-        <p className="mt-2 max-w-xl text-sm leading-relaxed text-muted-foreground">
-          Pick a home hub, name your carrier, and choose its colors. You can be ready to operate in
-          under a minute.
-        </p>
+        {isEphemeral && showKeyTools && (
+          <div className="mt-4 rounded-2xl border border-amber-500/20 bg-amber-950/30 p-4">
+            <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-300">
+              Local account key
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-amber-200/80">
+              Export your recovery key before launch so this airline stays yours if you lose this
+              browser.
+            </p>
+            <div className="mt-3">
+              <EphemeralKeyBackupActions />
+            </div>
+          </div>
+        )}
       </div>
 
       <form onSubmit={handleSubmit} className="space-y-6 p-8">

--- a/apps/web/src/features/identity/components/EphemeralKeyBackupActions.tsx
+++ b/apps/web/src/features/identity/components/EphemeralKeyBackupActions.tsx
@@ -1,0 +1,144 @@
+import { hasNip07, hasStoredEphemeralKey, loadEphemeralKey } from "@acars/nostr";
+import { useAirlineStore } from "@acars/store";
+import { Check, Copy, Download, Loader2, Shield } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { markEphemeralKeySecured } from "../lib/ephemeralBackup";
+
+export function EphemeralKeyBackupActions({
+  showUpgradeButton = true,
+}: {
+  showUpgradeButton?: boolean;
+}) {
+  const initializeIdentity = useAirlineStore((state) => state.initializeIdentity);
+  const isLoading = useAirlineStore((state) => state.isLoading);
+  const pubkey = useAirlineStore((state) => state.pubkey);
+  const [copied, setCopied] = useState(false);
+  const [busyAction, setBusyAction] = useState<"copy" | "download" | null>(null);
+  const hasKey = hasStoredEphemeralKey();
+
+  async function withKeyExport(action: "copy" | "download", run: (nsec: string) => Promise<void>) {
+    setBusyAction(action);
+    try {
+      const nsec = await loadEphemeralKey();
+      if (!nsec) {
+        toast.error("Secret key unavailable", {
+          description: "No local recovery key was found on this device.",
+        });
+        return;
+      }
+
+      await run(nsec);
+      if (pubkey) {
+        markEphemeralKeySecured(pubkey);
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to access your locally stored account key.";
+      toast.error(action === "copy" ? "Copy failed" : "Download failed", {
+        description: message,
+      });
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function copyNsec() {
+    if (!navigator.clipboard?.writeText) {
+      toast.error("Copy failed", {
+        description: "Clipboard access is unavailable in this browser context.",
+      });
+      return;
+    }
+
+    await withKeyExport("copy", async (nsec) => {
+      await navigator.clipboard.writeText(nsec);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2500);
+      toast.success("Secret key copied", {
+        description: "Store it somewhere only you can access.",
+      });
+    });
+  }
+
+  async function downloadNsec() {
+    await withKeyExport("download", async (nsec) => {
+      const blob = new Blob(
+        [
+          `ACARS Secret Key — keep this safe!\n\nDo NOT share this with anyone.\n\n${nsec}\n\nTo restore your account, paste this key in the ACARS login screen.`,
+        ],
+        { type: "text/plain" },
+      );
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = "acars-secret-key.txt";
+      anchor.click();
+      URL.revokeObjectURL(url);
+      toast.success("Key file downloaded", {
+        description: "Move it to a password manager or another safe place.",
+      });
+    });
+  }
+
+  async function upgradeToExtension() {
+    await initializeIdentity();
+  }
+
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={copyNsec}
+          disabled={!hasKey || busyAction === "download"}
+          className="flex items-center gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition hover:bg-amber-500/20 disabled:opacity-40"
+        >
+          {busyAction === "copy" ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : copied ? (
+            <Check className="h-3.5 w-3.5" />
+          ) : (
+            <Copy className="h-3.5 w-3.5" />
+          )}
+          {busyAction === "copy" ? "Copying…" : copied ? "Copied!" : "Copy my secret key"}
+        </button>
+        <button
+          type="button"
+          onClick={downloadNsec}
+          disabled={!hasKey || busyAction === "copy"}
+          className="flex items-center gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition hover:bg-amber-500/20 disabled:opacity-40"
+        >
+          {busyAction === "download" ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Download className="h-3.5 w-3.5" />
+          )}
+          {busyAction === "download" ? "Preparing…" : "Download key file"}
+        </button>
+        {showUpgradeButton && hasNip07() && (
+          <button
+            type="button"
+            onClick={upgradeToExtension}
+            disabled={isLoading}
+            className="flex items-center gap-1.5 rounded border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-300 transition hover:bg-emerald-500/20 disabled:opacity-40"
+          >
+            {isLoading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Shield className="h-3.5 w-3.5" />
+            )}
+            {isLoading ? "Switching…" : "Switch to wallet extension"}
+          </button>
+        )}
+      </div>
+      <p className="mt-2 text-[10px] leading-relaxed text-amber-400/60">
+        Your secret key starts with <code className="font-mono">nsec1…</code> — treat it like a
+        password. ACARS stores it locally on this device and exports it from here whenever you need
+        your recovery copy.
+      </p>
+    </>
+  );
+}

--- a/apps/web/src/features/identity/components/GuestKeyOnboarding.tsx
+++ b/apps/web/src/features/identity/components/GuestKeyOnboarding.tsx
@@ -1,0 +1,78 @@
+import { useAirlineStore } from "@acars/store";
+import { Loader2, Plane, Sparkles, Zap } from "lucide-react";
+
+/**
+ * One-click "Create Free Account" flow for users with no Nostr identity.
+ *
+ * Generates a fresh keypair in-browser via createNewIdentity() and
+ * sets the user up for immediate play. The SecurityUpgradeBanner
+ * will then guide them to back up their key.
+ */
+export function GuestKeyOnboarding({ onExistingAccount }: { onExistingAccount?: () => void }) {
+  const createNewIdentity = useAirlineStore((state) => state.createNewIdentity);
+  const isLoading = useAirlineStore((state) => state.isLoading);
+  const error = useAirlineStore((state) => state.error);
+
+  return (
+    <div className="flex w-full max-w-sm flex-col gap-4">
+      <div className="space-y-1">
+        <div className="flex items-center gap-2">
+          <Plane className="h-5 w-5 text-primary" />
+          <h2 className="text-base font-bold tracking-tight text-foreground">Start your airline</h2>
+        </div>
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          No account, no download, no crypto knowledge needed. Your progress is saved automatically.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => createNewIdentity()}
+        disabled={isLoading}
+        className="flex min-h-12 w-full items-center justify-center gap-2 rounded-xl border border-primary/50 bg-primary/15 px-4 py-3 text-sm font-bold text-primary shadow-lg shadow-primary/10 transition hover:bg-primary/25 hover:border-primary/70 disabled:opacity-60"
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Creating your account…
+          </>
+        ) : (
+          <>
+            <Sparkles className="h-4 w-4" />
+            Play for free — no sign-up required
+          </>
+        )}
+      </button>
+
+      {error && <p className="text-center text-[11px] font-medium text-rose-400">{error}</p>}
+
+      <div className="grid grid-cols-2 gap-2">
+        {[
+          { icon: Plane, label: "Real-time flights", sub: "Routes resolve in actual hours" },
+          { icon: Zap, label: "Earn Bitcoin", sub: "Real sats via Lightning zaps" },
+        ].map((item) => (
+          <div
+            key={item.label}
+            className="flex flex-col gap-1 rounded-lg border border-border/50 bg-background/40 p-3 backdrop-blur-sm"
+          >
+            <div className="flex items-center gap-1.5">
+              <item.icon className="h-3.5 w-3.5 text-primary/70" />
+              <span className="text-[11px] font-semibold text-foreground">{item.label}</span>
+            </div>
+            <span className="text-[10px] leading-snug text-muted-foreground">{item.sub}</span>
+          </div>
+        ))}
+      </div>
+
+      {onExistingAccount && (
+        <button
+          type="button"
+          onClick={onExistingAccount}
+          className="mt-1 text-center text-[11px] text-muted-foreground underline-offset-2 transition hover:text-foreground hover:underline"
+        >
+          I already have a Nostr account →
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/identity/components/IdentityGate.tsx
+++ b/apps/web/src/features/identity/components/IdentityGate.tsx
@@ -1,9 +1,10 @@
 import { useAirlineStore } from "@acars/store";
 import { Loader2 } from "lucide-react";
 import { AirlineCreator } from "./AirlineCreator";
+import { SecurityUpgradeBanner } from "./SecurityUpgradeBanner";
 
 export function IdentityGate({ children }: { children: React.ReactNode }) {
-  const { identityStatus, airline } = useAirlineStore();
+  const { identityStatus, airline, isEphemeral } = useAirlineStore();
 
   if (identityStatus === "checking") {
     return (
@@ -31,6 +32,11 @@ export function IdentityGate({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // Success
-  return <>{children}</>;
+  // Success — render the full app with optional security banner for ephemeral keys
+  return (
+    <div className="flex h-full w-full flex-col">
+      {isEphemeral && <SecurityUpgradeBanner />}
+      {children}
+    </div>
+  );
 }

--- a/apps/web/src/features/identity/components/SecurityUpgradeBanner.test.tsx
+++ b/apps/web/src/features/identity/components/SecurityUpgradeBanner.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SecurityUpgradeBanner } from "./SecurityUpgradeBanner";
+
+type Selector<T> = (state: T) => unknown;
+type AirlineStoreState = {
+  initializeIdentity: () => Promise<void>;
+  pubkey: string | null;
+};
+
+const mockUseAirlineStore = vi.fn();
+const mockHasNip07 = vi.fn();
+const mockLoadEphemeralKey = vi.fn();
+const mockWriteText = vi.fn().mockResolvedValue(undefined);
+const localStorageState = new Map<string, string>();
+const sessionStorageState = new Map<string, string>();
+
+function createMockStorage(state: Map<string, string>) {
+  return {
+    getItem: vi.fn((key: string) => state.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      state.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      state.delete(key);
+    }),
+    clear: vi.fn(() => {
+      state.clear();
+    }),
+  };
+}
+
+vi.mock("@acars/store", () => ({
+  useAirlineStore: (selector?: Selector<AirlineStoreState>) => {
+    const state = mockUseAirlineStore() as AirlineStoreState;
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock("@acars/nostr", () => ({
+  hasNip07: () => mockHasNip07(),
+  loadEphemeralKey: () => mockLoadEphemeralKey(),
+}));
+
+describe("SecurityUpgradeBanner", () => {
+  beforeEach(() => {
+    localStorageState.clear();
+    sessionStorageState.clear();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: createMockStorage(localStorageState),
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: createMockStorage(sessionStorageState),
+      configurable: true,
+    });
+    mockUseAirlineStore.mockReturnValue({
+      initializeIdentity: vi.fn().mockResolvedValue(undefined),
+      pubkey: "pubkey-1",
+    });
+    mockHasNip07.mockReturnValue(false);
+    mockLoadEphemeralKey.mockReturnValue("nsec1testvalue");
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText: mockWriteText },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    mockUseAirlineStore.mockReset();
+    mockHasNip07.mockReset();
+    mockLoadEphemeralKey.mockReset();
+    mockWriteText.mockReset();
+    localStorageState.clear();
+    sessionStorageState.clear();
+  });
+
+  it("persists banner dismissal for an account after copying the secret key", async () => {
+    render(<SecurityUpgradeBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Secure it/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Copy my secret key/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/isn't backed up yet/i)).not.toBeInTheDocument();
+    });
+
+    expect(mockWriteText).toHaveBeenCalledWith("nsec1testvalue");
+    expect(localStorage.getItem("acars:banner:secured:pubkey-1")).toBe("1");
+  });
+
+  it("stays hidden when the current account was already secured", () => {
+    localStorage.setItem("acars:banner:secured:pubkey-1", "1");
+
+    render(<SecurityUpgradeBanner />);
+
+    expect(screen.queryByText(/isn't backed up yet/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/identity/components/SecurityUpgradeBanner.test.tsx
+++ b/apps/web/src/features/identity/components/SecurityUpgradeBanner.test.tsx
@@ -5,11 +5,13 @@ import { SecurityUpgradeBanner } from "./SecurityUpgradeBanner";
 type Selector<T> = (state: T) => unknown;
 type AirlineStoreState = {
   initializeIdentity: () => Promise<void>;
+  isLoading: boolean;
   pubkey: string | null;
 };
 
 const mockUseAirlineStore = vi.fn();
 const mockHasNip07 = vi.fn();
+const mockHasStoredEphemeralKey = vi.fn();
 const mockLoadEphemeralKey = vi.fn();
 const mockWriteText = vi.fn().mockResolvedValue(undefined);
 const localStorageState = new Map<string, string>();
@@ -39,7 +41,15 @@ vi.mock("@acars/store", () => ({
 
 vi.mock("@acars/nostr", () => ({
   hasNip07: () => mockHasNip07(),
+  hasStoredEphemeralKey: () => mockHasStoredEphemeralKey(),
   loadEphemeralKey: () => mockLoadEphemeralKey(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
 }));
 
 describe("SecurityUpgradeBanner", () => {
@@ -56,10 +66,12 @@ describe("SecurityUpgradeBanner", () => {
     });
     mockUseAirlineStore.mockReturnValue({
       initializeIdentity: vi.fn().mockResolvedValue(undefined),
+      isLoading: false,
       pubkey: "pubkey-1",
     });
     mockHasNip07.mockReturnValue(false);
-    mockLoadEphemeralKey.mockReturnValue("nsec1testvalue");
+    mockHasStoredEphemeralKey.mockReturnValue(true);
+    mockLoadEphemeralKey.mockResolvedValue("nsec1testvalue");
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText: mockWriteText },
       configurable: true,
@@ -70,6 +82,7 @@ describe("SecurityUpgradeBanner", () => {
     cleanup();
     mockUseAirlineStore.mockReset();
     mockHasNip07.mockReset();
+    mockHasStoredEphemeralKey.mockReset();
     mockLoadEphemeralKey.mockReset();
     mockWriteText.mockReset();
     localStorageState.clear();

--- a/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
+++ b/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
@@ -1,4 +1,4 @@
-import { clearEphemeralKey, hasNip07, loadEphemeralKey } from "@acars/nostr";
+import { hasNip07, loadEphemeralKey } from "@acars/nostr";
 import { useAirlineStore } from "@acars/store";
 import { Check, Copy, Download, Shield, ShieldAlert, X } from "lucide-react";
 import { useState } from "react";
@@ -52,7 +52,6 @@ export function SecurityUpgradeBanner() {
   }
 
   async function upgradeToExtension() {
-    clearEphemeralKey();
     await initializeIdentity();
   }
 

--- a/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
+++ b/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
@@ -1,15 +1,13 @@
-import { hasNip07, loadEphemeralKey } from "@acars/nostr";
 import { useAirlineStore } from "@acars/store";
-import { Check, Copy, Download, Shield, ShieldAlert, X } from "lucide-react";
-import { useState } from "react";
-
-function getDismissedBannerKey(pubkey: string) {
-  return `acars:banner:dismissed:${pubkey}`;
-}
-
-function getSecuredBannerKey(pubkey: string) {
-  return `acars:banner:secured:${pubkey}`;
-}
+import { ShieldAlert, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { EphemeralKeyBackupActions } from "./EphemeralKeyBackupActions";
+import {
+  dismissEphemeralBanner,
+  isEphemeralBannerDismissed,
+  isEphemeralKeySecured,
+  subscribeEphemeralKeySecurityChanges,
+} from "../lib/ephemeralBackup";
 
 /**
  * Non-blocking banner shown when the user is playing with an
@@ -21,67 +19,37 @@ function getSecuredBannerKey(pubkey: string) {
  * their secret key.
  */
 export function SecurityUpgradeBanner() {
-  const initializeIdentity = useAirlineStore((state) => state.initializeIdentity);
   const pubkey = useAirlineStore((state) => state.pubkey);
   const [dismissedAccounts, setDismissedAccounts] = useState<Record<string, true>>({});
-  const [securedAccounts, setSecuredAccounts] = useState<Record<string, true>>({});
-  const [copied, setCopied] = useState(false);
+  const [securityRefreshToken, setSecurityRefreshToken] = useState(0);
   const [expanded, setExpanded] = useState(false);
 
   const dismissed = pubkey
-    ? dismissedAccounts[pubkey] || sessionStorage.getItem(getDismissedBannerKey(pubkey)) === "1"
+    ? dismissedAccounts[pubkey] || isEphemeralBannerDismissed(pubkey)
     : false;
-  const secured = pubkey
-    ? securedAccounts[pubkey] || localStorage.getItem(getSecuredBannerKey(pubkey)) === "1"
-    : false;
+  const secured = pubkey ? isEphemeralKeySecured(pubkey) : false;
+
+  useEffect(() => {
+    return subscribeEphemeralKeySecurityChanges((updatedPubkey) => {
+      if (updatedPubkey === pubkey) {
+        setSecurityRefreshToken((current) => current + 1);
+      }
+    });
+  }, [pubkey]);
 
   if (dismissed || secured) return null;
 
-  const nsec = loadEphemeralKey();
-
   function dismiss() {
     if (!pubkey) return;
-    sessionStorage.setItem(getDismissedBannerKey(pubkey), "1");
+    dismissEphemeralBanner(pubkey);
     setDismissedAccounts((current) => ({ ...current, [pubkey]: true }));
   }
 
-  function markSecured() {
-    if (!pubkey) return;
-    localStorage.setItem(getSecuredBannerKey(pubkey), "1");
-    setSecuredAccounts((current) => ({ ...current, [pubkey]: true }));
-  }
-
-  async function copyNsec() {
-    if (!nsec) return;
-    await navigator.clipboard.writeText(nsec);
-    markSecured();
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2500);
-  }
-
-  function downloadNsec() {
-    if (!nsec) return;
-    const blob = new Blob(
-      [
-        `ACARS Secret Key — keep this safe!\n\nDo NOT share this with anyone.\n\n${nsec}\n\nTo restore your account, paste this key in the ACARS login screen.`,
-      ],
-      { type: "text/plain" },
-    );
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = "acars-secret-key.txt";
-    a.click();
-    URL.revokeObjectURL(url);
-    markSecured();
-  }
-
-  async function upgradeToExtension() {
-    await initializeIdentity();
-  }
-
   return (
-    <div className="pointer-events-auto w-full border-b border-amber-500/30 bg-amber-950/70 backdrop-blur-xl">
+    <div
+      key={securityRefreshToken}
+      className="pointer-events-auto w-full border-b border-amber-500/30 bg-amber-950/70 backdrop-blur-xl"
+    >
       <div className="flex items-center gap-3 px-4 py-2">
         <ShieldAlert className="h-4 w-4 shrink-0 text-amber-400" />
         <p className="flex-1 text-xs font-medium text-amber-200">
@@ -111,40 +79,7 @@ export function SecurityUpgradeBanner() {
             Your account key is saved only in this browser. Back it up so you can play from
             anywhere:
           </p>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={copyNsec}
-              disabled={!nsec}
-              className="flex items-center gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition hover:bg-amber-500/20 disabled:opacity-40"
-            >
-              {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-              {copied ? "Copied!" : "Copy my secret key"}
-            </button>
-            <button
-              type="button"
-              onClick={downloadNsec}
-              disabled={!nsec}
-              className="flex items-center gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition hover:bg-amber-500/20 disabled:opacity-40"
-            >
-              <Download className="h-3.5 w-3.5" />
-              Download key file
-            </button>
-            {hasNip07() && (
-              <button
-                type="button"
-                onClick={upgradeToExtension}
-                className="flex items-center gap-1.5 rounded border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-300 transition hover:bg-emerald-500/20"
-              >
-                <Shield className="h-3.5 w-3.5" />
-                Switch to wallet extension
-              </button>
-            )}
-          </div>
-          <p className="mt-2 text-[10px] leading-relaxed text-amber-400/60">
-            Your secret key starts with <code className="font-mono">nsec1…</code> — treat it like a
-            password. Anyone who has it controls your airline.
-          </p>
+          <EphemeralKeyBackupActions />
         </div>
       )}
     </div>

--- a/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
+++ b/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
@@ -1,0 +1,128 @@
+import { clearEphemeralKey, hasNip07, loadEphemeralKey } from "@acars/nostr";
+import { useAirlineStore } from "@acars/store";
+import { Check, Copy, Download, Shield, ShieldAlert, X } from "lucide-react";
+import { useState } from "react";
+
+/**
+ * Non-blocking banner shown when the user is playing with an
+ * in-browser generated key that hasn't been backed up yet.
+ *
+ * Displayed when identityStatus === "ready" && isEphemeral === true.
+ * Dismissed per-session via sessionStorage but reappears on next visit
+ * until the user properly secures their account.
+ */
+export function SecurityUpgradeBanner() {
+  const initializeIdentity = useAirlineStore((state) => state.initializeIdentity);
+  const [dismissed, setDismissed] = useState(
+    () => sessionStorage.getItem("acars:banner:dismissed") === "1",
+  );
+  const [copied, setCopied] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  if (dismissed) return null;
+
+  const nsec = loadEphemeralKey();
+
+  function dismiss() {
+    sessionStorage.setItem("acars:banner:dismissed", "1");
+    setDismissed(true);
+  }
+
+  async function copyNsec() {
+    if (!nsec) return;
+    await navigator.clipboard.writeText(nsec);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2500);
+  }
+
+  function downloadNsec() {
+    if (!nsec) return;
+    const blob = new Blob(
+      [
+        `ACARS Secret Key — keep this safe!\n\nDo NOT share this with anyone.\n\n${nsec}\n\nTo restore your account, paste this key in the ACARS login screen.`,
+      ],
+      { type: "text/plain" },
+    );
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "acars-secret-key.txt";
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  async function upgradeToExtension() {
+    clearEphemeralKey();
+    await initializeIdentity();
+  }
+
+  return (
+    <div className="pointer-events-auto w-full border-b border-amber-500/30 bg-amber-950/70 backdrop-blur-xl">
+      <div className="flex items-center gap-3 px-4 py-2">
+        <ShieldAlert className="h-4 w-4 shrink-0 text-amber-400" />
+        <p className="flex-1 text-xs font-medium text-amber-200">
+          Your account isn&apos;t backed up yet — if you lose this browser/tab, your airline is
+          gone.
+        </p>
+        <button
+          type="button"
+          onClick={() => setExpanded((e) => !e)}
+          className="shrink-0 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-amber-300 transition hover:bg-amber-500/20"
+        >
+          {expanded ? "Hide" : "Secure it"}
+        </button>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss security warning"
+          className="shrink-0 rounded p-1 text-amber-400/60 transition hover:text-amber-300"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-amber-500/20 px-4 py-3">
+          <p className="mb-3 text-xs leading-relaxed text-amber-200/80">
+            Your account key is saved only in this browser. Back it up so you can play from
+            anywhere:
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={copyNsec}
+              disabled={!nsec}
+              className="flex items-center gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition hover:bg-amber-500/20 disabled:opacity-40"
+            >
+              {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+              {copied ? "Copied!" : "Copy my secret key"}
+            </button>
+            <button
+              type="button"
+              onClick={downloadNsec}
+              disabled={!nsec}
+              className="flex items-center gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-3 py-1.5 text-xs font-semibold text-amber-200 transition hover:bg-amber-500/20 disabled:opacity-40"
+            >
+              <Download className="h-3.5 w-3.5" />
+              Download key file
+            </button>
+            {hasNip07() && (
+              <button
+                type="button"
+                onClick={upgradeToExtension}
+                className="flex items-center gap-1.5 rounded border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-semibold text-emerald-300 transition hover:bg-emerald-500/20"
+              >
+                <Shield className="h-3.5 w-3.5" />
+                Switch to wallet extension
+              </button>
+            )}
+          </div>
+          <p className="mt-2 text-[10px] leading-relaxed text-amber-400/60">
+            Your secret key starts with <code className="font-mono">nsec1…</code> — treat it like a
+            password. Anyone who has it controls your airline.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
+++ b/apps/web/src/features/identity/components/SecurityUpgradeBanner.tsx
@@ -3,34 +3,58 @@ import { useAirlineStore } from "@acars/store";
 import { Check, Copy, Download, Shield, ShieldAlert, X } from "lucide-react";
 import { useState } from "react";
 
+function getDismissedBannerKey(pubkey: string) {
+  return `acars:banner:dismissed:${pubkey}`;
+}
+
+function getSecuredBannerKey(pubkey: string) {
+  return `acars:banner:secured:${pubkey}`;
+}
+
 /**
  * Non-blocking banner shown when the user is playing with an
  * in-browser generated key that hasn't been backed up yet.
  *
  * Displayed when identityStatus === "ready" && isEphemeral === true.
- * Dismissed per-session via sessionStorage but reappears on next visit
- * until the user properly secures their account.
+ * Dismissed per-session for the current account via sessionStorage, and
+ * permanently hidden for that account once the user copies or downloads
+ * their secret key.
  */
 export function SecurityUpgradeBanner() {
   const initializeIdentity = useAirlineStore((state) => state.initializeIdentity);
-  const [dismissed, setDismissed] = useState(
-    () => sessionStorage.getItem("acars:banner:dismissed") === "1",
-  );
+  const pubkey = useAirlineStore((state) => state.pubkey);
+  const [dismissedAccounts, setDismissedAccounts] = useState<Record<string, true>>({});
+  const [securedAccounts, setSecuredAccounts] = useState<Record<string, true>>({});
   const [copied, setCopied] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
-  if (dismissed) return null;
+  const dismissed = pubkey
+    ? dismissedAccounts[pubkey] || sessionStorage.getItem(getDismissedBannerKey(pubkey)) === "1"
+    : false;
+  const secured = pubkey
+    ? securedAccounts[pubkey] || localStorage.getItem(getSecuredBannerKey(pubkey)) === "1"
+    : false;
+
+  if (dismissed || secured) return null;
 
   const nsec = loadEphemeralKey();
 
   function dismiss() {
-    sessionStorage.setItem("acars:banner:dismissed", "1");
-    setDismissed(true);
+    if (!pubkey) return;
+    sessionStorage.setItem(getDismissedBannerKey(pubkey), "1");
+    setDismissedAccounts((current) => ({ ...current, [pubkey]: true }));
+  }
+
+  function markSecured() {
+    if (!pubkey) return;
+    localStorage.setItem(getSecuredBannerKey(pubkey), "1");
+    setSecuredAccounts((current) => ({ ...current, [pubkey]: true }));
   }
 
   async function copyNsec() {
     if (!nsec) return;
     await navigator.clipboard.writeText(nsec);
+    markSecured();
     setCopied(true);
     setTimeout(() => setCopied(false), 2500);
   }
@@ -49,6 +73,7 @@ export function SecurityUpgradeBanner() {
     a.download = "acars-secret-key.txt";
     a.click();
     URL.revokeObjectURL(url);
+    markSecured();
   }
 
   async function upgradeToExtension() {

--- a/apps/web/src/features/identity/lib/ephemeralBackup.ts
+++ b/apps/web/src/features/identity/lib/ephemeralBackup.ts
@@ -1,0 +1,57 @@
+const DISMISSED_KEY_PREFIX = "acars:banner:dismissed:";
+const SECURED_KEY_PREFIX = "acars:banner:secured:";
+const SECURED_EVENT = "acars:ephemeral-key-secured";
+
+export function getDismissedBannerKey(pubkey: string) {
+  return `${DISMISSED_KEY_PREFIX}${pubkey}`;
+}
+
+export function getSecuredBannerKey(pubkey: string) {
+  return `${SECURED_KEY_PREFIX}${pubkey}`;
+}
+
+export function isEphemeralBannerDismissed(pubkey: string): boolean {
+  if (typeof window === "undefined") return false;
+  return sessionStorage.getItem(getDismissedBannerKey(pubkey)) === "1";
+}
+
+export function dismissEphemeralBanner(pubkey: string): void {
+  if (typeof window === "undefined") return;
+  sessionStorage.setItem(getDismissedBannerKey(pubkey), "1");
+}
+
+export function isEphemeralKeySecured(pubkey: string): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(getSecuredBannerKey(pubkey)) === "1";
+}
+
+export function markEphemeralKeySecured(pubkey: string): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(getSecuredBannerKey(pubkey), "1");
+  window.dispatchEvent(new CustomEvent(SECURED_EVENT, { detail: { pubkey } }));
+}
+
+export function subscribeEphemeralKeySecurityChanges(
+  onSecure: (pubkey: string) => void,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  const handleSecure = (event: Event) => {
+    const detail = (event as CustomEvent<{ pubkey?: string }>).detail;
+    if (detail?.pubkey) onSecure(detail.pubkey);
+  };
+
+  const handleStorage = (event: StorageEvent) => {
+    if (!event.key?.startsWith(SECURED_KEY_PREFIX)) return;
+    const pubkey = event.key.slice(SECURED_KEY_PREFIX.length);
+    if (pubkey) onSecure(pubkey);
+  };
+
+  window.addEventListener(SECURED_EVENT, handleSecure);
+  window.addEventListener("storage", handleStorage);
+
+  return () => {
+    window.removeEventListener(SECURED_EVENT, handleSecure);
+    window.removeEventListener("storage", handleStorage);
+  };
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -8,190 +8,210 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as NetworkRouteImport } from './routes/network'
-import { Route as LeaderboardRouteImport } from './routes/leaderboard'
-import { Route as FleetRouteImport } from './routes/fleet'
-import { Route as CorporateRouteImport } from './routes/corporate'
-import { Route as AboutRouteImport } from './routes/about'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as AirportIataRouteImport } from './routes/airport.$iata'
-import { Route as AircraftIdRouteImport } from './routes/aircraft.$id'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as NetworkRouteImport } from "./routes/network";
+import { Route as LeaderboardRouteImport } from "./routes/leaderboard";
+import { Route as JoinRouteImport } from "./routes/join";
+import { Route as FleetRouteImport } from "./routes/fleet";
+import { Route as CorporateRouteImport } from "./routes/corporate";
+import { Route as AboutRouteImport } from "./routes/about";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as AirportIataRouteImport } from "./routes/airport.$iata";
+import { Route as AircraftIdRouteImport } from "./routes/aircraft.$id";
 
 const NetworkRoute = NetworkRouteImport.update({
-  id: '/network',
-  path: '/network',
+  id: "/network",
+  path: "/network",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LeaderboardRoute = LeaderboardRouteImport.update({
-  id: '/leaderboard',
-  path: '/leaderboard',
+  id: "/leaderboard",
+  path: "/leaderboard",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
+const JoinRoute = JoinRouteImport.update({
+  id: "/join",
+  path: "/join",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const FleetRoute = FleetRouteImport.update({
-  id: '/fleet',
-  path: '/fleet',
+  id: "/fleet",
+  path: "/fleet",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const CorporateRoute = CorporateRouteImport.update({
-  id: '/corporate',
-  path: '/corporate',
+  id: "/corporate",
+  path: "/corporate",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AboutRoute = AboutRouteImport.update({
-  id: '/about',
-  path: '/about',
+  id: "/about",
+  path: "/about",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AirportIataRoute = AirportIataRouteImport.update({
-  id: '/airport/$iata',
-  path: '/airport/$iata',
+  id: "/airport/$iata",
+  path: "/airport/$iata",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const AircraftIdRoute = AircraftIdRouteImport.update({
-  id: '/aircraft/$id',
-  path: '/aircraft/$id',
+  id: "/aircraft/$id",
+  path: "/aircraft/$id",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/about': typeof AboutRoute
-  '/corporate': typeof CorporateRoute
-  '/fleet': typeof FleetRoute
-  '/leaderboard': typeof LeaderboardRoute
-  '/network': typeof NetworkRoute
-  '/aircraft/$id': typeof AircraftIdRoute
-  '/airport/$iata': typeof AirportIataRoute
+  "/": typeof IndexRoute;
+  "/about": typeof AboutRoute;
+  "/corporate": typeof CorporateRoute;
+  "/fleet": typeof FleetRoute;
+  "/join": typeof JoinRoute;
+  "/leaderboard": typeof LeaderboardRoute;
+  "/network": typeof NetworkRoute;
+  "/aircraft/$id": typeof AircraftIdRoute;
+  "/airport/$iata": typeof AirportIataRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/about': typeof AboutRoute
-  '/corporate': typeof CorporateRoute
-  '/fleet': typeof FleetRoute
-  '/leaderboard': typeof LeaderboardRoute
-  '/network': typeof NetworkRoute
-  '/aircraft/$id': typeof AircraftIdRoute
-  '/airport/$iata': typeof AirportIataRoute
+  "/": typeof IndexRoute;
+  "/about": typeof AboutRoute;
+  "/corporate": typeof CorporateRoute;
+  "/fleet": typeof FleetRoute;
+  "/join": typeof JoinRoute;
+  "/leaderboard": typeof LeaderboardRoute;
+  "/network": typeof NetworkRoute;
+  "/aircraft/$id": typeof AircraftIdRoute;
+  "/airport/$iata": typeof AirportIataRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/about': typeof AboutRoute
-  '/corporate': typeof CorporateRoute
-  '/fleet': typeof FleetRoute
-  '/leaderboard': typeof LeaderboardRoute
-  '/network': typeof NetworkRoute
-  '/aircraft/$id': typeof AircraftIdRoute
-  '/airport/$iata': typeof AirportIataRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/about": typeof AboutRoute;
+  "/corporate": typeof CorporateRoute;
+  "/fleet": typeof FleetRoute;
+  "/join": typeof JoinRoute;
+  "/leaderboard": typeof LeaderboardRoute;
+  "/network": typeof NetworkRoute;
+  "/aircraft/$id": typeof AircraftIdRoute;
+  "/airport/$iata": typeof AirportIataRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/about'
-    | '/corporate'
-    | '/fleet'
-    | '/leaderboard'
-    | '/network'
-    | '/aircraft/$id'
-    | '/airport/$iata'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/about"
+    | "/corporate"
+    | "/fleet"
+    | "/join"
+    | "/leaderboard"
+    | "/network"
+    | "/aircraft/$id"
+    | "/airport/$iata";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/'
-    | '/about'
-    | '/corporate'
-    | '/fleet'
-    | '/leaderboard'
-    | '/network'
-    | '/aircraft/$id'
-    | '/airport/$iata'
+    | "/"
+    | "/about"
+    | "/corporate"
+    | "/fleet"
+    | "/join"
+    | "/leaderboard"
+    | "/network"
+    | "/aircraft/$id"
+    | "/airport/$iata";
   id:
-    | '__root__'
-    | '/'
-    | '/about'
-    | '/corporate'
-    | '/fleet'
-    | '/leaderboard'
-    | '/network'
-    | '/aircraft/$id'
-    | '/airport/$iata'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/about"
+    | "/corporate"
+    | "/fleet"
+    | "/join"
+    | "/leaderboard"
+    | "/network"
+    | "/aircraft/$id"
+    | "/airport/$iata";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  AboutRoute: typeof AboutRoute
-  CorporateRoute: typeof CorporateRoute
-  FleetRoute: typeof FleetRoute
-  LeaderboardRoute: typeof LeaderboardRoute
-  NetworkRoute: typeof NetworkRoute
-  AircraftIdRoute: typeof AircraftIdRoute
-  AirportIataRoute: typeof AirportIataRoute
+  IndexRoute: typeof IndexRoute;
+  AboutRoute: typeof AboutRoute;
+  CorporateRoute: typeof CorporateRoute;
+  FleetRoute: typeof FleetRoute;
+  JoinRoute: typeof JoinRoute;
+  LeaderboardRoute: typeof LeaderboardRoute;
+  NetworkRoute: typeof NetworkRoute;
+  AircraftIdRoute: typeof AircraftIdRoute;
+  AirportIataRoute: typeof AirportIataRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/network': {
-      id: '/network'
-      path: '/network'
-      fullPath: '/network'
-      preLoaderRoute: typeof NetworkRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/leaderboard': {
-      id: '/leaderboard'
-      path: '/leaderboard'
-      fullPath: '/leaderboard'
-      preLoaderRoute: typeof LeaderboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/fleet': {
-      id: '/fleet'
-      path: '/fleet'
-      fullPath: '/fleet'
-      preLoaderRoute: typeof FleetRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/corporate': {
-      id: '/corporate'
-      path: '/corporate'
-      fullPath: '/corporate'
-      preLoaderRoute: typeof CorporateRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/about': {
-      id: '/about'
-      path: '/about'
-      fullPath: '/about'
-      preLoaderRoute: typeof AboutRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/airport/$iata': {
-      id: '/airport/$iata'
-      path: '/airport/$iata'
-      fullPath: '/airport/$iata'
-      preLoaderRoute: typeof AirportIataRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/aircraft/$id': {
-      id: '/aircraft/$id'
-      path: '/aircraft/$id'
-      fullPath: '/aircraft/$id'
-      preLoaderRoute: typeof AircraftIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/network": {
+      id: "/network";
+      path: "/network";
+      fullPath: "/network";
+      preLoaderRoute: typeof NetworkRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/leaderboard": {
+      id: "/leaderboard";
+      path: "/leaderboard";
+      fullPath: "/leaderboard";
+      preLoaderRoute: typeof LeaderboardRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/join": {
+      id: "/join";
+      path: "/join";
+      fullPath: "/join";
+      preLoaderRoute: typeof JoinRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/fleet": {
+      id: "/fleet";
+      path: "/fleet";
+      fullPath: "/fleet";
+      preLoaderRoute: typeof FleetRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/corporate": {
+      id: "/corporate";
+      path: "/corporate";
+      fullPath: "/corporate";
+      preLoaderRoute: typeof CorporateRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/about": {
+      id: "/about";
+      path: "/about";
+      fullPath: "/about";
+      preLoaderRoute: typeof AboutRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/airport/$iata": {
+      id: "/airport/$iata";
+      path: "/airport/$iata";
+      fullPath: "/airport/$iata";
+      preLoaderRoute: typeof AirportIataRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/aircraft/$id": {
+      id: "/aircraft/$id";
+      path: "/aircraft/$id";
+      fullPath: "/aircraft/$id";
+      preLoaderRoute: typeof AircraftIdRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
@@ -200,11 +220,12 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   CorporateRoute: CorporateRoute,
   FleetRoute: FleetRoute,
+  JoinRoute: JoinRoute,
   LeaderboardRoute: LeaderboardRoute,
   NetworkRoute: NetworkRoute,
   AircraftIdRoute: AircraftIdRoute,
   AirportIataRoute: AirportIataRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();

--- a/apps/web/src/routes/-join.lazy.test.tsx
+++ b/apps/web/src/routes/-join.lazy.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import JoinPage from "./-join.lazy";
+
+type Selector<T> = (state: T) => unknown;
+type AirlineStoreState = {
+  airline: { id: string } | null;
+  identityStatus: string;
+};
+
+const mockUseAirlineStore = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock("@acars/store", () => ({
+  useAirlineStore: (selector: Selector<AirlineStoreState>) =>
+    selector(mockUseAirlineStore() as AirlineStoreState),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("@/features/identity/components/GuestKeyOnboarding", () => ({
+  GuestKeyOnboarding: () => <div>Guest Onboarding</div>,
+}));
+
+describe("JoinPage", () => {
+  it("redirects ready identities away from the join page even before airline creation", async () => {
+    mockUseAirlineStore.mockReturnValue({
+      airline: null,
+      identityStatus: "ready",
+    });
+
+    render(<JoinPage />);
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: "/" });
+    });
+  });
+
+  it("renders onboarding for guest users", () => {
+    mockUseAirlineStore.mockReturnValue({
+      airline: null,
+      identityStatus: "guest",
+    });
+
+    render(<JoinPage />);
+
+    expect(screen.getAllByText("Guest Onboarding").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/routes/-join.lazy.tsx
+++ b/apps/web/src/routes/-join.lazy.tsx
@@ -37,15 +37,15 @@ const features = [
 
 export default function JoinPage() {
   const identityStatus = useAirlineStore((state) => state.identityStatus);
-  const airline = useAirlineStore((state) => state.airline);
   const navigate = useNavigate();
 
-  // Redirect to app once identity + airline are ready
+  // Redirect to app once identity exists so users cannot overwrite
+  // a freshly generated local account by re-triggering onboarding.
   useEffect(() => {
-    if (identityStatus === "ready" && airline) {
+    if (identityStatus === "ready") {
       void navigate({ to: "/" });
     }
-  }, [identityStatus, airline, navigate]);
+  }, [identityStatus, navigate]);
 
   function handleExistingAccount() {
     void navigate({ to: "/" });

--- a/apps/web/src/routes/-join.lazy.tsx
+++ b/apps/web/src/routes/-join.lazy.tsx
@@ -1,0 +1,121 @@
+import { useAirlineStore } from "@acars/store";
+import { useNavigate } from "@tanstack/react-router";
+import { Globe, Plane, TrendingUp, Users, Zap } from "lucide-react";
+import { useEffect } from "react";
+import { GuestKeyOnboarding } from "@/features/identity/components/GuestKeyOnboarding";
+
+const features = [
+  {
+    icon: Plane,
+    title: "Real-time flights",
+    description:
+      "Routes resolve in actual real-world time. A 7-hour transatlantic flight takes 7 real hours — check in anytime.",
+  },
+  {
+    icon: TrendingUp,
+    title: "Run a real corporation",
+    description:
+      "Issue stock, manage a cap table, file for IPO, weather bankruptcies, or launch a hostile takeover.",
+  },
+  {
+    icon: Zap,
+    title: "Earn real Bitcoin",
+    description: "Play-to-earn prize pools and Lightning Zaps. Trade airline stock slots P2P.",
+  },
+  {
+    icon: Globe,
+    title: "Fully decentralized",
+    description:
+      "No servers, no central database. Your airline lives on the open Nostr network — you own it completely.",
+  },
+  {
+    icon: Users,
+    title: "Compete globally",
+    description: "Thousands of airlines, live leaderboards, and a global route marketplace.",
+  },
+];
+
+export default function JoinPage() {
+  const identityStatus = useAirlineStore((state) => state.identityStatus);
+  const airline = useAirlineStore((state) => state.airline);
+  const navigate = useNavigate();
+
+  // Redirect to app once identity + airline are ready
+  useEffect(() => {
+    if (identityStatus === "ready" && airline) {
+      void navigate({ to: "/" });
+    }
+  }, [identityStatus, airline, navigate]);
+
+  function handleExistingAccount() {
+    void navigate({ to: "/" });
+  }
+
+  return (
+    <div className="pointer-events-auto relative flex min-h-screen w-full flex-col overflow-auto bg-background/95 backdrop-blur-2xl">
+      {/* Header */}
+      <header className="flex items-center gap-3 border-b border-border/60 bg-background/80 px-6 py-4 backdrop-blur-xl">
+        <div className="flex h-8 w-8 items-center justify-center rounded bg-primary/20 text-xs font-bold text-primary">
+          AT
+        </div>
+        <div>
+          <h1 className="text-sm font-bold leading-none tracking-tight text-foreground">ACARS</h1>
+          <p className="mt-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+            Aircraft Communication Addressing and Relay System
+          </p>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-12 px-6 py-12">
+        <section className="flex flex-col items-start gap-8 lg:flex-row lg:items-center">
+          {/* Pitch */}
+          <div className="flex-1 space-y-4">
+            <div className="inline-flex items-center gap-1.5 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+              <Plane className="h-3 w-3" />
+              Free to play · No account needed
+            </div>
+            <h2 className="text-3xl font-extrabold leading-tight tracking-tight text-foreground sm:text-4xl">
+              Build the world&apos;s <br />
+              most powerful airline.
+            </h2>
+            <p className="max-w-md text-sm leading-relaxed text-muted-foreground">
+              An open-source, real-time airline tycoon where you own everything — your fleet, your
+              routes, your data. No middlemen. No subscriptions.
+            </p>
+          </div>
+
+          {/* Onboarding card */}
+          <div className="w-full max-w-sm rounded-2xl border border-border/60 bg-background/60 p-6 shadow-2xl backdrop-blur-xl">
+            <GuestKeyOnboarding onExistingAccount={handleExistingAccount} />
+          </div>
+        </section>
+
+        {/* Feature grid */}
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((f) => (
+            <div
+              key={f.title}
+              className="flex gap-3 rounded-xl border border-border/50 bg-background/50 p-4 backdrop-blur-sm"
+            >
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <f.icon className="h-4 w-4" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-foreground">{f.title}</p>
+                <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+                  {f.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        {/* Footer note */}
+        <p className="text-center text-[11px] text-muted-foreground/50">
+          Open source · MIT License · Powered by the Nostr protocol
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/routes/join.tsx
+++ b/apps/web/src/routes/join.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, lazyRouteComponent } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/join")({
+  component: lazyRouteComponent(() => import("./-join.lazy")),
+});

--- a/apps/web/src/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.test.tsx
@@ -7,10 +7,20 @@ import { Topbar } from "./Topbar";
 const mockUseAirlineStore = vi.fn();
 
 const mockUseActiveAirline = vi.fn();
+type MockAirlineStoreState = {
+  airline: AirlineEntity | null;
+  initializeIdentity: () => void;
+  createNewIdentity?: () => void;
+  loginWithNsec?: () => void;
+  isLoading: boolean;
+  isEphemeral: boolean;
+  error?: string | null;
+  viewAs: () => void;
+};
 
 vi.mock("@acars/store", () => {
   return {
-    useAirlineStore: (selector?: (state: { airline: AirlineEntity | null }) => unknown) => {
+    useAirlineStore: (selector?: (state: MockAirlineStoreState) => unknown) => {
       const state = mockUseAirlineStore();
       return selector ? selector(state) : state;
     },
@@ -23,6 +33,10 @@ vi.mock("@tanstack/react-router", () => {
     useNavigate: () => vi.fn(),
   };
 });
+
+vi.mock("@/features/identity/components/EphemeralKeyBackupActions", () => ({
+  EphemeralKeyBackupActions: () => <div>Backup Actions</div>,
+}));
 
 afterEach(() => {
   cleanup();
@@ -39,6 +53,7 @@ describe("Topbar", () => {
         createNewIdentity: vi.fn(),
         loginWithNsec: vi.fn(),
         isLoading: false,
+        isEphemeral: false,
         error: null,
         viewAs: vi.fn(),
       };
@@ -84,6 +99,7 @@ describe("Topbar", () => {
           airline,
           initializeIdentity: vi.fn(),
           isLoading: false,
+          isEphemeral: false,
           viewAs: vi.fn(),
         };
         return selector ? selector(state) : state;
@@ -130,6 +146,7 @@ describe("Topbar", () => {
           airline,
           initializeIdentity: vi.fn(),
           isLoading: false,
+          isEphemeral: false,
           viewAs: vi.fn(),
         };
         return selector ? selector(state) : state;
@@ -150,5 +167,52 @@ describe("Topbar", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /close flight deck/i }));
     expect(screen.queryByRole("dialog", { name: /flight deck/i })).not.toBeInTheDocument();
+  });
+
+  it("shows persistent account key tools for ephemeral airlines", () => {
+    const airline: AirlineEntity = {
+      id: "air-1",
+      foundedBy: "founder",
+      status: "private",
+      ceoPubkey: "ceo",
+      sharesOutstanding: 10000000,
+      shareholders: { ceo: 10000000 },
+      name: "Test Air",
+      icaoCode: "TST",
+      callsign: "TEST",
+      hubs: ["JFK"],
+      livery: { primary: "#111111", secondary: "#222222", accent: "#333333" },
+      brandScore: 0.7,
+      tier: 2,
+      cumulativeRevenue: fp(0),
+      corporateBalance: fp(1000000),
+      stockPrice: fp(12),
+      fleetIds: [],
+      routeIds: [],
+    };
+
+    mockUseAirlineStore.mockImplementation(
+      (selector?: (state: { airline: AirlineEntity }) => unknown) => {
+        const state = {
+          airline,
+          initializeIdentity: vi.fn(),
+          isLoading: false,
+          isEphemeral: true,
+          viewAs: vi.fn(),
+        };
+        return selector ? selector(state) : state;
+      },
+    );
+    mockUseActiveAirline.mockReturnValue({
+      airline,
+      timeline: [],
+      isViewingOther: false,
+    });
+
+    render(<Topbar />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Account key/i })[0]);
+    expect(screen.getByText("Local account key")).toBeInTheDocument();
+    expect(screen.getByText("Backup Actions")).toBeInTheDocument();
   });
 });

--- a/apps/web/src/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.test.tsx
@@ -36,7 +36,10 @@ describe("Topbar", () => {
       const state = {
         airline: null,
         initializeIdentity: vi.fn(),
+        createNewIdentity: vi.fn(),
+        loginWithNsec: vi.fn(),
         isLoading: false,
+        error: null,
         viewAs: vi.fn(),
       };
       return selector ? selector(state) : state;
@@ -48,11 +51,9 @@ describe("Topbar", () => {
     });
     render(<Topbar />);
     expect(screen.getAllByText("ACARS")).toHaveLength(2);
-    expect(
-      screen.getByRole("button", { name: /Continue with browser wallet/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Play Free/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /I already have an nsec key/i })).toBeInTheDocument();
-    expect(screen.getByText(/New to Nostr\? Start with a browser wallet/i)).toBeInTheDocument();
+    expect(screen.getByText(/New here\? Create a free account instantly/i)).toBeInTheDocument();
   });
 
   it("renders airline metrics when available", () => {

--- a/apps/web/src/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.test.tsx
@@ -53,7 +53,7 @@ describe("Topbar", () => {
     expect(screen.getAllByText("ACARS")).toHaveLength(2);
     expect(screen.getByRole("button", { name: /Play Free/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /I already have an nsec key/i })).toBeInTheDocument();
-    expect(screen.getByText(/New here\? Create a free account instantly/i)).toBeInTheDocument();
+    expect(screen.getByText(/New here\? Start free in one click/i)).toBeInTheDocument();
   });
 
   it("renders airline metrics when available", () => {

--- a/apps/web/src/shared/components/layout/Topbar.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.tsx
@@ -230,7 +230,7 @@ export function Topbar() {
           </div>
         )}
 
-        <div className="pointer-events-auto hidden w-full border-b border-border bg-background/80 px-4 py-3 backdrop-blur-xl sm:block sm:px-6">
+        <div className="pointer-events-auto hidden w-full border-b border-border bg-background/80 px-4 py-2.5 backdrop-blur-xl sm:block sm:px-6">
           <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center space-x-3">
               <div className="flex h-8 w-8 items-center justify-center rounded bg-primary/20 text-xs font-bold text-primary">
@@ -252,7 +252,7 @@ export function Topbar() {
             <div className="w-full sm:w-auto">
               {showNsecInput ? (
                 <form
-                  className="flex w-full flex-col gap-2 sm:max-w-sm sm:items-end"
+                  className="flex w-full flex-col gap-2 sm:max-w-none sm:flex-row sm:items-center"
                   onSubmit={async (e) => {
                     e.preventDefault();
                     const normalized = (
@@ -271,10 +271,7 @@ export function Topbar() {
                     }
                   }}
                 >
-                  <label
-                    htmlFor="topbar-nsec"
-                    className="text-[11px] text-muted-foreground sm:max-w-xs sm:text-right"
-                  >
+                  <label htmlFor="topbar-nsec" className="sr-only">
                     Already have a Nostr secret key? Paste your nsec1 to sign in.
                   </label>
                   <input
@@ -283,9 +280,9 @@ export function Topbar() {
                     type="password"
                     placeholder="Paste your nsec1 key"
                     autoComplete="off"
-                    className="min-h-11 w-full rounded-md border border-border bg-background/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary/60 focus:outline-none"
+                    className="min-h-11 w-full rounded-md border border-border bg-background/70 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:border-primary/60 focus:outline-none sm:w-72"
                   />
-                  <div className="flex w-full gap-2 sm:justify-end">
+                  <div className="flex w-full gap-2 sm:w-auto sm:shrink-0">
                     <button
                       type="submit"
                       disabled={isLoading}
@@ -313,10 +310,10 @@ export function Topbar() {
                 </form>
               ) : (
                 <div className="flex w-full flex-col gap-2 sm:items-end">
-                  <p className="text-[11px] text-muted-foreground sm:max-w-xs sm:text-right">
-                    New here? Create a free account instantly — no sign-up needed.
-                  </p>
-                  <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
+                  <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
+                    <p className="mr-1 hidden text-[11px] text-muted-foreground lg:block">
+                      New here? Start free in one click.
+                    </p>
                     <button
                       type="button"
                       onClick={createNewIdentity}
@@ -346,16 +343,16 @@ export function Topbar() {
                     >
                       <KeyRound className="h-4 w-4 shrink-0" />I already have an nsec key
                     </button>
+                    <a
+                      href="https://nostr.com"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="hidden min-h-11 items-center gap-2 rounded-md border border-border/60 bg-background/50 px-3 py-2 text-sm font-medium text-muted-foreground transition hover:border-border hover:text-foreground xl:inline-flex"
+                    >
+                      <CircleHelp className="h-4 w-4 shrink-0" />
+                      What is Nostr?
+                    </a>
                   </div>
-                  <a
-                    href="https://nostr.com"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex min-h-11 items-center gap-2 self-start rounded-md border border-border/60 bg-background/50 px-3 py-2 text-sm font-medium text-muted-foreground transition hover:border-border hover:text-foreground sm:self-end"
-                  >
-                    <CircleHelp className="h-4 w-4 shrink-0" />
-                    What is Nostr?
-                  </a>
                 </div>
               )}
             </div>

--- a/apps/web/src/shared/components/layout/Topbar.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.tsx
@@ -3,6 +3,7 @@ import { useActiveAirline, useAirlineStore } from "@acars/store";
 import { useNavigate } from "@tanstack/react-router";
 import { AlertTriangle, CircleHelp, KeyRound, Menu, Sparkles, Wallet, X } from "lucide-react";
 import { useState } from "react";
+import { EphemeralKeyBackupActions } from "@/features/identity/components/EphemeralKeyBackupActions";
 import { useFinancialPulse } from "@/features/corporate/hooks/useFinancialPulse";
 import { useRelayHealth } from "@/shared/hooks/useRelayHealth";
 
@@ -12,6 +13,7 @@ export function Topbar() {
   const loginWithNsec = useAirlineStore((state) => state.loginWithNsec);
   const createNewIdentity = useAirlineStore((state) => state.createNewIdentity);
   const authError = useAirlineStore((state) => state.error);
+  const isEphemeral = useAirlineStore((state) => state.isEphemeral);
   const isLoading = useAirlineStore((state) => state.isLoading);
   const viewAs = useAirlineStore((state) => state.viewAs);
   const { airline: activeAirline, timeline, isViewingOther } = useActiveAirline();
@@ -23,9 +25,11 @@ export function Topbar() {
   const [showNsecInput, setShowNsecInput] = useState(false);
   const [nsecInputError, setNsecInputError] = useState<string | null>(null);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [showKeyTools, setShowKeyTools] = useState(false);
 
   const mobilePanelTitle = airline ? "Flight deck" : "Identity";
   const mobilePanelLabel = mobilePanelTitle.toLowerCase();
+  const canManageLocalKey = isEphemeral && !isViewingOther;
 
   function renderMobileToggle(summary: React.ReactNode) {
     return (
@@ -385,7 +389,7 @@ export function Topbar() {
           aria-label={mobilePanelTitle}
         >
           {renderBankruptcyBanner()}
-          <div className="flex w-full flex-col gap-3 md:h-14 md:flex-row md:items-center md:justify-between">
+          <div className="flex w-full flex-col gap-3 md:min-h-14 md:flex-row md:items-center md:justify-between">
             <div className="flex min-w-0 flex-wrap items-center gap-3 sm:gap-4">
               <div
                 className="flex h-8 w-8 items-center justify-center rounded uppercase text-[10px] font-bold shadow-sm"
@@ -416,6 +420,18 @@ export function Topbar() {
                   className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-muted-foreground hover:border-primary/40 hover:text-foreground"
                 >
                   Back to Your Airline
+                </button>
+              )}
+              {canManageLocalKey && (
+                <button
+                  type="button"
+                  onClick={() => setShowKeyTools((open) => !open)}
+                  className="rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-amber-200 transition hover:bg-amber-500/20"
+                >
+                  <span className="inline-flex items-center gap-1.5">
+                    <KeyRound className="h-3.5 w-3.5" />
+                    {showKeyTools ? "Hide key tools" : "Account key"}
+                  </span>
                 </button>
               )}
             </div>
@@ -479,103 +495,143 @@ export function Topbar() {
               </div>
             </div>
           </div>
+          {canManageLocalKey && showKeyTools && (
+            <div className="mt-3 rounded-2xl border border-amber-500/20 bg-amber-950/40 p-3">
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-300">
+                Local account key
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-amber-200/80">
+                Export your recovery key anytime from here. Keep it somewhere only you can access.
+              </p>
+              <div className="mt-3">
+                <EphemeralKeyBackupActions />
+              </div>
+            </div>
+          )}
         </div>
       )}
 
       <div className="hidden sm:block">{renderBankruptcyBanner()}</div>
       <div className="pointer-events-auto hidden w-full border-b border-border bg-background/80 px-4 py-3 backdrop-blur-xl sm:block sm:px-6 md:py-2">
-        <div className="flex w-full flex-col gap-3 md:h-14 md:flex-row md:items-center md:justify-between">
-          <div className="flex min-w-0 flex-wrap items-center gap-3 sm:gap-4">
-            <div
-              className="flex h-8 w-8 items-center justify-center rounded uppercase text-[10px] font-bold shadow-sm"
-              style={{
-                backgroundColor: activeAirline.livery.primary,
-                color: activeAirline.livery.secondary,
-                border: `1px solid ${activeAirline.livery.secondary}40`,
-              }}
-            >
-              {activeAirline.icaoCode}
-            </div>
-            <div className="min-w-0">
-              <h1 className="text-sm leading-none font-bold tracking-tight text-foreground">
-                {activeAirline.name}
-              </h1>
-              <p className="mt-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">
-                {activeAirline.callsign}
-              </p>
-            </div>
-            {isViewingOther && (
-              <button
-                type="button"
-                onClick={() => {
-                  viewAs(null);
-                  navigate({ to: "/" });
+        <div className="flex w-full flex-col gap-3 md:min-h-14 md:justify-between">
+          <div className="flex w-full flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="flex min-w-0 flex-wrap items-center gap-3 sm:gap-4">
+              <div
+                className="flex h-8 w-8 items-center justify-center rounded uppercase text-[10px] font-bold shadow-sm"
+                style={{
+                  backgroundColor: activeAirline.livery.primary,
+                  color: activeAirline.livery.secondary,
+                  border: `1px solid ${activeAirline.livery.secondary}40`,
                 }}
-                className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-muted-foreground hover:border-primary/40 hover:text-foreground"
               >
-                Back to Your Airline
-              </button>
-            )}
-          </div>
+                {activeAirline.icaoCode}
+              </div>
+              <div className="min-w-0">
+                <h1 className="text-sm leading-none font-bold tracking-tight text-foreground">
+                  {activeAirline.name}
+                </h1>
+                <p className="mt-0.5 text-[10px] uppercase tracking-widest text-muted-foreground">
+                  {activeAirline.callsign}
+                </p>
+              </div>
+              {isViewingOther && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    viewAs(null);
+                    navigate({ to: "/" });
+                  }}
+                  className="rounded-full border border-border/60 bg-background/60 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-muted-foreground hover:border-primary/40 hover:text-foreground"
+                >
+                  Back to Your Airline
+                </button>
+              )}
+              {canManageLocalKey && (
+                <button
+                  type="button"
+                  onClick={() => setShowKeyTools((open) => !open)}
+                  className="rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-amber-200 transition hover:bg-amber-500/20"
+                >
+                  <span className="inline-flex items-center gap-1.5">
+                    <KeyRound className="h-3.5 w-3.5" />
+                    {showKeyTools ? "Hide key tools" : "Account key"}
+                  </span>
+                </button>
+              )}
+            </div>
 
-          <div
-            data-testid="topbar-metrics"
-            className="grid w-full grid-cols-2 gap-2 md:flex md:w-auto md:items-center md:space-x-6"
-          >
-            <output
-              className="col-span-2 flex min-h-11 items-center gap-2 rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:border-0 md:bg-transparent md:p-0"
-              aria-live="polite"
-              title={
-                isConnected
-                  ? `${relayCount} relay${relayCount !== 1 ? "s" : ""} connected`
-                  : "Disconnected from Nostr — changes may not save"
-              }
+            <div
+              data-testid="topbar-metrics"
+              className="grid w-full grid-cols-2 gap-2 md:flex md:w-auto md:items-center md:space-x-6"
             >
-              <span
-                className={`inline-block h-2 w-2 rounded-full ${isConnected ? "bg-emerald-400" : "animate-pulse bg-rose-500"}`}
-              />
-              <span className="text-[11px] font-medium text-muted-foreground">
-                {isConnected
-                  ? `${relayCount} relay${relayCount !== 1 ? "s" : ""} online`
-                  : "Nostr relays offline"}
-              </span>
-            </output>
-            <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
-              <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
-                Corporate Balance
-              </span>
-              <span className="mt-1 font-mono text-sm font-bold text-green-400">
-                {fpFormat(activeAirline.corporateBalance)}
-              </span>
-            </div>
-            <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
-              <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
-                Stock Price
-              </span>
-              <span className="mt-1 font-mono text-sm font-bold text-primary">
-                {fpFormat(activeAirline.stockPrice)}
-              </span>
-            </div>
-            <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
-              <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
-                Brand / Tier
-              </span>
-              <span className="mt-1 font-mono text-sm font-bold text-foreground md:text-right">
-                {(activeAirline.brandScore * 10).toFixed(1)}{" "}
-                <span className="text-muted-foreground">T{activeAirline.tier}</span>
-              </span>
-            </div>
-            <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
-              <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
-                Avg Load Factor
-              </span>
-              <span
-                className={`mt-1 font-mono text-sm font-bold ${avgLoadFactor >= 0.8 ? "text-emerald-400" : avgLoadFactor >= 0.6 ? "text-amber-400" : "text-rose-400"}`}
+              <output
+                className="col-span-2 flex min-h-11 items-center gap-2 rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:border-0 md:bg-transparent md:p-0"
+                aria-live="polite"
+                title={
+                  isConnected
+                    ? `${relayCount} relay${relayCount !== 1 ? "s" : ""} connected`
+                    : "Disconnected from Nostr — changes may not save"
+                }
               >
-                {Math.round(avgLoadFactor * 100)}%
-              </span>
+                <span
+                  className={`inline-block h-2 w-2 rounded-full ${isConnected ? "bg-emerald-400" : "animate-pulse bg-rose-500"}`}
+                />
+                <span className="text-[11px] font-medium text-muted-foreground">
+                  {isConnected
+                    ? `${relayCount} relay${relayCount !== 1 ? "s" : ""} online`
+                    : "Nostr relays offline"}
+                </span>
+              </output>
+              <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
+                <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
+                  Corporate Balance
+                </span>
+                <span className="mt-1 font-mono text-sm font-bold text-green-400">
+                  {fpFormat(activeAirline.corporateBalance)}
+                </span>
+              </div>
+              <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
+                <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
+                  Stock Price
+                </span>
+                <span className="mt-1 font-mono text-sm font-bold text-primary">
+                  {fpFormat(activeAirline.stockPrice)}
+                </span>
+              </div>
+              <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
+                <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
+                  Brand / Tier
+                </span>
+                <span className="mt-1 font-mono text-sm font-bold text-foreground md:text-right">
+                  {(activeAirline.brandScore * 10).toFixed(1)}{" "}
+                  <span className="text-muted-foreground">T{activeAirline.tier}</span>
+                </span>
+              </div>
+              <div className="flex min-h-11 flex-col justify-center rounded-xl border border-border/60 bg-background/60 px-3 py-2 md:min-h-0 md:items-end md:border-0 md:bg-transparent md:p-0">
+                <span className="text-[10px] leading-none font-semibold uppercase text-muted-foreground">
+                  Avg Load Factor
+                </span>
+                <span
+                  className={`mt-1 font-mono text-sm font-bold ${avgLoadFactor >= 0.8 ? "text-emerald-400" : avgLoadFactor >= 0.6 ? "text-amber-400" : "text-rose-400"}`}
+                >
+                  {Math.round(avgLoadFactor * 100)}%
+                </span>
+              </div>
             </div>
           </div>
+          {canManageLocalKey && showKeyTools && (
+            <div className="rounded-2xl border border-amber-500/20 bg-amber-950/40 p-3">
+              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-amber-300">
+                Local account key
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-amber-200/80">
+                Export your recovery key anytime from here. Keep it somewhere only you can access.
+              </p>
+              <div className="mt-3">
+                <EphemeralKeyBackupActions />
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/apps/web/src/shared/components/layout/Topbar.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.tsx
@@ -1,7 +1,7 @@
 import { fpFormat } from "@acars/core";
 import { useActiveAirline, useAirlineStore } from "@acars/store";
 import { useNavigate } from "@tanstack/react-router";
-import { AlertTriangle, CircleHelp, KeyRound, Menu, Wallet, X } from "lucide-react";
+import { AlertTriangle, CircleHelp, KeyRound, Menu, Sparkles, Wallet, X } from "lucide-react";
 import { useState } from "react";
 import { useFinancialPulse } from "@/features/corporate/hooks/useFinancialPulse";
 import { useRelayHealth } from "@/shared/hooks/useRelayHealth";
@@ -10,6 +10,7 @@ export function Topbar() {
   const airline = useAirlineStore((state) => state.airline);
   const initializeIdentity = useAirlineStore((state) => state.initializeIdentity);
   const loginWithNsec = useAirlineStore((state) => state.loginWithNsec);
+  const createNewIdentity = useAirlineStore((state) => state.createNewIdentity);
   const authError = useAirlineStore((state) => state.error);
   const isLoading = useAirlineStore((state) => state.isLoading);
   const viewAs = useAirlineStore((state) => state.viewAs);
@@ -179,18 +180,26 @@ export function Topbar() {
                   ) : (
                     <div className="flex w-full flex-col gap-2 sm:items-end">
                       <p className="text-[11px] text-muted-foreground sm:max-w-xs sm:text-right">
-                        New to Nostr? Start with a browser wallet. Already have a key? Import it
-                        directly.
+                        New here? Create a free account instantly — no sign-up needed.
                       </p>
                       <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
                         <button
                           type="button"
+                          onClick={createNewIdentity}
+                          disabled={isLoading}
+                          className="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border border-primary/50 bg-primary/15 px-3 py-2 text-sm font-bold text-primary transition hover:bg-primary/25 disabled:opacity-60 sm:w-auto"
+                        >
+                          <Sparkles className="h-4 w-4 shrink-0" />
+                          {isLoading ? "Creating…" : "Play Free"}
+                        </button>
+                        <button
+                          type="button"
                           onClick={initializeIdentity}
                           disabled={isLoading}
-                          className="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-semibold text-primary transition hover:bg-primary/20 disabled:opacity-60 sm:w-auto"
+                          className="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border border-border bg-background/70 px-3 py-2 text-sm font-medium text-muted-foreground transition hover:border-primary/40 hover:text-foreground disabled:opacity-60 sm:w-auto"
                         >
                           <Wallet className="h-4 w-4 shrink-0" />
-                          {isLoading ? "Connecting…" : "Continue with browser wallet"}
+                          {isLoading ? "Connecting…" : "Browser wallet"}
                         </button>
                         <button
                           type="button"
@@ -305,18 +314,26 @@ export function Topbar() {
               ) : (
                 <div className="flex w-full flex-col gap-2 sm:items-end">
                   <p className="text-[11px] text-muted-foreground sm:max-w-xs sm:text-right">
-                    New to Nostr? Start with a browser wallet. Already have a key? Import it
-                    directly.
+                    New here? Create a free account instantly — no sign-up needed.
                   </p>
                   <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row">
                     <button
                       type="button"
+                      onClick={createNewIdentity}
+                      disabled={isLoading}
+                      className="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border border-primary/50 bg-primary/15 px-3 py-2 text-sm font-bold text-primary transition hover:bg-primary/25 disabled:opacity-60 sm:w-auto"
+                    >
+                      <Sparkles className="h-4 w-4 shrink-0" />
+                      {isLoading ? "Creating…" : "Play Free"}
+                    </button>
+                    <button
+                      type="button"
                       onClick={initializeIdentity}
                       disabled={isLoading}
-                      className="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border border-primary/40 bg-primary/10 px-3 py-2 text-sm font-semibold text-primary transition hover:bg-primary/20 disabled:opacity-60 sm:w-auto"
+                      className="flex min-h-11 w-full items-center justify-center gap-2 rounded-md border border-border bg-background/70 px-3 py-2 text-sm font-medium text-muted-foreground transition hover:border-primary/40 hover:text-foreground disabled:opacity-60 sm:w-auto"
                     >
                       <Wallet className="h-4 w-4 shrink-0" />
-                      {isLoading ? "Connecting…" : "Continue with browser wallet"}
+                      {isLoading ? "Connecting…" : "Browser wallet"}
                     </button>
                     <button
                       type="button"

--- a/packages/nostr/package.json
+++ b/packages/nostr/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "@acars/core": "workspace:^",
     "@nostr-dev-kit/ndk": "^2.15.2",
-    "@nostr-dev-kit/ndk-blossom": "^2.0.2"
+    "@nostr-dev-kit/ndk-blossom": "^2.0.2",
+    "nostr-tools": "^2.23.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/nostr/src/identity.test.ts
+++ b/packages/nostr/src/identity.test.ts
@@ -41,9 +41,11 @@ import {
   clearEphemeralKey,
   generateNewKeypair,
   getPubkey,
+  hasStoredEphemeralKey,
   hasNip07,
   loadEphemeralKey,
   loginWithNsec,
+  resetSigner,
   saveEphemeralKey,
   waitForNip07,
 } from "./identity.js";
@@ -127,6 +129,16 @@ describe("identity", () => {
     expect(ndk.signer).not.toBe(privateSigner);
   });
 
+  it("can reset an attached signer explicitly", async () => {
+    privateSignerUserMock.mockResolvedValueOnce({ pubkey: "pubkey-1" });
+
+    await loginWithNsec("nsec1valid");
+    expect(ndk.signer).not.toBeNull();
+
+    resetSigner();
+    expect(ndk.signer).toBeUndefined();
+  });
+
   it("loginWithNsec validates before attaching signer", async () => {
     let resolveUser: ((value: { pubkey: string }) => void) | null = null;
     privateSignerUserMock.mockImplementation(
@@ -154,17 +166,21 @@ describe("identity", () => {
     expect(ndk.signer).toBeNull();
   });
 
-  it("persists and clears ephemeral keys from localStorage", () => {
+  it("persists and clears ephemeral keys from localStorage when secure storage is unavailable", async () => {
     (globalThis as any).window = {};
     (globalThis as any).localStorage = localStorageMock;
 
-    saveEphemeralKey("nsec1saved");
+    await saveEphemeralKey("nsec1saved");
     expect(localStorageMock.setItem).toHaveBeenCalledWith("acars:ephemeral:nsec", "nsec1saved");
 
-    localStorageMock.getItem.mockReturnValueOnce("nsec1saved");
-    expect(loadEphemeralKey()).toBe("nsec1saved");
+    localStorageMock.getItem.mockImplementation((key) =>
+      key === "acars:ephemeral:nsec" ? "nsec1saved" : null,
+    );
+    expect(hasStoredEphemeralKey()).toBe(true);
+    await expect(loadEphemeralKey()).resolves.toBe("nsec1saved");
 
-    clearEphemeralKey();
+    await clearEphemeralKey();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith("acars:ephemeral:nsec:secure");
     expect(localStorageMock.removeItem).toHaveBeenCalledWith("acars:ephemeral:nsec");
   });
 

--- a/packages/nostr/src/identity.test.ts
+++ b/packages/nostr/src/identity.test.ts
@@ -5,6 +5,11 @@ const signerMock = vi.fn();
 const privateSignerCtorMock = vi.fn();
 const privateSignerUserMock = vi.fn();
 const ndk = { signer: null as unknown };
+const localStorageMock = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+};
 
 vi.mock("@nostr-dev-kit/ndk", () => {
   return {
@@ -31,7 +36,17 @@ vi.mock("./ndk.js", () => {
   };
 });
 
-import { attachSigner, getPubkey, hasNip07, loginWithNsec, waitForNip07 } from "./identity.js";
+import {
+  attachSigner,
+  clearEphemeralKey,
+  generateNewKeypair,
+  getPubkey,
+  hasNip07,
+  loadEphemeralKey,
+  loginWithNsec,
+  saveEphemeralKey,
+  waitForNip07,
+} from "./identity.js";
 
 describe("identity", () => {
   beforeEach(() => {
@@ -39,8 +54,12 @@ describe("identity", () => {
     signerMock.mockReset();
     privateSignerCtorMock.mockReset();
     privateSignerUserMock.mockReset();
+    localStorageMock.getItem.mockReset();
+    localStorageMock.setItem.mockReset();
+    localStorageMock.removeItem.mockReset();
     ndk.signer = null;
     delete (globalThis as any).window;
+    delete (globalThis as any).localStorage;
   });
 
   afterEach(() => {
@@ -82,6 +101,32 @@ describe("identity", () => {
     expect(signerMock).toHaveBeenCalledWith(15000);
   });
 
+  it("does not override an active private-key signer unless forced", async () => {
+    let resolveUser: ((value: { pubkey: string }) => void) | null = null;
+    privateSignerUserMock.mockImplementation(
+      () =>
+        new Promise<{ pubkey: string }>((resolve) => {
+          resolveUser = resolve;
+        }),
+    );
+
+    const loginPromise = loginWithNsec("nsec1valid");
+    if (!resolveUser) throw new Error("Expected signer.user resolver");
+    resolveUser({ pubkey: "pubkey-1" });
+    await loginPromise;
+
+    const privateSigner = ndk.signer;
+    (globalThis as any).window = { nostr: { getPublicKey: getPublicKeyMock } };
+
+    attachSigner();
+    expect(ndk.signer).toBe(privateSigner);
+    expect(signerMock).not.toHaveBeenCalled();
+
+    attachSigner(true);
+    expect(signerMock).toHaveBeenCalledWith(15000);
+    expect(ndk.signer).not.toBe(privateSigner);
+  });
+
   it("loginWithNsec validates before attaching signer", async () => {
     let resolveUser: ((value: { pubkey: string }) => void) | null = null;
     privateSignerUserMock.mockImplementation(
@@ -107,5 +152,25 @@ describe("identity", () => {
 
     await expect(loginWithNsec("nsec1bad")).rejects.toThrow("invalid nsec");
     expect(ndk.signer).toBeNull();
+  });
+
+  it("persists and clears ephemeral keys from localStorage", () => {
+    (globalThis as any).window = {};
+    (globalThis as any).localStorage = localStorageMock;
+
+    saveEphemeralKey("nsec1saved");
+    expect(localStorageMock.setItem).toHaveBeenCalledWith("acars:ephemeral:nsec", "nsec1saved");
+
+    localStorageMock.getItem.mockReturnValueOnce("nsec1saved");
+    expect(loadEphemeralKey()).toBe("nsec1saved");
+
+    clearEphemeralKey();
+    expect(localStorageMock.removeItem).toHaveBeenCalledWith("acars:ephemeral:nsec");
+  });
+
+  it("generates a valid nsec/pubkey pair", () => {
+    const { nsec, pubkey } = generateNewKeypair();
+    expect(nsec.startsWith("nsec1")).toBe(true);
+    expect(pubkey).toMatch(/^[0-9a-f]{64}$/);
   });
 });

--- a/packages/nostr/src/identity.ts
+++ b/packages/nostr/src/identity.ts
@@ -2,7 +2,120 @@ import { NDKNip07Signer, NDKPrivateKeySigner } from "@nostr-dev-kit/ndk";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { getNDK } from "./ndk.js";
 
-const EPHEMERAL_KEY_STORAGE = "acars:ephemeral:nsec";
+const LEGACY_EPHEMERAL_KEY_STORAGE = "acars:ephemeral:nsec";
+const SECURE_EPHEMERAL_KEY_STORAGE = "acars:ephemeral:nsec:secure";
+const SECURE_STORAGE_DB = "acars-secure-storage";
+const SECURE_STORAGE_STORE = "keys";
+const SECURE_STORAGE_KEY = "ephemeral-nsec";
+
+interface EncryptedEphemeralKeyPayload {
+  version: 1;
+  iv: string;
+  ciphertext: string;
+}
+
+let encryptionKeyPromise: Promise<CryptoKey | null> | null = null;
+
+function canUseSecureEphemeralStorage(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof indexedDB !== "undefined" &&
+    typeof globalThis.crypto?.subtle !== "undefined"
+  );
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const value of bytes) {
+    binary += String.fromCharCode(value);
+  }
+  return btoa(binary);
+}
+
+function base64ToArrayBuffer(value: string): ArrayBuffer {
+  const binary = atob(value);
+  const buffer = new ArrayBuffer(binary.length);
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return buffer;
+}
+
+function openSecureStorageDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(SECURE_STORAGE_DB, 1);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(SECURE_STORAGE_STORE)) {
+        db.createObjectStore(SECURE_STORAGE_STORE);
+      }
+    };
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("Unable to open secure key storage."));
+  });
+}
+
+async function readStoredEncryptionKey(): Promise<CryptoKey | null> {
+  const db = await openSecureStorageDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(SECURE_STORAGE_STORE, "readonly");
+    const request = tx.objectStore(SECURE_STORAGE_STORE).get(SECURE_STORAGE_KEY);
+
+    tx.oncomplete = () => db.close();
+    tx.onerror = () => reject(tx.error ?? new Error("Unable to read secure key storage."));
+    request.onsuccess = () => resolve((request.result as CryptoKey | undefined) ?? null);
+    request.onerror = () => reject(request.error ?? new Error("Unable to read secure key."));
+  });
+}
+
+async function writeStoredEncryptionKey(key: CryptoKey): Promise<void> {
+  const db = await openSecureStorageDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(SECURE_STORAGE_STORE, "readwrite");
+    tx.objectStore(SECURE_STORAGE_STORE).put(key, SECURE_STORAGE_KEY);
+
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    tx.onerror = () => reject(tx.error ?? new Error("Unable to persist secure key."));
+  });
+}
+
+async function getOrCreateEncryptionKey(): Promise<CryptoKey | null> {
+  if (!canUseSecureEphemeralStorage()) return null;
+
+  if (!encryptionKeyPromise) {
+    encryptionKeyPromise = (async () => {
+      const existingKey = await readStoredEncryptionKey();
+      if (existingKey) return existingKey;
+
+      const createdKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, false, [
+        "encrypt",
+        "decrypt",
+      ]);
+
+      await writeStoredEncryptionKey(createdKey as CryptoKey);
+      return createdKey as CryptoKey;
+    })().catch((error) => {
+      encryptionKeyPromise = null;
+      throw error;
+    });
+  }
+
+  return encryptionKeyPromise;
+}
+
+function warnSecureStorageFallback(error: unknown) {
+  console.warn(
+    "[Nostr] Secure ephemeral key storage unavailable, falling back to plain localStorage.",
+    error,
+  );
+}
 
 /**
  * Generate a brand-new Nostr keypair entirely in the browser.
@@ -16,30 +129,116 @@ export function generateNewKeypair(): { nsec: string; pubkey: string } {
 }
 
 /**
- * Persist an ephemeral nsec to localStorage so it survives page reload.
- * This is intentionally "just localStorage" — the SecurityUpgradeBanner
- * will prompt the user to export/protect it properly.
+ * Persist an ephemeral nsec locally so it survives page reload.
+ * We prefer AES-GCM ciphertext in localStorage with a non-extractable
+ * origin-bound CryptoKey stored in IndexedDB. If that stack is unavailable,
+ * we fall back to plain localStorage so recovery still works.
  */
-export function saveEphemeralKey(nsec: string): void {
+export async function saveEphemeralKey(nsec: string): Promise<void> {
   if (typeof window === "undefined") return;
-  localStorage.setItem(EPHEMERAL_KEY_STORAGE, nsec);
+
+  if (!canUseSecureEphemeralStorage()) {
+    localStorage.setItem(LEGACY_EPHEMERAL_KEY_STORAGE, nsec);
+    localStorage.removeItem(SECURE_EPHEMERAL_KEY_STORAGE);
+    return;
+  }
+
+  try {
+    const encryptionKey = await getOrCreateEncryptionKey();
+    if (!encryptionKey) {
+      localStorage.setItem(LEGACY_EPHEMERAL_KEY_STORAGE, nsec);
+      return;
+    }
+
+    const iv = crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      encryptionKey,
+      new TextEncoder().encode(nsec),
+    );
+
+    const payload: EncryptedEphemeralKeyPayload = {
+      version: 1,
+      iv: bytesToBase64(iv),
+      ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+    };
+
+    localStorage.setItem(SECURE_EPHEMERAL_KEY_STORAGE, JSON.stringify(payload));
+    localStorage.removeItem(LEGACY_EPHEMERAL_KEY_STORAGE);
+  } catch (error) {
+    warnSecureStorageFallback(error);
+    localStorage.setItem(LEGACY_EPHEMERAL_KEY_STORAGE, nsec);
+    localStorage.removeItem(SECURE_EPHEMERAL_KEY_STORAGE);
+  }
+}
+
+export function hasStoredEphemeralKey(): boolean {
+  if (typeof window === "undefined") return false;
+  return Boolean(
+    localStorage.getItem(SECURE_EPHEMERAL_KEY_STORAGE) ??
+      localStorage.getItem(LEGACY_EPHEMERAL_KEY_STORAGE),
+  );
 }
 
 /**
- * Load a previously saved ephemeral nsec from localStorage.
- * Returns null if nothing is stored.
+ * Load a previously saved ephemeral nsec from browser storage.
+ * Legacy plain-text values are transparently migrated when possible.
  */
-export function loadEphemeralKey(): string | null {
+export async function loadEphemeralKey(): Promise<string | null> {
   if (typeof window === "undefined") return null;
-  return localStorage.getItem(EPHEMERAL_KEY_STORAGE);
+
+  const encryptedPayload = localStorage.getItem(SECURE_EPHEMERAL_KEY_STORAGE);
+  if (encryptedPayload) {
+    if (!canUseSecureEphemeralStorage()) {
+      throw new Error("This browser cannot unlock the locally stored account key.");
+    }
+
+    const encryptionKey = await getOrCreateEncryptionKey();
+    if (!encryptionKey) {
+      throw new Error("This browser cannot unlock the locally stored account key.");
+    }
+
+    let parsedPayload: EncryptedEphemeralKeyPayload;
+    try {
+      parsedPayload = JSON.parse(encryptedPayload) as EncryptedEphemeralKeyPayload;
+    } catch {
+      throw new Error("Stored account key data is unreadable.");
+    }
+
+    if (
+      parsedPayload.version !== 1 ||
+      typeof parsedPayload.iv !== "string" ||
+      typeof parsedPayload.ciphertext !== "string"
+    ) {
+      throw new Error("Stored account key data is invalid.");
+    }
+
+    try {
+      const decrypted = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: base64ToArrayBuffer(parsedPayload.iv) },
+        encryptionKey,
+        base64ToArrayBuffer(parsedPayload.ciphertext),
+      );
+      return new TextDecoder().decode(decrypted);
+    } catch {
+      throw new Error("Stored account key data could not be decrypted.");
+    }
+  }
+
+  const legacyKey = localStorage.getItem(LEGACY_EPHEMERAL_KEY_STORAGE);
+  if (!legacyKey) return null;
+
+  await saveEphemeralKey(legacyKey);
+  return legacyKey;
 }
 
 /**
  * Remove the stored ephemeral key (e.g., after user exports it or upgrades to a proper signer).
  */
-export function clearEphemeralKey(): void {
+export async function clearEphemeralKey(): Promise<void> {
   if (typeof window === "undefined") return;
-  localStorage.removeItem(EPHEMERAL_KEY_STORAGE);
+  localStorage.removeItem(SECURE_EPHEMERAL_KEY_STORAGE);
+  localStorage.removeItem(LEGACY_EPHEMERAL_KEY_STORAGE);
 }
 
 /**
@@ -122,6 +321,11 @@ export function attachSigner(forceRefresh = false): void {
   if (!forceRefresh && ndk.signer instanceof NDKPrivateKeySigner) return;
   // Always create a fresh NIP-07 signer to avoid cached identity.
   ndk.signer = new NDKNip07Signer(15000);
+}
+
+export function resetSigner(): void {
+  const ndk = getNDK();
+  ndk.signer = undefined;
 }
 
 /**

--- a/packages/nostr/src/identity.ts
+++ b/packages/nostr/src/identity.ts
@@ -1,5 +1,46 @@
 import { NDKNip07Signer, NDKPrivateKeySigner } from "@nostr-dev-kit/ndk";
+import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { getNDK } from "./ndk.js";
+
+const EPHEMERAL_KEY_STORAGE = "acars:ephemeral:nsec";
+
+/**
+ * Generate a brand-new Nostr keypair entirely in the browser.
+ * Returns the nsec1-encoded secret key and the hex pubkey.
+ */
+export function generateNewKeypair(): { nsec: string; pubkey: string } {
+  const sk = generateSecretKey();
+  const nsec = nip19.nsecEncode(sk);
+  const pubkey = getPublicKey(sk);
+  return { nsec, pubkey };
+}
+
+/**
+ * Persist an ephemeral nsec to localStorage so it survives page reload.
+ * This is intentionally "just localStorage" — the SecurityUpgradeBanner
+ * will prompt the user to export/protect it properly.
+ */
+export function saveEphemeralKey(nsec: string): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(EPHEMERAL_KEY_STORAGE, nsec);
+}
+
+/**
+ * Load a previously saved ephemeral nsec from localStorage.
+ * Returns null if nothing is stored.
+ */
+export function loadEphemeralKey(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(EPHEMERAL_KEY_STORAGE);
+}
+
+/**
+ * Remove the stored ephemeral key (e.g., after user exports it or upgrades to a proper signer).
+ */
+export function clearEphemeralKey(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(EPHEMERAL_KEY_STORAGE);
+}
 
 /**
  * Check if a NIP-07 extension (nos2x, Alby, etc.) is available RIGHT NOW.

--- a/packages/nostr/src/identity.ts
+++ b/packages/nostr/src/identity.ts
@@ -111,13 +111,16 @@ export async function getPubkey(timeoutMs = 15000): Promise<string | null> {
  * Attach the NIP-07 signer to NDK for event signing.
  * Must be called after confirming NIP-07 is available.
  *
- * We create a NEW signer each time to avoid the cached _userPromise
- * issue when users switch identities in their extension.
+ * By default, we do not override an existing private-key signer because
+ * nsec/ephemeral sessions must keep signing with their current identity
+ * even when a browser extension is present. Pass forceRefresh=true when
+ * intentionally switching back to the browser extension.
  */
-export function attachSigner(): void {
+export function attachSigner(forceRefresh = false): void {
   if (!hasNip07()) return;
   const ndk = getNDK();
-  // Always create a fresh signer to avoid cached identity
+  if (!forceRefresh && ndk.signer instanceof NDKPrivateKeySigner) return;
+  // Always create a fresh NIP-07 signer to avoid cached identity.
   ndk.signer = new NDKNip07Signer(15000);
 }
 

--- a/packages/nostr/src/index.ts
+++ b/packages/nostr/src/index.ts
@@ -3,9 +3,13 @@ export { NDKEvent } from "@nostr-dev-kit/ndk";
 export { uploadToBlossom } from "./blossom.js";
 export {
   attachSigner,
+  clearEphemeralKey,
+  generateNewKeypair,
   getPubkey,
   hasNip07,
+  loadEphemeralKey,
   loginWithNsec,
+  saveEphemeralKey,
   waitForNip07,
 } from "./identity.js";
 export {

--- a/packages/nostr/src/index.ts
+++ b/packages/nostr/src/index.ts
@@ -6,9 +6,11 @@ export {
   clearEphemeralKey,
   generateNewKeypair,
   getPubkey,
+  hasStoredEphemeralKey,
   hasNip07,
   loadEphemeralKey,
   loginWithNsec,
+  resetSigner,
   saveEphemeralKey,
   waitForNip07,
 } from "./identity.js";

--- a/packages/store/src/slices/identitySlice.test.ts
+++ b/packages/store/src/slices/identitySlice.test.ts
@@ -9,14 +9,28 @@ vi.mock("../localLoader", () => ({
 }));
 
 const loginWithNsecMock = vi.fn();
+const attachSignerMock = vi.fn();
+const clearEphemeralKeyMock = vi.fn();
+const generateNewKeypairMock = vi.fn(() => ({
+  nsec: "nsec1generated",
+  pubkey: "generated-pubkey",
+}));
+const getPubkeyMock = vi.fn(() => Promise.resolve("pubkey-1"));
+const loadEphemeralKeyMock = vi.fn(() => null);
+const saveEphemeralKeyMock = vi.fn();
+const waitForNip07Mock = vi.fn(() => Promise.resolve(true));
 
 vi.mock("@acars/nostr", () => ({
-  attachSigner: vi.fn(),
+  attachSigner: (...args: unknown[]) => attachSignerMock(...args),
+  clearEphemeralKey: (...args: unknown[]) => clearEphemeralKeyMock(...args),
   ensureConnected: vi.fn(),
-  getPubkey: vi.fn(() => Promise.resolve("pubkey-1")),
+  generateNewKeypair: (...args: unknown[]) => generateNewKeypairMock(...args),
+  getPubkey: (...args: unknown[]) => getPubkeyMock(...args),
+  loadEphemeralKey: (...args: unknown[]) => loadEphemeralKeyMock(...args),
   loginWithNsec: (...args: unknown[]) => loginWithNsecMock(...args),
   publishAction: vi.fn(),
-  waitForNip07: vi.fn(() => Promise.resolve(true)),
+  saveEphemeralKey: (...args: unknown[]) => saveEphemeralKeyMock(...args),
+  waitForNip07: (...args: unknown[]) => waitForNip07Mock(...args),
 }));
 
 vi.mock("../engine", () => ({
@@ -31,6 +45,7 @@ const createSliceState = (overrides: Partial<AirlineState> = {}) => {
   const state = {
     pubkey: null,
     identityStatus: "checking",
+    isEphemeral: false,
     isLoading: false,
     error: null,
     airline: null,
@@ -43,6 +58,7 @@ const createSliceState = (overrides: Partial<AirlineState> = {}) => {
     fleetDeletedDuringCatchup: [],
     initializeIdentity: vi.fn(),
     createAirline: vi.fn(),
+    createNewIdentity: vi.fn(),
     loginWithNsec: vi.fn(),
   } as unknown as AirlineState;
 
@@ -60,7 +76,21 @@ const createSliceState = (overrides: Partial<AirlineState> = {}) => {
 
 beforeEach(() => {
   vi.mocked(hydrateIdentityFromStorage).mockReset();
+  attachSignerMock.mockReset();
+  clearEphemeralKeyMock.mockReset();
+  generateNewKeypairMock.mockClear();
+  generateNewKeypairMock.mockReturnValue({
+    nsec: "nsec1generated",
+    pubkey: "generated-pubkey",
+  });
+  getPubkeyMock.mockReset();
+  getPubkeyMock.mockResolvedValue("pubkey-1");
+  loadEphemeralKeyMock.mockReset();
+  loadEphemeralKeyMock.mockReturnValue(null);
   loginWithNsecMock.mockReset();
+  saveEphemeralKeyMock.mockReset();
+  waitForNip07Mock.mockReset();
+  waitForNip07Mock.mockResolvedValue(true);
 });
 
 describe("identitySlice initializeIdentity", () => {
@@ -74,9 +104,19 @@ describe("identitySlice initializeIdentity", () => {
     // The state isn't explicitly changed to ready here because hydrateIdentityFromStorage handles the set() calls now
   });
 
+  it("forces NIP-07 signer refresh and clears ephemeral state on successful extension auth", async () => {
+    const { state } = createSliceState({ identityStatus: "ready", isEphemeral: true });
+
+    await state.initializeIdentity();
+
+    expect(attachSignerMock).toHaveBeenCalledWith(true);
+    expect(clearEphemeralKeyMock).toHaveBeenCalled();
+    expect(state.isEphemeral).toBe(false);
+    expect(hydrateIdentityFromStorage).toHaveBeenCalledWith("pubkey-1", expect.any(Function));
+  });
+
   it("sets guest status if extension returns no pubkey", async () => {
-    const { getPubkey } = await import("@acars/nostr");
-    vi.mocked(getPubkey).mockResolvedValueOnce(null);
+    getPubkeyMock.mockResolvedValueOnce(null);
 
     const { state } = createSliceState();
 
@@ -84,6 +124,71 @@ describe("identitySlice initializeIdentity", () => {
 
     expect(state.identityStatus).toBe("guest");
     expect(hydrateIdentityFromStorage).not.toHaveBeenCalled();
+  });
+
+  it("preserves a ready ephemeral session when extension upgrade is cancelled", async () => {
+    getPubkeyMock.mockResolvedValueOnce(null);
+
+    const { state } = createSliceState({
+      identityStatus: "ready",
+      isEphemeral: true,
+      pubkey: "ephemeral-pubkey",
+      airline: { id: "airline-1" } as AirlineState["airline"],
+    });
+
+    await state.initializeIdentity();
+
+    expect(state.identityStatus).toBe("ready");
+    expect(state.isEphemeral).toBe(true);
+    expect(state.error).toBe("Extension did not return a pubkey — check nos2x popup");
+  });
+
+  it("restores a saved ephemeral key when no extension is available", async () => {
+    waitForNip07Mock.mockResolvedValueOnce(false);
+    loadEphemeralKeyMock.mockReturnValueOnce("nsec1saved");
+    loginWithNsecMock.mockResolvedValueOnce("pubkey-ephemeral");
+
+    const { state } = createSliceState();
+
+    await state.initializeIdentity();
+
+    expect(loginWithNsecMock).toHaveBeenCalledWith("nsec1saved");
+    expect(state.isEphemeral).toBe(true);
+    expect(clearEphemeralKeyMock).not.toHaveBeenCalled();
+    expect(hydrateIdentityFromStorage).toHaveBeenCalledWith(
+      "pubkey-ephemeral",
+      expect.any(Function),
+    );
+  });
+
+  it("clears corrupt saved ephemeral keys and falls back to no-extension", async () => {
+    waitForNip07Mock.mockResolvedValueOnce(false);
+    loadEphemeralKeyMock.mockReturnValueOnce("nsec1corrupt");
+    loginWithNsecMock.mockRejectedValueOnce(new Error("invalid key"));
+
+    const { state } = createSliceState();
+
+    await state.initializeIdentity();
+
+    expect(clearEphemeralKeyMock).toHaveBeenCalled();
+    expect(state.identityStatus).toBe("no-extension");
+  });
+
+  it("preserves a ready session when the browser wallet extension is unavailable", async () => {
+    waitForNip07Mock.mockResolvedValueOnce(false);
+
+    const { state } = createSliceState({
+      identityStatus: "ready",
+      isEphemeral: true,
+      pubkey: "ephemeral-pubkey",
+      airline: { id: "airline-1" } as AirlineState["airline"],
+    });
+
+    await state.initializeIdentity();
+
+    expect(state.identityStatus).toBe("ready");
+    expect(state.isEphemeral).toBe(true);
+    expect(state.error).toBe("Browser wallet extension is unavailable.");
   });
 });
 
@@ -94,11 +199,14 @@ describe("identitySlice loginWithNsec", () => {
     const { state } = createSliceState({
       pubkey: "old-pubkey",
       identityStatus: "ready",
+      isEphemeral: true,
     });
 
     await state.loginWithNsec("nsec1valid");
 
     expect(loginWithNsecMock).toHaveBeenCalledWith("nsec1valid");
+    expect(clearEphemeralKeyMock).toHaveBeenCalled();
+    expect(state.isEphemeral).toBe(false);
     expect(hydrateIdentityFromStorage).toHaveBeenCalledWith("pubkey-2", expect.any(Function));
   });
 
@@ -113,5 +221,21 @@ describe("identitySlice loginWithNsec", () => {
     expect(state.identityStatus).toBe("ready");
     expect(state.isLoading).toBe(false);
     warnSpy.mockRestore();
+  });
+});
+
+describe("identitySlice createNewIdentity", () => {
+  it("generates, saves, and hydrates a new ephemeral identity", async () => {
+    loginWithNsecMock.mockResolvedValueOnce("pubkey-new");
+
+    const { state } = createSliceState();
+
+    await state.createNewIdentity();
+
+    expect(generateNewKeypairMock).toHaveBeenCalled();
+    expect(saveEphemeralKeyMock).toHaveBeenCalledWith("nsec1generated");
+    expect(loginWithNsecMock).toHaveBeenCalledWith("nsec1generated");
+    expect(state.isEphemeral).toBe(true);
+    expect(hydrateIdentityFromStorage).toHaveBeenCalledWith("pubkey-new", expect.any(Function));
   });
 });

--- a/packages/store/src/slices/identitySlice.test.ts
+++ b/packages/store/src/slices/identitySlice.test.ts
@@ -11,24 +11,27 @@ vi.mock("../localLoader", () => ({
 const loginWithNsecMock = vi.fn();
 const attachSignerMock = vi.fn();
 const clearEphemeralKeyMock = vi.fn();
+const ensureConnectedMock = vi.fn();
 const generateNewKeypairMock = vi.fn(() => ({
   nsec: "nsec1generated",
   pubkey: "generated-pubkey",
 }));
 const getPubkeyMock = vi.fn(() => Promise.resolve("pubkey-1"));
 const loadEphemeralKeyMock = vi.fn(() => null);
+const resetSignerMock = vi.fn();
 const saveEphemeralKeyMock = vi.fn();
 const waitForNip07Mock = vi.fn(() => Promise.resolve(true));
 
 vi.mock("@acars/nostr", () => ({
   attachSigner: (...args: unknown[]) => attachSignerMock(...args),
   clearEphemeralKey: (...args: unknown[]) => clearEphemeralKeyMock(...args),
-  ensureConnected: vi.fn(),
+  ensureConnected: (...args: unknown[]) => ensureConnectedMock(...args),
   generateNewKeypair: (...args: unknown[]) => generateNewKeypairMock(...args),
   getPubkey: (...args: unknown[]) => getPubkeyMock(...args),
   loadEphemeralKey: (...args: unknown[]) => loadEphemeralKeyMock(...args),
   loginWithNsec: (...args: unknown[]) => loginWithNsecMock(...args),
   publishAction: vi.fn(),
+  resetSigner: (...args: unknown[]) => resetSignerMock(...args),
   saveEphemeralKey: (...args: unknown[]) => saveEphemeralKeyMock(...args),
   waitForNip07: (...args: unknown[]) => waitForNip07Mock(...args),
 }));
@@ -78,6 +81,7 @@ beforeEach(() => {
   vi.mocked(hydrateIdentityFromStorage).mockReset();
   attachSignerMock.mockReset();
   clearEphemeralKeyMock.mockReset();
+  ensureConnectedMock.mockReset();
   generateNewKeypairMock.mockClear();
   generateNewKeypairMock.mockReturnValue({
     nsec: "nsec1generated",
@@ -86,8 +90,10 @@ beforeEach(() => {
   getPubkeyMock.mockReset();
   getPubkeyMock.mockResolvedValue("pubkey-1");
   loadEphemeralKeyMock.mockReset();
-  loadEphemeralKeyMock.mockReturnValue(null);
+  loadEphemeralKeyMock.mockResolvedValue(null);
   loginWithNsecMock.mockReset();
+  ensureConnectedMock.mockResolvedValue(undefined);
+  resetSignerMock.mockReset();
   saveEphemeralKeyMock.mockReset();
   waitForNip07Mock.mockReset();
   waitForNip07Mock.mockResolvedValue(true);
@@ -145,7 +151,7 @@ describe("identitySlice initializeIdentity", () => {
 
   it("restores a saved ephemeral key when no extension is available", async () => {
     waitForNip07Mock.mockResolvedValueOnce(false);
-    loadEphemeralKeyMock.mockReturnValueOnce("nsec1saved");
+    loadEphemeralKeyMock.mockResolvedValueOnce("nsec1saved");
     loginWithNsecMock.mockResolvedValueOnce("pubkey-ephemeral");
 
     const { state } = createSliceState();
@@ -163,7 +169,7 @@ describe("identitySlice initializeIdentity", () => {
 
   it("clears corrupt saved ephemeral keys and falls back to no-extension", async () => {
     waitForNip07Mock.mockResolvedValueOnce(false);
-    loadEphemeralKeyMock.mockReturnValueOnce("nsec1corrupt");
+    loadEphemeralKeyMock.mockResolvedValueOnce("nsec1corrupt");
     loginWithNsecMock.mockRejectedValueOnce(new Error("invalid key"));
 
     const { state } = createSliceState();
@@ -172,6 +178,22 @@ describe("identitySlice initializeIdentity", () => {
 
     expect(clearEphemeralKeyMock).toHaveBeenCalled();
     expect(state.identityStatus).toBe("no-extension");
+  });
+
+  it("resets the signer but preserves a saved key when restore fails after login succeeds", async () => {
+    waitForNip07Mock.mockResolvedValueOnce(false);
+    loadEphemeralKeyMock.mockResolvedValueOnce("nsec1saved");
+    loginWithNsecMock.mockResolvedValueOnce("pubkey-ephemeral");
+    vi.mocked(hydrateIdentityFromStorage).mockRejectedValueOnce(new Error("hydrate failed"));
+
+    const { state } = createSliceState();
+
+    await state.initializeIdentity();
+
+    expect(resetSignerMock).toHaveBeenCalled();
+    expect(clearEphemeralKeyMock).not.toHaveBeenCalled();
+    expect(state.identityStatus).toBe("no-extension");
+    expect(state.error).toBe("Saved browser account could not be restored right now.");
   });
 
   it("preserves a ready session when the browser wallet extension is unavailable", async () => {
@@ -237,5 +259,21 @@ describe("identitySlice createNewIdentity", () => {
     expect(loginWithNsecMock).toHaveBeenCalledWith("nsec1generated");
     expect(state.isEphemeral).toBe(true);
     expect(hydrateIdentityFromStorage).toHaveBeenCalledWith("pubkey-new", expect.any(Function));
+  });
+
+  it("keeps a valid new key and resets the signer when post-login setup fails", async () => {
+    loginWithNsecMock.mockResolvedValueOnce("pubkey-new");
+    ensureConnectedMock.mockRejectedValueOnce(new Error("relay unavailable"));
+
+    const { state } = createSliceState();
+
+    await state.createNewIdentity();
+
+    expect(resetSignerMock).toHaveBeenCalled();
+    expect(clearEphemeralKeyMock).not.toHaveBeenCalled();
+    expect(state.pubkey).toBe("pubkey-new");
+    expect(state.identityStatus).toBe("ready");
+    expect(state.isEphemeral).toBe(true);
+    expect(state.error).toBe("relay unavailable");
   });
 });

--- a/packages/store/src/slices/identitySlice.ts
+++ b/packages/store/src/slices/identitySlice.ts
@@ -9,10 +9,14 @@ import { computeActionChainHash, fp, fpSub } from "@acars/core";
 import { getHubPricingForIata } from "@acars/data";
 import {
   attachSigner,
+  clearEphemeralKey,
   ensureConnected,
+  generateNewKeypair,
   getPubkey,
+  loadEphemeralKey,
   loginWithNsec as loginWithNsecNostr,
   publishAction,
+  saveEphemeralKey,
   waitForNip07,
 } from "@acars/nostr";
 import type { StateCreator } from "zustand";
@@ -24,6 +28,7 @@ import type { AirlineState } from "../types";
 export interface IdentitySlice {
   pubkey: string | null;
   identityStatus: "checking" | "no-extension" | "guest" | "ready";
+  isEphemeral: boolean;
   isLoading: boolean;
   error: string | null;
   airline: AirlineEntity | null;
@@ -35,6 +40,7 @@ export interface IdentitySlice {
   latestCheckpoint: Checkpoint | null;
   initializeIdentity: () => Promise<void>;
   loginWithNsec: (nsec: string) => Promise<void>;
+  createNewIdentity: () => Promise<void>;
   createAirline: (params: CreateAirlineParams) => Promise<void>;
   dissolveAirline: () => Promise<void>;
 }
@@ -50,6 +56,7 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
 ) => ({
   pubkey: null,
   identityStatus: "checking",
+  isEphemeral: false,
   isLoading: false,
   error: null,
   airline: null,
@@ -66,7 +73,22 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
     set({ isLoading: true, error: null, airline: null, pubkey: null });
 
     const extensionReady = await waitForNip07();
+
+    // If no extension, try to restore an ephemeral key from a previous session
     if (!extensionReady) {
+      const savedNsec = loadEphemeralKey();
+      if (savedNsec) {
+        try {
+          const pubkey = await loginWithNsecNostr(savedNsec);
+          ensureConnected();
+          set({ isEphemeral: true });
+          await hydrateIdentityFromStorage(pubkey, set);
+          return;
+        } catch {
+          // Stored key is corrupt — clear it and fall through to no-extension
+          clearEphemeralKey();
+        }
+      }
       set({ identityStatus: "no-extension", isLoading: false });
       return;
     }
@@ -119,6 +141,22 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
         identityStatus: "ready",
         isLoading: false,
       });
+    }
+  },
+
+  createNewIdentity: async () => {
+    set({ isLoading: true, error: null, airline: null, pubkey: null });
+
+    try {
+      const { nsec } = generateNewKeypair();
+      saveEphemeralKey(nsec);
+      const pubkey = await loginWithNsecNostr(nsec);
+      ensureConnected();
+      set({ isEphemeral: true });
+      await hydrateIdentityFromStorage(pubkey, set);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unable to create identity.";
+      set({ error: message, isLoading: false });
     }
   },
 

--- a/packages/store/src/slices/identitySlice.ts
+++ b/packages/store/src/slices/identitySlice.ts
@@ -70,7 +70,8 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
 
   initializeIdentity: async () => {
     const prevStatus = get().identityStatus;
-    set({ isLoading: true, error: null, airline: null, pubkey: null });
+    const hasExistingIdentity = prevStatus === "ready" && Boolean(get().airline || get().pubkey);
+    set({ isLoading: true, error: null });
 
     const extensionReady = await waitForNip07();
 
@@ -89,7 +90,11 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
           clearEphemeralKey();
         }
       }
-      set({ identityStatus: "no-extension", isLoading: false });
+      set({
+        identityStatus: hasExistingIdentity ? "ready" : "no-extension",
+        isLoading: false,
+        error: hasExistingIdentity ? "Browser wallet extension is unavailable." : null,
+      });
       return;
     }
 
@@ -105,15 +110,17 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
 
       if (!pubkey) {
         set({
-          identityStatus: "guest",
+          identityStatus: hasExistingIdentity ? "ready" : "guest",
           isLoading: false,
           error: isPassiveInit ? null : "Extension did not return a pubkey — check nos2x popup",
         });
         return;
       }
 
-      attachSigner();
+      attachSigner(true);
       ensureConnected();
+      clearEphemeralKey();
+      set({ isEphemeral: false });
 
       await hydrateIdentityFromStorage(pubkey, set);
     } catch (error) {
@@ -127,11 +134,13 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
   },
 
   loginWithNsec: async (nsec: string) => {
-    set({ isLoading: true, error: null, airline: null, pubkey: null });
+    set({ isLoading: true, error: null });
 
     try {
       const pubkey = await loginWithNsecNostr(nsec);
       ensureConnected();
+      clearEphemeralKey();
+      set({ isEphemeral: false });
 
       await hydrateIdentityFromStorage(pubkey, set);
     } catch (error) {
@@ -145,7 +154,7 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
   },
 
   createNewIdentity: async () => {
-    set({ isLoading: true, error: null, airline: null, pubkey: null });
+    set({ isLoading: true, error: null });
 
     try {
       const { nsec } = generateNewKeypair();
@@ -155,8 +164,9 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
       set({ isEphemeral: true });
       await hydrateIdentityFromStorage(pubkey, set);
     } catch (error) {
+      clearEphemeralKey();
       const message = error instanceof Error ? error.message : "Unable to create identity.";
-      set({ error: message, isLoading: false });
+      set({ error: message, isEphemeral: false, isLoading: false });
     }
   },
 

--- a/packages/store/src/slices/identitySlice.ts
+++ b/packages/store/src/slices/identitySlice.ts
@@ -16,6 +16,7 @@ import {
   loadEphemeralKey,
   loginWithNsec as loginWithNsecNostr,
   publishAction,
+  resetSigner,
   saveEphemeralKey,
   waitForNip07,
 } from "@acars/nostr";
@@ -77,17 +78,45 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
 
     // If no extension, try to restore an ephemeral key from a previous session
     if (!extensionReady) {
-      const savedNsec = loadEphemeralKey();
+      let savedNsec: string | null = null;
+      try {
+        savedNsec = await loadEphemeralKey();
+      } catch {
+        await clearEphemeralKey();
+      }
       if (savedNsec) {
+        let pubkey: string;
         try {
-          const pubkey = await loginWithNsecNostr(savedNsec);
-          ensureConnected();
+          pubkey = await loginWithNsecNostr(savedNsec);
+        } catch {
+          await clearEphemeralKey();
+          set({
+            identityStatus: hasExistingIdentity ? "ready" : "no-extension",
+            isEphemeral: false,
+            isLoading: false,
+            error: hasExistingIdentity ? "Browser wallet extension is unavailable." : null,
+          });
+          return;
+        }
+
+        try {
+          await ensureConnected();
           set({ isEphemeral: true });
           await hydrateIdentityFromStorage(pubkey, set);
           return;
-        } catch {
-          // Stored key is corrupt — clear it and fall through to no-extension
-          clearEphemeralKey();
+        } catch (error) {
+          resetSigner();
+          set({
+            identityStatus: hasExistingIdentity ? "ready" : "no-extension",
+            isEphemeral: hasExistingIdentity ? get().isEphemeral : false,
+            isLoading: false,
+            error: hasExistingIdentity
+              ? error instanceof Error
+                ? error.message
+                : "Unable to restore your saved browser account."
+              : "Saved browser account could not be restored right now.",
+          });
+          return;
         }
       }
       set({
@@ -118,11 +147,11 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
       }
 
       attachSigner(true);
-      ensureConnected();
-      clearEphemeralKey();
+      await ensureConnected();
       set({ isEphemeral: false });
 
       await hydrateIdentityFromStorage(pubkey, set);
+      await clearEphemeralKey();
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to initialize identity.";
       set({
@@ -136,18 +165,31 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
   loginWithNsec: async (nsec: string) => {
     set({ isLoading: true, error: null });
 
+    let pubkey: string;
     try {
-      const pubkey = await loginWithNsecNostr(nsec);
-      ensureConnected();
-      clearEphemeralKey();
-      set({ isEphemeral: false });
-
-      await hydrateIdentityFromStorage(pubkey, set);
+      pubkey = await loginWithNsecNostr(nsec);
     } catch (error) {
       console.warn("[IdentitySlice] nsec login failed", error);
       set({
         error: "Invalid nsec key.",
         identityStatus: "ready",
+        isLoading: false,
+      });
+      return;
+    }
+
+    try {
+      await ensureConnected();
+      set({ isEphemeral: false });
+      await hydrateIdentityFromStorage(pubkey, set);
+      await clearEphemeralKey();
+    } catch (error) {
+      resetSigner();
+      const message = error instanceof Error ? error.message : "Unable to load this account.";
+      set({
+        error: message,
+        identityStatus: "ready",
+        isEphemeral: false,
         isLoading: false,
       });
     }
@@ -156,17 +198,40 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
   createNewIdentity: async () => {
     set({ isLoading: true, error: null });
 
+    let pubkey: string;
     try {
       const { nsec } = generateNewKeypair();
-      saveEphemeralKey(nsec);
-      const pubkey = await loginWithNsecNostr(nsec);
-      ensureConnected();
+      await saveEphemeralKey(nsec);
+      pubkey = await loginWithNsecNostr(nsec);
+    } catch (error) {
+      await clearEphemeralKey();
+      const message = error instanceof Error ? error.message : "Unable to create identity.";
+      set({ error: message, isEphemeral: false, isLoading: false });
+      return;
+    }
+
+    try {
+      await ensureConnected();
       set({ isEphemeral: true });
       await hydrateIdentityFromStorage(pubkey, set);
     } catch (error) {
-      clearEphemeralKey();
+      resetSigner();
       const message = error instanceof Error ? error.message : "Unable to create identity.";
-      set({ error: message, isEphemeral: false, isLoading: false });
+      set({
+        pubkey,
+        airline: null,
+        fleet: [],
+        routes: [],
+        timeline: [],
+        actionChainHash: "",
+        actionSeq: 0,
+        latestCheckpoint: null,
+        fleetDeletedDuringCatchup: [],
+        identityStatus: "ready",
+        error: message,
+        isEphemeral: true,
+        isLoading: false,
+      });
     }
   },
 
@@ -174,7 +239,7 @@ export const createIdentitySlice: StateCreator<AirlineState, [], [], IdentitySli
     set({ isLoading: true, error: null });
     try {
       attachSigner();
-      ensureConnected();
+      await ensureConnected();
 
       const initialHub = params.hubs[0];
       if (!initialHub) throw new Error("Primary hub is required");

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -28,12 +28,14 @@ export interface AirlineState {
   pubkey: string | null;
   viewedPubkey: string | null;
   identityStatus: IdentityStatus;
+  isEphemeral: boolean;
   isLoading: boolean;
   error: string | null;
 
   // Actions
   initializeIdentity: () => Promise<void>;
   loginWithNsec: (nsec: string) => Promise<void>;
+  createNewIdentity: () => Promise<void>;
   createAirline: (params: CreateAirlineParams) => Promise<void>;
   dissolveAirline: () => Promise<void>;
   modifyHubs: (action: HubAction) => Promise<void>;
@@ -56,11 +58,7 @@ export interface AirlineState {
   cancelListing: (aircraftId: string) => Promise<void>;
   performMaintenance: (aircraftId: string) => Promise<void>;
   ferryAircraft: (aircraftId: string, destinationIata: string) => Promise<void>;
-  updateAircraftLivery: (
-    aircraftId: string,
-    imageUrl: string,
-    promptHash: string,
-  ) => Promise<void>;
+  updateAircraftLivery: (aircraftId: string, imageUrl: string, promptHash: string) => Promise<void>;
   openRoute: (originIata: string, destinationIata: string, distanceKm: number) => Promise<void>;
   rebaseRoute: (routeId: string, newOriginIata: string) => Promise<void>;
   closeRoute: (routeId: string) => Promise<void>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       "@nostr-dev-kit/ndk-blossom":
         specifier: ^2.0.2
         version: 2.0.2(@nostr-dev-kit/ndk@2.15.2(nostr-tools@2.23.1(typescript@5.9.3)))
+      nostr-tools:
+        specifier: ^2.23.1
+        version: 2.23.1(typescript@5.9.3)
     devDependencies:
       typescript:
         specifier: ^5.9.3


### PR DESCRIPTION
## Summary
- add a zero-friction onboarding path with browser-generated Nostr keys and a shareable `/join` route
- add an in-game security upgrade banner so new users can back up or upgrade their signer later
- harden the signer handoff so nsec/ephemeral sessions are not silently overridden by a browser extension
- preserve existing ephemeral sessions when extension upgrade attempts fail and add targeted auth-flow tests

## Why
Most users do not understand Nostr before they click a link. This PR lets a brand-new player start from a shared URL, create an account in one click, and learn about keys progressively instead of up front.

## Validation
- `pnpm --filter @acars/nostr test`
- `pnpm --filter @acars/nostr build`
- `pnpm --filter @acars/store test`
- `pnpm --filter @acars/store build`
- `pnpm --filter @acars/web test`
- `pnpm --filter @acars/web typecheck`
- `pnpm --filter @acars/web lint`
- `pnpm --filter @acars/web build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a "/join" landing and compact guest onboarding for one‑click ephemeral accounts.
  - "Play Free" topbar action to create an ephemeral account instantly.
  - Security upgrade banner with per‑account dismissal and backup actions (copy/download/upgrade).
  - Ephemeral key export UI and secure in‑browser ephemeral key handling (generate/save/load/clear).

* **UI**
  - Updated onboarding/topbar copy and onboarding feature grid.
  - Empty leaderboard now shows a friendly placeholder when no rows.

* **Tests**
  - Expanded tests for onboarding, ephemeral key flows, banner dismissal, and route behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->