### PR TITLE
Change minimum height from 14 to 11 in Topbar

### DIFF
--- a/apps/web/src/shared/components/layout/Topbar.tsx
+++ b/apps/web/src/shared/components/layout/Topbar.tsx
@@ -558,7 +558,7 @@ export function Topbar() {
 
       <div className="hidden sm:block">{renderBankruptcyBanner()}</div>
       <div className="pointer-events-auto hidden w-full border-b border-border bg-background/80 px-4 py-3 backdrop-blur-xl sm:block sm:px-6 md:py-2">
-        <div className="flex w-full flex-col gap-3 md:min-h-14 md:justify-between">
+        <div className="flex w-full flex-col gap-3 md:min-h-11 md:justify-between">
           <div className="flex w-full flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="flex min-w-0 flex-wrap items-center gap-3 sm:gap-4">
               <div


### PR DESCRIPTION
Adjusted minimum height for layout consistency.

## Summary
- 

## Testing
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test:run`

## Checklist
- [ ] I reviewed the Prime Directive and system constraints
- [ ] I used fixed-point arithmetic for money
- [ ] I avoided O(N^2) loops
- [ ] I considered list virtualization for large datasets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the minimum height of the desktop topbar on medium screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->