### PR TITLE
feat: add deterministic dynamic fuel market

### DIFF
--- a/apps/web/src/features/network/components/AirlineFlightBoard.tsx
+++ b/apps/web/src/features/network/components/AirlineFlightBoard.tsx
@@ -1,6 +1,8 @@
 import { useActiveAirline, useEngineStore } from "@acars/store";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Plane } from "lucide-react";
-import { useMemo } from "react";
+import type { CSSProperties } from "react";
+import { useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import {
   buildAirlineFlightBoardRows,
@@ -14,11 +16,15 @@ const STATUS_CLASS: Record<AirlineFlightRow["statusTone"], string> = {
   sky: "text-sky-400",
   slate: "text-slate-400",
 };
+const ROW_HEIGHT = 36;
 
-function AirlineFidsRow({ flight }: { flight: AirlineFlightRow }) {
+function AirlineFidsRow({ flight, style }: { flight: AirlineFlightRow; style?: CSSProperties }) {
   const loadFactor = flight.loadFactor !== undefined ? Math.round(flight.loadFactor * 100) : null;
   return (
-    <div className="grid grid-cols-[68px_1fr_44px_44px_52px_72px_36px] items-center gap-1.5 border-b border-slate-700/60 px-3 py-1.5 text-[11px] font-mono hover:bg-white/[0.03] transition-colors">
+    <div
+      style={style}
+      className="grid grid-cols-[68px_1fr_44px_44px_52px_72px_36px] items-center gap-1.5 border-b border-slate-700/60 px-3 py-1.5 text-[11px] font-mono hover:bg-white/[0.03] transition-colors"
+    >
       <span
         className={`font-bold uppercase tracking-wide text-[10px] leading-tight ${STATUS_CLASS[flight.statusTone]}`}
       >
@@ -62,11 +68,20 @@ export function AirlineFlightBoard() {
   const { t } = useTranslation("game");
   const { airline, fleet } = useActiveAirline();
   const tick = useEngineStore((s) => s.tick);
+  const scrollParentRef = useRef<HTMLDivElement | null>(null);
 
   const flights = useMemo(
     () => buildAirlineFlightBoardRows(fleet, airline, tick),
     [fleet, airline, tick],
   );
+  const flightBoardVirtualizer = useVirtualizer({
+    count: flights.length,
+    getScrollElement: () => scrollParentRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    initialRect: { width: 1024, height: ROW_HEIGHT * Math.min(flights.length, 8) },
+    overscan: 8,
+  });
+  const virtualRows = flightBoardVirtualizer.getVirtualItems();
 
   if (flights.length === 0) return null;
 
@@ -102,9 +117,31 @@ export function AirlineFlightBoard() {
       </div>
 
       {/* Rows */}
-      {flights.map((flight) => (
-        <AirlineFidsRow key={flight.key} flight={flight} />
-      ))}
+      <div
+        ref={scrollParentRef}
+        className="max-h-[288px] overflow-y-auto"
+        style={{ scrollbarGutter: "stable" }}
+      >
+        <div className="relative" style={{ height: `${flightBoardVirtualizer.getTotalSize()}px` }}>
+          {virtualRows.map((virtualRow) => {
+            const flight = flights[virtualRow.index];
+            if (!flight) return null;
+            return (
+              <AirlineFidsRow
+                key={flight.key}
+                flight={flight}
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  width: "100%",
+                  transform: `translateY(${virtualRow.start}px)`,
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/features/network/components/RouteManager.tsx
+++ b/apps/web/src/features/network/components/RouteManager.tsx
@@ -43,6 +43,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import { AirlineFlightBoard } from "@/features/network/components/AirlineFlightBoard";
 import { getRouteDemandSnapshot } from "@/features/network/hooks/useRouteDemand";
 import {
   estimateRouteEconomics,
@@ -53,7 +54,6 @@ import { PanelHeader } from "@/shared/components/layout/PanelLayout";
 import { usePanelScrollRef } from "@/shared/components/layout/panelScrollContext";
 import { navigateToAirport } from "@/shared/lib/permalinkNavigation";
 import { useConfirm } from "@/shared/lib/useConfirm";
-import { AirlineFlightBoard } from "@/features/network/components/AirlineFlightBoard";
 
 const toneDotClass = {
   emerald: "bg-emerald-500",
@@ -241,6 +241,7 @@ export function RouteManager() {
             aircraft: sampleModel,
             aircraftCount: 1,
             cabinConfig: sampleModel.capacity,
+            tick,
           })
         : null;
       return {
@@ -311,6 +312,7 @@ export function RouteManager() {
               aircraft: sampleModel,
               aircraftCount: 1,
               cabinConfig: sampleModel.capacity,
+              tick,
             })
           : null;
         return {
@@ -590,7 +592,10 @@ export function RouteManager() {
         })}
         badge={
           <span className="rounded-full border border-primary/20 bg-primary/10 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-primary sm:px-3 sm:text-xs">
-            {t("routeManager.activeBadge", { ns: "game", count: activeRoutes.length })}
+            {t("routeManager.activeBadge", {
+              ns: "game",
+              count: activeRoutes.length,
+            })}
           </span>
         }
       />
@@ -602,7 +607,9 @@ export function RouteManager() {
               <div className="flex items-center gap-2 rounded-xl border border-border/50 bg-muted/30 px-3 py-2">
                 <MapPin className="h-4 w-4 text-primary" aria-hidden="true" />
                 <select
-                  aria-label={t("routeManager.selectPlanningHub", { ns: "game" })}
+                  aria-label={t("routeManager.selectPlanningHub", {
+                    ns: "game",
+                  })}
                   value={planningOriginIata ?? ""}
                   onChange={(event) => setPlanningOriginIata(event.target.value || null)}
                   className="h-9 flex-1 rounded-lg border border-border/50 bg-background px-3 text-xs font-bold text-foreground sm:flex-none"
@@ -622,7 +629,10 @@ export function RouteManager() {
                 onClick={() => setTab("active")}
                 className={`rounded-lg px-3 py-2 text-xs font-bold transition-all sm:text-sm ${tab === "active" ? "bg-background text-foreground shadow-sm" : "text-muted-foreground hover:text-foreground"}`}
               >
-                {t("routeManager.activeTab", { ns: "game", count: activeRoutes.length })}
+                {t("routeManager.activeTab", {
+                  ns: "game",
+                  count: activeRoutes.length,
+                })}
               </button>
               <button
                 type="button"
@@ -721,10 +731,17 @@ export function RouteManager() {
                                 const message =
                                   err instanceof Error
                                     ? err.message
-                                    : t("routeManager.routeRebaseFailed", { ns: "game" });
-                                toast.error(t("routeManager.routeRebaseFailed", { ns: "game" }), {
-                                  description: message,
-                                });
+                                    : t("routeManager.routeRebaseFailed", {
+                                        ns: "game",
+                                      });
+                                toast.error(
+                                  t("routeManager.routeRebaseFailed", {
+                                    ns: "game",
+                                  }),
+                                  {
+                                    description: message,
+                                  },
+                                );
                               }
                             }}
                             className="h-9 rounded-lg bg-amber-500 px-3 text-xs font-bold text-amber-950 hover:bg-amber-400 transition"
@@ -734,20 +751,26 @@ export function RouteManager() {
                         </>
                       ) : (
                         <div className="text-xs font-bold text-amber-100/70">
-                          {t("routeManager.openAnotherHubToRebase", { ns: "game" })}
+                          {t("routeManager.openAnotherHubToRebase", {
+                            ns: "game",
+                          })}
                         </div>
                       )}
                       <button
                         type="button"
                         onClick={async () => {
                           const approved = await confirm({
-                            title: t("routeManager.closeRouteTitle", { ns: "game" }),
+                            title: t("routeManager.closeRouteTitle", {
+                              ns: "game",
+                            }),
                             description: t("routeManager.closeRouteDescription", {
                               ns: "game",
                               origin: route.originIata,
                               destination: route.destinationIata,
                             }),
-                            confirmLabel: t("routeManager.closeRoute", { ns: "game" }),
+                            confirmLabel: t("routeManager.closeRoute", {
+                              ns: "game",
+                            }),
                             tone: "destructive",
                           });
                           if (!approved) return;
@@ -757,10 +780,17 @@ export function RouteManager() {
                             const message =
                               err instanceof Error
                                 ? err.message
-                                : t("routeManager.routeCloseFailed", { ns: "game" });
-                            toast.error(t("routeManager.routeCloseFailed", { ns: "game" }), {
-                              description: message,
-                            });
+                                : t("routeManager.routeCloseFailed", {
+                                    ns: "game",
+                                  });
+                            toast.error(
+                              t("routeManager.routeCloseFailed", {
+                                ns: "game",
+                              }),
+                              {
+                                description: message,
+                              },
+                            );
                           }
                         }}
                         className="h-9 rounded-lg border border-amber-500/30 bg-transparent px-3 text-xs font-bold text-amber-100 hover:bg-amber-500/20 transition"
@@ -780,7 +810,9 @@ export function RouteManager() {
                 <input
                   type="text"
                   name="routeSearch"
-                  placeholder={t("routeManager.searchPlaceholder", { ns: "game" })}
+                  placeholder={t("routeManager.searchPlaceholder", {
+                    ns: "game",
+                  })}
                   className="w-full bg-background border border-border/50 rounded-xl py-2 pl-10 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary/50 transition-all font-bold"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
@@ -897,6 +929,7 @@ export function RouteManager() {
                             aircraftCount: Math.max(1, route.assignedAircraftIds.length),
                             cabinConfig: primaryAssignment.aircraft.configuration,
                             includeFixedCosts: true,
+                            tick,
                           })
                         : null;
 
@@ -1010,7 +1043,9 @@ export function RouteManager() {
                                         }}
                                         className="px-4 py-2 bg-white/5 text-white/60 border border-white/5 rounded-xl text-sm font-bold hover:bg-white/10 transition-all"
                                       >
-                                        {t("routeManager.editFares", { ns: "game" })}
+                                        {t("routeManager.editFares", {
+                                          ns: "game",
+                                        })}
                                       </button>
 
                                       <button
@@ -1050,7 +1085,9 @@ export function RouteManager() {
                                         }}
                                         className="px-3 py-2 rounded-xl border border-red-500/30 text-red-200/80 text-sm font-bold hover:bg-red-500/15 transition-all"
                                       >
-                                        {t("routeManager.closeRoute", { ns: "game" })}
+                                        {t("routeManager.closeRoute", {
+                                          ns: "game",
+                                        })}
                                       </button>
                                     </>
                                   )}

--- a/apps/web/src/features/network/utils/routeEconomics.test.ts
+++ b/apps/web/src/features/network/utils/routeEconomics.test.ts
@@ -41,6 +41,7 @@ describe("estimateRouteEconomics", () => {
       aircraftCount: 1,
       cabinConfig: mockAircraft.capacity,
       includeFixedCosts: true,
+      tick: 1000,
     });
 
     expect(projection.frequencyPerWeek).toBeGreaterThan(0);
@@ -48,5 +49,57 @@ describe("estimateRouteEconomics", () => {
     expect(projection.breakEvenLoadFactor).toBeGreaterThan(0);
     expect(projection.supplyRatio).toBeGreaterThan(0);
     expect(fpToNumber(projection.costPerFlight)).toBeGreaterThan(0);
+  });
+
+  it("reflects live fuel pricing at different ticks", () => {
+    const early = estimateRouteEconomics({
+      route: {
+        originIata: "PTY",
+        destinationIata: "BOG",
+        distanceKm: 761,
+        fareEconomy: fp(164),
+        fareBusiness: fp(454),
+        fareFirst: fp(1009),
+      },
+      addressableDemand: {
+        origin: "PTY",
+        destination: "BOG",
+        economy: 4282,
+        business: 1142,
+        first: 285,
+      },
+      pressureMultiplier: 0.88,
+      effectiveLoadFactor: 0.82,
+      aircraft: mockAircraft,
+      aircraftCount: 1,
+      cabinConfig: mockAircraft.capacity,
+      tick: 10,
+    });
+
+    const later = estimateRouteEconomics({
+      route: {
+        originIata: "PTY",
+        destinationIata: "BOG",
+        distanceKm: 761,
+        fareEconomy: fp(164),
+        fareBusiness: fp(454),
+        fareFirst: fp(1009),
+      },
+      addressableDemand: {
+        origin: "PTY",
+        destination: "BOG",
+        economy: 4282,
+        business: 1142,
+        first: 285,
+      },
+      pressureMultiplier: 0.88,
+      effectiveLoadFactor: 0.82,
+      aircraft: mockAircraft,
+      aircraftCount: 1,
+      cabinConfig: mockAircraft.capacity,
+      tick: 5000,
+    });
+
+    expect(early.costBreakdown.fuel).not.toBe(later.costBreakdown.fuel);
   });
 });

--- a/apps/web/src/features/network/utils/routeEconomics.ts
+++ b/apps/web/src/features/network/utils/routeEconomics.ts
@@ -11,6 +11,7 @@ import {
   fpScale,
   fpSub,
   fpToNumber,
+  getFuelPriceAtTick,
   type Route,
 } from "@acars/core";
 import { getHubPricingForIata } from "@acars/data";
@@ -77,6 +78,7 @@ type ProjectionInput = {
   cabinConfig?: CabinConfig;
   airportFeesMultiplier?: number;
   includeFixedCosts?: boolean;
+  tick?: number;
 };
 
 const clamp01 = (value: number) => Math.min(1, Math.max(0, value));
@@ -93,6 +95,7 @@ export function estimateRouteEconomics({
   cabinConfig,
   airportFeesMultiplier = 1,
   includeFixedCosts = false,
+  tick = 0,
 }: ProjectionInput): ProjectedRouteEconomics {
   const count = Math.max(1, aircraftCount);
   const config = cabinConfig ?? aircraft.capacity;
@@ -165,6 +168,7 @@ export function estimateRouteEconomics({
     actualPassengers: revenue.actualPassengers,
     blockHours,
     airportFeesMultiplier,
+    fuelPricePerKg: getFuelPriceAtTick(tick),
   });
 
   const weeklyLeaseShare = includeFixedCosts

--- a/apps/web/src/i18n/locales/en/game.json
+++ b/apps/web/src/i18n/locales/en/game.json
@@ -234,6 +234,8 @@
     "billingCycleProgress": "Billing cycle progress",
     "netCashFlow": "Net Cash Flow",
     "netCashFlowDescription": "Flight revenue minus fixed costs",
+    "liveJetFuel": "Live Jet Fuel",
+    "fuelTrendWindow": "4h trend, deterministic market tape.",
     "hidePnl": "Hide P&L",
     "viewPnl": "View P&L Breakdown",
     "avgProfitPerFlight": "Avg Profit/Flight",

--- a/apps/web/src/i18n/locales/es/game.json
+++ b/apps/web/src/i18n/locales/es/game.json
@@ -234,6 +234,8 @@
     "billingCycleProgress": "Progreso del ciclo de facturación",
     "netCashFlow": "Flujo neto de caja",
     "netCashFlowDescription": "Ingresos de vuelo menos costos fijos",
+    "liveJetFuel": "Combustible Jet en Vivo",
+    "fuelTrendWindow": "Tendencia de 4 h, cinta de mercado determinista.",
     "hidePnl": "Ocultar P&L",
     "viewPnl": "Ver desglose de P&L",
     "avgProfitPerFlight": "Ganancia prom./vuelo",

--- a/apps/web/src/routes/-corporate.lazy.tsx
+++ b/apps/web/src/routes/-corporate.lazy.tsx
@@ -2,7 +2,6 @@ import type { Airport, FixedPoint, TimelineEvent } from "@acars/core";
 import {
   CHAPTER11_BALANCE_THRESHOLD_USD,
   FP_ZERO,
-  TIER_THRESHOLDS,
   fp,
   fpAdd,
   fpDiv,
@@ -11,7 +10,10 @@ import {
   fpSub,
   fpSum,
   fpToNumber,
+  getFuelPriceAtTick,
+  getFuelPriceHistory,
   TICK_DURATION,
+  TIER_THRESHOLDS,
 } from "@acars/core";
 import { getAircraftById, getHubPricingForIata } from "@acars/data";
 import { useActiveAirline, useAirlineStore, useEngineStore } from "@acars/store";
@@ -64,12 +66,14 @@ function FinancialPulse({
   hubOpex,
   fleetLease,
   leasedCount,
+  tick,
 }: {
   corporateBalance: FixedPoint;
   pulse: FinancialPulseData;
   hubOpex: number;
   fleetLease: FixedPoint;
   leasedCount: number;
+  tick: number;
 }) {
   const { t } = useTranslation(["common", "game"]);
   const [showBreakdown, setShowBreakdown] = useState(false);
@@ -84,6 +88,19 @@ function FinancialPulse({
   const billingCyclePercent = Math.min(99, Math.floor(billingCycle.progress * 100));
 
   const lowConfidence = pulse.flightCount > 0 && pulse.financialFlightCount < 5;
+  const fuelPrice = getFuelPriceAtTick(tick);
+  const fuelHistory = useMemo(() => getFuelPriceHistory(tick, 24, 600), [tick]);
+  const fuelMin = Math.min(...fuelHistory.map((sample) => fpToNumber(sample.price)));
+  const fuelMax = Math.max(...fuelHistory.map((sample) => fpToNumber(sample.price)));
+  const sparklinePoints = fuelHistory
+    .map((sample, index) => {
+      const x = fuelHistory.length === 1 ? 100 : (index / (fuelHistory.length - 1)) * 100;
+      const price = fpToNumber(sample.price);
+      const normalized = fuelMax === fuelMin ? 0.5 : (price - fuelMin) / (fuelMax - fuelMin);
+      const y = 100 - normalized * 100;
+      return `${x},${y}`;
+    })
+    .join(" ");
 
   // Billing cycle urgency colors
   const cycleColor =
@@ -162,6 +179,37 @@ function FinancialPulse({
 
         {/* Monthly fixed costs breakdown */}
         <div className="mt-3 space-y-1">
+          <div className="rounded-lg border border-border/40 bg-background/60 px-3 py-2">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                  {t("corporate.liveJetFuel", { ns: "game" })}
+                </p>
+                <p
+                  className="text-sm font-black text-foreground"
+                  style={{ fontVariantNumeric: "tabular-nums" }}
+                >
+                  {fpFormat(fuelPrice, 2)}/kg
+                </p>
+              </div>
+              <div className="h-10 w-28 shrink-0 opacity-85">
+                <svg viewBox="0 0 100 100" className="h-full w-full" aria-hidden="true">
+                  <polyline
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    points={sparklinePoints}
+                    className="text-primary/80"
+                    vectorEffect="non-scaling-stroke"
+                  />
+                </svg>
+              </div>
+            </div>
+            <p className="mt-1 text-[10px] text-muted-foreground/70">
+              {t("corporate.fuelTrendWindow", { ns: "game" })}
+            </p>
+          </div>
+
           <div
             className="flex items-center justify-between text-xs text-muted-foreground"
             style={{ fontVariantNumeric: "tabular-nums" }}
@@ -524,7 +572,12 @@ function CompanyProfile({
               rel={npub ? "noreferrer" : undefined}
               className="h-7 w-7 overflow-hidden rounded-full border border-border/60 bg-muted/40"
               aria-label={
-                npub ? t("corporate.openProfileAria", { ns: "game", name: displayName }) : undefined
+                npub
+                  ? t("corporate.openProfileAria", {
+                      ns: "game",
+                      name: displayName,
+                    })
+                  : undefined
               }
               style={airlinePrimary ? { boxShadow: `0 0 0 2px ${airlinePrimary}` } : undefined}
             >
@@ -698,7 +751,9 @@ function BankruptcyPanel({
       </div>
       <p className="text-xs text-rose-300/70 leading-relaxed">
         {airline.status === "chapter11"
-          ? t("bankruptcy.panelChapter11Desc", { threshold: CHAPTER11_THRESHOLD_DISPLAY })
+          ? t("bankruptcy.panelChapter11Desc", {
+              threshold: CHAPTER11_THRESHOLD_DISPLAY,
+            })
           : t("bankruptcy.panelLiquidatedDesc")}
       </p>
       {airline.status === "chapter11" && (
@@ -896,7 +951,10 @@ function HubConfirmDialog({
       onClick={(e) => {
         if (e.target === dialogRef.current) onCancel();
       }}
-      aria-label={t("corporate.hubContractReviewAria", { ns: "game", iata: action.iata })}
+      aria-label={t("corporate.hubContractReviewAria", {
+        ns: "game",
+        iata: action.iata,
+      })}
       className="fixed inset-0 z-50 m-auto w-full max-w-xl rounded-2xl border border-white/10 bg-gradient-to-br from-[#0b1117] via-[#0d1218] to-[#101722] p-0 shadow-2xl backdrop:bg-black/70 backdrop:backdrop-blur-sm open:animate-in open:fade-in open:zoom-in-95"
       style={{ overscrollBehavior: "contain" }}
     >
@@ -1017,14 +1075,27 @@ function ActivityLog({ timeline }: { timeline: TimelineEvent[] }) {
   const getRelativeTime = (eventTick: number, currentTick: number) => {
     const diffSecs = Math.max(0, (currentTick - eventTick) * (TICK_DURATION / 1000));
     if (diffSecs < 10) return t("time.justNow", { ns: "common" });
-    if (diffSecs < 60) return t("time.secondsAgo", { ns: "common", count: Math.floor(diffSecs) });
+    if (diffSecs < 60)
+      return t("time.secondsAgo", {
+        ns: "common",
+        count: Math.floor(diffSecs),
+      });
     if (diffSecs < 3600) {
-      return t("time.minutesAgo", { ns: "common", count: Math.floor(diffSecs / 60) });
+      return t("time.minutesAgo", {
+        ns: "common",
+        count: Math.floor(diffSecs / 60),
+      });
     }
     if (diffSecs < 86400) {
-      return t("time.hoursAgo", { ns: "common", count: Math.floor(diffSecs / 3600) });
+      return t("time.hoursAgo", {
+        ns: "common",
+        count: Math.floor(diffSecs / 3600),
+      });
     }
-    return t("time.daysAgo", { ns: "common", count: Math.floor(diffSecs / 86400) });
+    return t("time.daysAgo", {
+      ns: "common",
+      count: Math.floor(diffSecs / 86400),
+    });
   };
 
   if (timeline.length === 0) {
@@ -1146,6 +1217,7 @@ export default function CorporateDashboard() {
     isLoading,
   } = useAirlineStore();
   const { fleet, timeline, routes, isViewingOther } = useActiveAirline();
+  const tick = useEngineStore((s) => s.tick);
   const homeAirport = useEngineStore((s) => s.homeAirport);
   const setActiveHubIata = useEngineStore((s) => s.setActiveHubIata);
 
@@ -1227,6 +1299,7 @@ export default function CorporateDashboard() {
           aircraftCount: Math.max(1, route.assignedAircraftIds.length),
           cabinConfig: primaryAssignment.aircraft.configuration,
           includeFixedCosts: true,
+          tick,
         });
         return {
           routeId: route.id,
@@ -1246,7 +1319,7 @@ export default function CorporateDashboard() {
       projectedWeeklyProfit: fpSum(entries.map((entry) => entry.projectedProfit)),
       routesNeedingCuts: entries.filter((entry) => entry.needsCuts).length,
     };
-  }, [fleet, routes]);
+  }, [fleet, routes, tick]);
 
   if (!airline && !isViewingOther) {
     return (
@@ -1254,7 +1327,9 @@ export default function CorporateDashboard() {
         <NostrAccessCard
           icon={Building2}
           title={t("access.corporateLockedTitle", { ns: "identity" })}
-          description={t("access.corporateLockedDescription", { ns: "identity" })}
+          description={t("access.corporateLockedDescription", {
+            ns: "identity",
+          })}
           onConnect={initializeIdentity}
           onCreateFree={createNewIdentity}
           onLoginWithNsec={loginWithNsec}
@@ -1352,6 +1427,7 @@ export default function CorporateDashboard() {
             hubOpex={currentMonthlyOpex}
             fleetLease={totalMonthlyLease}
             leasedCount={leasedCount}
+            tick={tick}
           />
 
           {/* ── Zone 3: Network Intelligence ── */}

--- a/apps/web/src/routes/-corporate.lazy.tsx
+++ b/apps/web/src/routes/-corporate.lazy.tsx
@@ -13,6 +13,7 @@ import {
   getFuelPriceAtTick,
   getFuelPriceHistory,
   TICK_DURATION,
+  TICKS_PER_HOUR,
   TIER_THRESHOLDS,
 } from "@acars/core";
 import { getAircraftById, getHubPricingForIata } from "@acars/data";
@@ -89,7 +90,13 @@ function FinancialPulse({
 
   const lowConfidence = pulse.flightCount > 0 && pulse.financialFlightCount < 5;
   const fuelPrice = getFuelPriceAtTick(tick);
-  const fuelHistory = useMemo(() => getFuelPriceHistory(tick, 24, 600), [tick]);
+  const fuelHistory = useMemo(() => {
+    const fuelTrendWindowHours = 4;
+    const fuelTrendSampleCount = 25;
+    const fuelTrendSpacingTicks =
+      (fuelTrendWindowHours * TICKS_PER_HOUR) / (fuelTrendSampleCount - 1);
+    return getFuelPriceHistory(tick, fuelTrendSampleCount, fuelTrendSpacingTicks);
+  }, [tick]);
   const fuelMin = Math.min(...fuelHistory.map((sample) => fpToNumber(sample.price)));
   const fuelMax = Math.max(...fuelHistory.map((sample) => fpToNumber(sample.price)));
   const sparklinePoints = fuelHistory

--- a/packages/core/CONTRACT.md
+++ b/packages/core/CONTRACT.md
@@ -305,6 +305,11 @@ function getFuelPriceHistory(
   sampleCount?: number,
   sampleSpacingTicks?: number,
 ): Array<{ tick: number; price: FixedPoint }>;
+function stepFuelPrice(currentPrice: FixedPoint, tick: number): FixedPoint;
+const FUEL_PRICE_EPOCH_TICKS: number;
+const FUEL_PRICE_MAX_PER_KG: FixedPoint;
+const FUEL_PRICE_MEAN_PER_KG: FixedPoint;
+const FUEL_PRICE_MIN_PER_KG: FixedPoint;
 
 function calculateHubLandingFee(
   baseLandingFee: FixedPoint,

--- a/packages/core/CONTRACT.md
+++ b/packages/core/CONTRACT.md
@@ -286,6 +286,7 @@ interface FlightCostParams {
   actualPassengers: number;
   blockHours: number;
   airportFeesMultiplier?: number;
+  fuelPricePerKg?: FixedPoint;
 }
 interface FlightCostResult {
   costFuel: FixedPoint;
@@ -298,6 +299,12 @@ interface FlightCostResult {
   costTotal: FixedPoint;
 }
 function calculateFlightCost(params: FlightCostParams): FlightCostResult;
+function getFuelPriceAtTick(tick: number): FixedPoint;
+function getFuelPriceHistory(
+  currentTick: number,
+  sampleCount?: number,
+  sampleSpacingTicks?: number,
+): Array<{ tick: number; price: FixedPoint }>;
 
 function calculateHubLandingFee(
   baseLandingFee: FixedPoint,

--- a/packages/core/src/finance.ts
+++ b/packages/core/src/finance.ts
@@ -5,6 +5,7 @@
 // ============================================================
 
 import { FP_ZERO, fp, fpAdd, fpDiv, fpScale } from "./fixed-point.js";
+import { FUEL_PRICE_MEAN_PER_KG } from "./fuel.js";
 import type { AircraftModel, FixedPoint, FlightOffer } from "./types.js";
 
 /**
@@ -31,7 +32,6 @@ export function detectPriceWar(offers: FlightOffer[]): {
 }
 
 // Global constants
-const FUEL_PRICE_PER_KG = fp(1.2); // $1.20 per kg
 const CREW_COST_PER_HOUR = fp(150); // $150 per hour per crew member
 const NAV_FEE_PER_KM = fp(0.5); // $0.50 per km overflight
 
@@ -59,6 +59,7 @@ export interface FlightCostParams {
   actualPassengers: number;
   blockHours: number;
   airportFeesMultiplier?: number;
+  fuelPricePerKg?: FixedPoint;
 }
 
 export function calculateHubLandingFee(
@@ -159,7 +160,8 @@ export function calculateFlightCost(params: FlightCostParams): {
 } {
   // Fuel: distance_km * fuel_per_km * fuel_price
   const fuelKg = params.distanceKm * params.aircraft.fuelBurnKgPerKm;
-  const costFuel = fpScale(FUEL_PRICE_PER_KG, fuelKg);
+  const fuelPricePerKg = params.fuelPricePerKg ?? FUEL_PRICE_MEAN_PER_KG;
+  const costFuel = fpScale(fuelPricePerKg, fuelKg);
 
   // Crew: blockHours * crewCostPerHour * crewCount
   const crewCount = params.aircraft.crewRequired.cockpit + params.aircraft.crewRequired.cabin;

--- a/packages/core/src/fuel.test.ts
+++ b/packages/core/src/fuel.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { fpToNumber } from "./fixed-point.js";
+import {
+  FUEL_PRICE_MAX_PER_KG,
+  FUEL_PRICE_MEAN_PER_KG,
+  FUEL_PRICE_MIN_PER_KG,
+  getFuelPriceAtTick,
+  getFuelPriceHistory,
+  stepFuelPrice,
+} from "./fuel.js";
+
+describe("fuel market", () => {
+  it("returns the same price for the same tick", () => {
+    expect(getFuelPriceAtTick(42)).toBe(getFuelPriceAtTick(42));
+    expect(getFuelPriceAtTick(250_000)).toBe(getFuelPriceAtTick(250_000));
+  });
+
+  it("stays within configured bounds", () => {
+    for (const tick of [0, 1, 12, 120, 10_000, 125_000, 980_000]) {
+      const price = getFuelPriceAtTick(tick);
+      expect(price).toBeGreaterThanOrEqual(FUEL_PRICE_MIN_PER_KG);
+      expect(price).toBeLessThanOrEqual(FUEL_PRICE_MAX_PER_KG);
+    }
+  });
+
+  it("starts at the configured mean", () => {
+    expect(getFuelPriceAtTick(0)).toBe(FUEL_PRICE_MEAN_PER_KG);
+  });
+
+  it("returns ordered history ending at current tick", () => {
+    const history = getFuelPriceHistory(1000, 8, 25);
+    expect(history).toHaveLength(8);
+    expect(history[0]?.tick).toBe(825);
+    expect(history[history.length - 1]?.tick).toBe(1000);
+  });
+
+  it("mean reversion nudges extreme values back toward center", () => {
+    const fromHigh = stepFuelPrice(fpToNumber(FUEL_PRICE_MAX_PER_KG), 10);
+    const fromLow = stepFuelPrice(fpToNumber(FUEL_PRICE_MIN_PER_KG), 11);
+    expect(fromHigh).toBeLessThanOrEqual(fpToNumber(FUEL_PRICE_MAX_PER_KG));
+    expect(fromLow).toBeGreaterThanOrEqual(fpToNumber(FUEL_PRICE_MIN_PER_KG));
+  });
+});

--- a/packages/core/src/fuel.test.ts
+++ b/packages/core/src/fuel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fpToNumber } from "./fixed-point.js";
+import { fp, fpSub, fpToNumber } from "./fixed-point.js";
 import {
   FUEL_PRICE_MAX_PER_KG,
   FUEL_PRICE_MEAN_PER_KG,
@@ -35,9 +35,30 @@ describe("fuel market", () => {
   });
 
   it("mean reversion nudges extreme values back toward center", () => {
-    const fromHigh = stepFuelPrice(fpToNumber(FUEL_PRICE_MAX_PER_KG), 10);
-    const fromLow = stepFuelPrice(fpToNumber(FUEL_PRICE_MIN_PER_KG), 11);
-    expect(fromHigh).toBeLessThanOrEqual(fpToNumber(FUEL_PRICE_MAX_PER_KG));
-    expect(fromLow).toBeGreaterThanOrEqual(fpToNumber(FUEL_PRICE_MIN_PER_KG));
+    const highStart = fp(1.55);
+    const lowStart = fp(0.85);
+    const highTick = Array.from({ length: 256 }, (_, tick) => tick).find(
+      (tick) => stepFuelPrice(highStart, tick) < highStart,
+    );
+    const lowTick = Array.from({ length: 256 }, (_, tick) => tick).find(
+      (tick) => stepFuelPrice(lowStart, tick) > lowStart,
+    );
+
+    expect(highTick).toBeDefined();
+    expect(lowTick).toBeDefined();
+
+    const fromHigh = stepFuelPrice(highStart, highTick ?? 0);
+    const fromHighMean = stepFuelPrice(FUEL_PRICE_MEAN_PER_KG, highTick ?? 0);
+    const fromLow = stepFuelPrice(lowStart, lowTick ?? 0);
+    const fromLowMean = stepFuelPrice(FUEL_PRICE_MEAN_PER_KG, lowTick ?? 0);
+
+    expect(fromHigh).toBeLessThan(highStart);
+    expect(fromLow).toBeGreaterThan(lowStart);
+    expect(fpToNumber(fpSub(fromHigh, fromHighMean))).toBeLessThan(
+      fpToNumber(fpSub(highStart, FUEL_PRICE_MEAN_PER_KG)),
+    );
+    expect(fpToNumber(fpSub(fromLowMean, fromLow))).toBeLessThan(
+      fpToNumber(fpSub(FUEL_PRICE_MEAN_PER_KG, lowStart)),
+    );
   });
 });

--- a/packages/core/src/fuel.ts
+++ b/packages/core/src/fuel.ts
@@ -1,4 +1,4 @@
-import { fp } from "./fixed-point.js";
+import { fp, fpAdd, fpScale, fpSub } from "./fixed-point.js";
 import { createTickPRNG } from "./prng.js";
 import type { FixedPoint } from "./types.js";
 import { TICKS_PER_DAY } from "./types.js";
@@ -8,16 +8,15 @@ export const FUEL_PRICE_MIN_PER_KG = fp(0.8);
 export const FUEL_PRICE_MAX_PER_KG = fp(1.6);
 export const FUEL_PRICE_EPOCH_TICKS = TICKS_PER_DAY;
 
-const FUEL_MEAN = 1.2;
-const FUEL_MIN = 0.8;
-const FUEL_MAX = 1.6;
 const FUEL_THETA = 0.00018;
 const FUEL_SIGMA = 0.0035;
 
-const epochCache = new Map<number, number>([[0, FUEL_MEAN]]);
+const epochCache = new Map<number, FixedPoint>([[0, FUEL_PRICE_MEAN_PER_KG]]);
 
-function clampFuelPrice(price: number): number {
-  return Math.min(FUEL_MAX, Math.max(FUEL_MIN, price));
+function clampFuelPrice(price: FixedPoint): FixedPoint {
+  if (price < FUEL_PRICE_MIN_PER_KG) return FUEL_PRICE_MIN_PER_KG;
+  if (price > FUEL_PRICE_MAX_PER_KG) return FUEL_PRICE_MAX_PER_KG;
+  return price;
 }
 
 function randomStandardNormal(tick: number): number {
@@ -27,15 +26,13 @@ function randomStandardNormal(tick: number): number {
   return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
 }
 
-export function stepFuelPrice(currentPrice: number, tick: number): number {
-  const nextPrice =
-    currentPrice +
-    FUEL_THETA * (FUEL_MEAN - currentPrice) +
-    FUEL_SIGMA * randomStandardNormal(tick);
-  return clampFuelPrice(nextPrice);
+export function stepFuelPrice(currentPrice: FixedPoint, tick: number): FixedPoint {
+  const drift = fpScale(fpSub(FUEL_PRICE_MEAN_PER_KG, currentPrice), FUEL_THETA);
+  const shock = fp(FUEL_SIGMA * randomStandardNormal(tick));
+  return clampFuelPrice(fpAdd(currentPrice, fpAdd(drift, shock)));
 }
 
-function getEpochFuelPrice(epoch: number): number {
+function getEpochFuelPrice(epoch: number): FixedPoint {
   const cached = epochCache.get(epoch);
   if (cached !== undefined) return cached;
 
@@ -62,7 +59,7 @@ export function getFuelPriceAtTick(tick: number): FixedPoint {
     price = stepFuelPrice(price, currentTick);
   }
 
-  return fp(price);
+  return price;
 }
 
 export interface FuelPriceSample {

--- a/packages/core/src/fuel.ts
+++ b/packages/core/src/fuel.ts
@@ -1,0 +1,96 @@
+import { fp } from "./fixed-point.js";
+import { createTickPRNG } from "./prng.js";
+import type { FixedPoint } from "./types.js";
+import { TICKS_PER_DAY } from "./types.js";
+
+export const FUEL_PRICE_MEAN_PER_KG = fp(1.2);
+export const FUEL_PRICE_MIN_PER_KG = fp(0.8);
+export const FUEL_PRICE_MAX_PER_KG = fp(1.6);
+export const FUEL_PRICE_EPOCH_TICKS = TICKS_PER_DAY;
+
+const FUEL_MEAN = 1.2;
+const FUEL_MIN = 0.8;
+const FUEL_MAX = 1.6;
+const FUEL_THETA = 0.00018;
+const FUEL_SIGMA = 0.0035;
+
+const epochCache = new Map<number, number>([[0, FUEL_MEAN]]);
+
+function clampFuelPrice(price: number): number {
+  return Math.min(FUEL_MAX, Math.max(FUEL_MIN, price));
+}
+
+function randomStandardNormal(tick: number): number {
+  const prng = createTickPRNG(tick);
+  const u1 = Math.max(prng(), Number.EPSILON);
+  const u2 = prng();
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+}
+
+export function stepFuelPrice(currentPrice: number, tick: number): number {
+  const nextPrice =
+    currentPrice +
+    FUEL_THETA * (FUEL_MEAN - currentPrice) +
+    FUEL_SIGMA * randomStandardNormal(tick);
+  return clampFuelPrice(nextPrice);
+}
+
+function getEpochFuelPrice(epoch: number): number {
+  const cached = epochCache.get(epoch);
+  if (cached !== undefined) return cached;
+
+  const previous = getEpochFuelPrice(epoch - 1);
+  let price = previous;
+  const startTick = (epoch - 1) * FUEL_PRICE_EPOCH_TICKS;
+  const endTick = epoch * FUEL_PRICE_EPOCH_TICKS;
+
+  for (let tick = startTick; tick < endTick; tick += 1) {
+    price = stepFuelPrice(price, tick);
+  }
+
+  epochCache.set(epoch, price);
+  return price;
+}
+
+export function getFuelPriceAtTick(tick: number): FixedPoint {
+  const safeTick = Math.max(0, Math.floor(tick));
+  const epoch = Math.floor(safeTick / FUEL_PRICE_EPOCH_TICKS);
+  let price = getEpochFuelPrice(epoch);
+  const epochStartTick = epoch * FUEL_PRICE_EPOCH_TICKS;
+
+  for (let currentTick = epochStartTick; currentTick < safeTick; currentTick += 1) {
+    price = stepFuelPrice(price, currentTick);
+  }
+
+  return fp(price);
+}
+
+export interface FuelPriceSample {
+  tick: number;
+  price: FixedPoint;
+}
+
+export function getFuelPriceHistory(
+  currentTick: number,
+  sampleCount = 48,
+  sampleSpacingTicks = 120,
+): FuelPriceSample[] {
+  const safeCurrentTick = Math.max(0, Math.floor(currentTick));
+  const safeSampleCount = Math.max(2, Math.floor(sampleCount));
+  const spacing = Math.max(1, Math.floor(sampleSpacingTicks));
+  const startTick = Math.max(0, safeCurrentTick - (safeSampleCount - 1) * spacing);
+  const samples: FuelPriceSample[] = [];
+
+  for (let tick = startTick; tick <= safeCurrentTick; tick += spacing) {
+    samples.push({ tick, price: getFuelPriceAtTick(tick) });
+  }
+
+  if (samples[samples.length - 1]?.tick !== safeCurrentTick) {
+    samples.push({
+      tick: safeCurrentTick,
+      price: getFuelPriceAtTick(safeCurrentTick),
+    });
+  }
+
+  return samples;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -67,6 +67,15 @@ export {
   computeRouteFrequency,
   getMaintenanceDowntimeTicks,
 } from "./fleet.js";
+export {
+  FUEL_PRICE_EPOCH_TICKS,
+  FUEL_PRICE_MAX_PER_KG,
+  FUEL_PRICE_MEAN_PER_KG,
+  FUEL_PRICE_MIN_PER_KG,
+  getFuelPriceAtTick,
+  getFuelPriceHistory,
+  stepFuelPrice,
+} from "./fuel.js";
 // Geography
 export { haversineDistance } from "./geo.js";
 // Hubs

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -19,6 +19,7 @@ import {
   fpToNumber,
   GENESIS_TIME,
   getCyclePhase,
+  getFuelPriceAtTick,
   getHubCongestionModifier,
   getHubDemandModifier,
   getProsperityIndex,
@@ -509,12 +510,14 @@ export function processFlightEngine(
         const airportFeesMultiplier = avgFee / 250;
 
         const distanceKm = route ? route.distanceKm : (ac.flight?.distanceKm ?? 0);
+        const fuelPricePerKg = getFuelPriceAtTick(tick);
         const cost = calculateFlightCost({
           distanceKm,
           aircraft: model,
           actualPassengers: rev.actualPassengers,
           blockHours: (ac.flight.arrivalTick - ac.flight.departureTick) / TICKS_PER_HOUR,
           airportFeesMultiplier,
+          fuelPricePerKg,
         });
 
         const profit = fpSub(rev.revenueTotal, cost.costTotal);
@@ -722,6 +725,7 @@ function accumulateLandingProfit(
   model: ReturnType<typeof getAircraftById>,
   hoursPerLeg: number,
   landings: number,
+  tick: number = 0,
 ): FixedPoint {
   if (landings <= 0) return fp(0);
   const perLeg = estimateLandingFinancials(
@@ -730,6 +734,7 @@ function accumulateLandingProfit(
     model,
     hoursPerLeg,
     ac.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
+    tick,
   );
   return fpScale(perLeg.profit, landings);
 }
@@ -786,6 +791,7 @@ export function estimateLandingFinancials(
   model: ReturnType<typeof getAircraftById>,
   hoursPerLeg: number,
   loadFactor: number,
+  tick: number = 0,
 ): LandingFinancialResult {
   if (!model || hoursPerLeg <= 0) {
     const zeroRevenue = calculateFlightRevenue({
@@ -879,6 +885,7 @@ export function estimateLandingFinancials(
     actualPassengers: revenue.actualPassengers,
     blockHours: hoursPerLeg,
     airportFeesMultiplier,
+    fuelPricePerKg: getFuelPriceAtTick(tick),
   });
 
   const profit = fpSub(revenue.revenueTotal, cost.costTotal);
@@ -1053,7 +1060,7 @@ export function reconcileFleetToTick(
         applyFlightHours(updated, landings * hoursPerLeg);
         balanceDelta = fpAdd(
           balanceDelta,
-          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
         );
         eventGenQueue.push({
           ac: updated,
@@ -1111,7 +1118,7 @@ export function reconcileFleetToTick(
         applyFlightHours(updated, landings * hoursPerLeg);
         balanceDelta = fpAdd(
           balanceDelta,
-          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
         );
         eventGenQueue.push({
           ac: updated,
@@ -1173,7 +1180,7 @@ export function reconcileFleetToTick(
       applyFlightHours(updated, landings * hoursPerLeg);
       balanceDelta = fpAdd(
         balanceDelta,
-        accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+        accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
       );
       eventGenQueue.push({
         ac: updated,
@@ -1231,7 +1238,7 @@ export function reconcileFleetToTick(
         applyFlightHours(updated, landings * hoursPerLeg);
         balanceDelta = fpAdd(
           balanceDelta,
-          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
         );
         eventGenQueue.push({
           ac: updated,
@@ -1284,7 +1291,7 @@ export function reconcileFleetToTick(
     applyFlightHours(updated, landings * hoursPerLeg);
     balanceDelta = fpAdd(
       balanceDelta,
-      accumulateLandingProfit(updated, route, model, hoursPerLeg, landings),
+      accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
     );
     eventGenQueue.push({
       ac: updated,
@@ -1354,6 +1361,7 @@ export function reconcileFleetToTick(
           model,
           hoursPerLeg,
           params.ac.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
+          evt.tick,
         );
 
         events.push({

--- a/packages/store/src/FlightEngine.ts
+++ b/packages/store/src/FlightEngine.ts
@@ -1,4 +1,11 @@
-import type { AircraftInstance, FixedPoint, FlightOffer, Route, TimelineEvent } from "@acars/core";
+import type {
+  AircraftInstance,
+  CycleFlightEvent,
+  FixedPoint,
+  FlightOffer,
+  Route,
+  TimelineEvent,
+} from "@acars/core";
 import {
   allocatePassengers,
   calculateDemand,
@@ -14,7 +21,6 @@ import {
   enumerateFlightEvents,
   fp,
   fpAdd,
-  fpScale,
   fpSub,
   fpToNumber,
   GENESIS_TIME,
@@ -715,6 +721,44 @@ function applyFlightHours(updated: AircraftInstance, hoursToAdd: number): void {
 
 const DEFAULT_RECONCILE_LOAD_FACTOR = 0.65;
 
+interface ReconciledEventParams {
+  route: Route;
+  cycleStartTick: number;
+  fromTick: number;
+  durationTicks: number;
+  turnaroundTicks: number;
+  phaseOffset: number;
+  cappedLandings: number;
+}
+
+function getCappedReconciledFlightEvents(
+  params: ReconciledEventParams,
+  targetTick: number,
+): CycleFlightEvent[] {
+  if (params.cappedLandings <= 0) return [];
+
+  const effectiveCycleStart = params.cycleStartTick - params.phaseOffset;
+  const rawEvents = enumerateFlightEvents(
+    effectiveCycleStart,
+    params.fromTick,
+    targetTick,
+    params.durationTicks,
+    params.turnaroundTicks,
+    params.route,
+  );
+
+  const events: CycleFlightEvent[] = [];
+  let remainingLandings = params.cappedLandings;
+
+  for (const evt of rawEvents) {
+    if (remainingLandings <= 0) break;
+    events.push(evt);
+    if (evt.type === "landing") remainingLandings -= 1;
+  }
+
+  return events;
+}
+
 /**
  * Compute the total profit delta for a batch of landings and accumulate it.
  * Extracted to deduplicate the identical pattern in reconcileFleetToTick.
@@ -724,19 +768,20 @@ function accumulateLandingProfit(
   route: Route,
   model: ReturnType<typeof getAircraftById>,
   hoursPerLeg: number,
-  landings: number,
-  tick: number = 0,
+  landingTicks: readonly number[],
 ): FixedPoint {
-  if (landings <= 0) return fp(0);
-  const perLeg = estimateLandingFinancials(
-    ac,
-    route,
-    model,
-    hoursPerLeg,
-    ac.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
-    tick,
-  );
-  return fpScale(perLeg.profit, landings);
+  if (landingTicks.length === 0) return fp(0);
+  return landingTicks.reduce<FixedPoint>((total, landingTick) => {
+    const perLeg = estimateLandingFinancials(
+      ac,
+      route,
+      model,
+      hoursPerLeg,
+      ac.lastKnownLoadFactor ?? DEFAULT_RECONCILE_LOAD_FACTOR,
+      landingTick,
+    );
+    return fpAdd(total, perLeg.profit);
+  }, fp(0));
 }
 
 const MIN_GROUNDED_CONDITION = 0.2;
@@ -959,15 +1004,8 @@ export function reconcileFleetToTick(
 
   // Collect per-aircraft cycle parameters so we can generate synthetic
   // timeline events after the positional reconciliation is complete.
-  interface EventGenParams {
+  interface EventGenParams extends ReconciledEventParams {
     ac: AircraftInstance;
-    route: Route;
-    cycleStartTick: number;
-    fromTick: number;
-    durationTicks: number;
-    turnaroundTicks: number;
-    phaseOffset: number;
-    cappedLandings: number;
   }
   const eventGenQueue: EventGenParams[] = [];
 
@@ -1058,11 +1096,7 @@ export function reconcileFleetToTick(
         const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
         landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
         applyFlightHours(updated, landings * hoursPerLeg);
-        balanceDelta = fpAdd(
-          balanceDelta,
-          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
-        );
-        eventGenQueue.push({
+        const eventParams: EventGenParams = {
           ac: updated,
           route,
           cycleStartTick,
@@ -1071,7 +1105,20 @@ export function reconcileFleetToTick(
           turnaroundTicks,
           phaseOffset: stalePhaseOffset,
           cappedLandings: landings,
-        });
+        };
+        balanceDelta = fpAdd(
+          balanceDelta,
+          accumulateLandingProfit(
+            updated,
+            route,
+            model,
+            hoursPerLeg,
+            getCappedReconciledFlightEvents(eventParams, targetTick)
+              .filter((evt) => evt.type === "landing")
+              .map((evt) => evt.tick),
+          ),
+        );
+        eventGenQueue.push(eventParams);
         return updated;
       }
       // Aircraft was mid-flight. Its cycle started at departureTick.
@@ -1116,11 +1163,7 @@ export function reconcileFleetToTick(
         const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
         landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
         applyFlightHours(updated, landings * hoursPerLeg);
-        balanceDelta = fpAdd(
-          balanceDelta,
-          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
-        );
-        eventGenQueue.push({
+        const eventParams: EventGenParams = {
           ac: updated,
           route,
           cycleStartTick,
@@ -1129,7 +1172,20 @@ export function reconcileFleetToTick(
           turnaroundTicks,
           phaseOffset: stalePhaseOffset,
           cappedLandings: landings,
-        });
+        };
+        balanceDelta = fpAdd(
+          balanceDelta,
+          accumulateLandingProfit(
+            updated,
+            route,
+            model,
+            hoursPerLeg,
+            getCappedReconciledFlightEvents(eventParams, targetTick)
+              .filter((evt) => evt.type === "landing")
+              .map((evt) => evt.tick),
+          ),
+        );
+        eventGenQueue.push(eventParams);
         return updated;
       }
       // Aircraft was in turnaround. Turnaround started at arrivalTick.
@@ -1178,11 +1234,7 @@ export function reconcileFleetToTick(
       const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
       landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
       applyFlightHours(updated, landings * hoursPerLeg);
-      balanceDelta = fpAdd(
-        balanceDelta,
-        accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
-      );
-      eventGenQueue.push({
+      const eventParams: EventGenParams = {
         ac: updated,
         route,
         cycleStartTick,
@@ -1191,7 +1243,20 @@ export function reconcileFleetToTick(
         turnaroundTicks,
         phaseOffset,
         cappedLandings: landings,
-      });
+      };
+      balanceDelta = fpAdd(
+        balanceDelta,
+        accumulateLandingProfit(
+          updated,
+          route,
+          model,
+          hoursPerLeg,
+          getCappedReconciledFlightEvents(eventParams, targetTick)
+            .filter((evt) => evt.type === "landing")
+            .map((evt) => evt.tick),
+        ),
+      );
+      eventGenQueue.push(eventParams);
       return updated;
     } else if (ac.status === "delivery") {
       // Delivery aircraft whose deliveryAtTick is in the past should be
@@ -1236,11 +1301,7 @@ export function reconcileFleetToTick(
         const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
         landings = capLandingsForGrounding(updated, landings, hoursPerLeg, false);
         applyFlightHours(updated, landings * hoursPerLeg);
-        balanceDelta = fpAdd(
-          balanceDelta,
-          accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
-        );
-        eventGenQueue.push({
+        const eventParams: EventGenParams = {
           ac: updated,
           route,
           cycleStartTick,
@@ -1249,7 +1310,20 @@ export function reconcileFleetToTick(
           turnaroundTicks,
           phaseOffset: delPhaseOffset,
           cappedLandings: landings,
-        });
+        };
+        balanceDelta = fpAdd(
+          balanceDelta,
+          accumulateLandingProfit(
+            updated,
+            route,
+            model,
+            hoursPerLeg,
+            getCappedReconciledFlightEvents(eventParams, targetTick)
+              .filter((evt) => evt.type === "landing")
+              .map((evt) => evt.tick),
+          ),
+        );
+        eventGenQueue.push(eventParams);
         return updated;
       }
       // Still in delivery period — skip
@@ -1289,11 +1363,7 @@ export function reconcileFleetToTick(
     const hoursPerLeg = Math.min(24, durationTicks / TICKS_PER_HOUR);
     landings = capLandingsForGrounding(updated, landings, hoursPerLeg, ac.status === "enroute");
     applyFlightHours(updated, landings * hoursPerLeg);
-    balanceDelta = fpAdd(
-      balanceDelta,
-      accumulateLandingProfit(updated, route, model, hoursPerLeg, landings, targetTick),
-    );
-    eventGenQueue.push({
+    const eventParams: EventGenParams = {
       ac: updated,
       route,
       cycleStartTick,
@@ -1302,7 +1372,20 @@ export function reconcileFleetToTick(
       turnaroundTicks,
       phaseOffset: 0,
       cappedLandings: landings,
-    });
+    };
+    balanceDelta = fpAdd(
+      balanceDelta,
+      accumulateLandingProfit(
+        updated,
+        route,
+        model,
+        hoursPerLeg,
+        getCappedReconciledFlightEvents(eventParams, targetTick)
+          .filter((evt) => evt.type === "landing")
+          .map((evt) => evt.tick),
+      ),
+    );
+    eventGenQueue.push(eventParams);
 
     return updated;
   });
@@ -1311,30 +1394,11 @@ export function reconcileFleetToTick(
   const events: TimelineEvent[] = [];
   for (const params of eventGenQueue) {
     if (params.cappedLandings <= 0) continue;
-    let remainingLandings = params.cappedLandings;
-
-    // For phase-offset routes (aircraft starting at destination), we need to
-    // adjust the effective cycle start so that enumerateFlightEvents (which
-    // always assumes the cycle starts at outbound takeoff) produces correctly
-    // shifted ticks.
-    const effectiveCycleStart = params.cycleStartTick - params.phaseOffset;
-
-    const rawEvents = enumerateFlightEvents(
-      effectiveCycleStart,
-      params.fromTick,
-      targetTick,
-      params.durationTicks,
-      params.turnaroundTicks,
-      params.route,
-    );
-
-    for (const evt of rawEvents) {
-      if (remainingLandings <= 0) break;
+    for (const evt of getCappedReconciledFlightEvents(params, targetTick)) {
       const simulatedTimestamp = GENESIS_TIME + evt.tick * TICK_DURATION;
       const idSuffix = evt.direction === "outbound" ? "" : "-rtn";
 
       if (evt.type === "takeoff") {
-        if (remainingLandings <= 0) break;
         events.push({
           id: `evt-takeoff${idSuffix}-${params.ac.id}-${evt.tick}`,
           tick: evt.tick,
@@ -1351,7 +1415,6 @@ export function reconcileFleetToTick(
               : `${params.ac.name} returning: ${evt.originIata} → ${evt.destinationIata}`,
         });
       } else {
-        remainingLandings -= 1;
         // Landing — include estimated financial details
         const model = getAircraftById(params.ac.modelId);
         const hoursPerLeg = Math.min(24, params.durationTicks / TICKS_PER_HOUR);


### PR DESCRIPTION
## Summary
- add a deterministic mean-reverting fuel market in `@acars/core` with bounded prices, history sampling, and tests
- wire live fuel pricing into flight cost calculation, offline reconciliation, and route economics so real and projected margins move with the market
- surface the current jet fuel price and a subtle real sparkline on the corporate dashboard, with localized copy

## Verification
- `pnpm -r build`
- `pnpm typecheck`
- `pnpm --filter @acars/core test -- --run`
- `pnpm --filter @acars/store test -- --run`
- `pnpm --filter @acars/web test -- --run routeEconomics RouteManager corporate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic fuel pricing now affects route costs and profitability projections.
  * Live Jet Fuel panel with current price and 4‑hour trend sparkline added to corporate dashboard.
  * Virtualized flight board for smoother, more performant flight list scrolling.

* **Localization**
  * New UI strings for live fuel display added (English and Spanish).

* **Tests**
  * Added tests covering fuel market behavior and its impact on cost estimates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->