### PR TITLE
fix(web): make aircraft catalog cards taller

### DIFF
--- a/apps/web/src/features/fleet/components/AircraftDealer.tsx
+++ b/apps/web/src/features/fleet/components/AircraftDealer.tsx
@@ -432,7 +432,7 @@ function AircraftCard({
     >
       {/* Top Image Splash */}
       <div
-        className={`relative flex h-32 w-full items-center justify-center border-b border-border/30 bg-gradient-to-br ${bgGradient} sm:h-40 lg:h-44`}
+        className={`relative flex h-40 w-full items-center justify-center border-b border-border/30 bg-gradient-to-br ${bgGradient} sm:h-48 lg:h-52`}
       >
         <div className="absolute left-3 top-3 flex gap-2 sm:left-4 sm:top-4">
           <span className="inline-flex items-center rounded-full bg-background/80 backdrop-blur-md px-2.5 py-0.5 text-xs font-semibold text-foreground border border-border/50">
@@ -444,7 +444,7 @@ function AircraftCard({
         </div>
         <CatalogImage
           model={aircraft}
-          className="h-full w-full object-cover"
+          className="h-full w-full object-cover object-center"
           fallback={
             <Plane className="h-10 w-10 rotate-[-15deg] text-foreground/20 transition-all duration-500 group-hover:scale-110 group-hover:text-foreground/40 sm:h-16 sm:w-16" />
           }


### PR DESCRIPTION
## Summary
- increase the aircraft catalog card hero height so the new factory images show more of the fuselage instead of cropping tightly
- keep the catalog image centered in the frame for more consistent composition across aircraft variants

## Verification
- `pnpm --filter @acars/web typecheck` *(fails on existing repository issues: missing `react-i18next` module resolution and stale `@acars/nostr` exports unrelated to this change)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced aircraft card layout with larger header images across all screen sizes
  * Improved image alignment for better visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->